### PR TITLE
Extend scenes to 16

### DIFF
--- a/faderpunk/src/storage.rs
+++ b/faderpunk/src/storage.rs
@@ -19,7 +19,7 @@ const APP_STORAGE_RANGE: Range<u32> = GLOBAL_CONFIG_RANGE.end..122_880;
 const APP_PARAM_RANGE: Range<u32> = APP_STORAGE_RANGE.end..131_072;
 const APP_STORAGE_MAX_BYTES: u32 = 400;
 const APP_PARAMS_MAX_BYTES: u32 = 128;
-const SCENES_PER_APP: u32 = 3;
+const SCENES_PER_APP: u32 = 16;
 
 pub async fn store_global_config(config: &GlobalConfig) {
     let res = write_with(GLOBAL_CONFIG_RANGE.start, |buf| {

--- a/faderpunk/src/tasks/fram.rs
+++ b/faderpunk/src/tasks/fram.rs
@@ -32,7 +32,7 @@ pub enum FramError {
     Empty,
 }
 
-pub const MAX_DATA_LEN: usize = 1024;
+pub const MAX_DATA_LEN: usize = 384;
 const MAX_CONCURRENT_REQUESTS: usize = 16;
 const TIMEOUT_MS: u64 = 200;
 const WRITES_CAPACITY: usize = 16;


### PR DESCRIPTION
The scenes per app number is now extended to 16.

**ATTENTION**: This limits the amount of space per `Storage` (the whole thing, not just a slot) to 384 bytes.