### PR TITLE
Add MidiOutput, MidiInput, MidiDuplex APIs

### DIFF
--- a/faderpunk/src/apps/automator.rs
+++ b/faderpunk/src/apps/automator.rs
@@ -13,7 +13,7 @@ use libfp::{Config, Curve, Param, Value};
 use smart_leds::RGB8;
 
 use crate::{
-    app::{App, AppStorage, ClockEvent, Led, ManagedStorage, ParamSlot, Range},
+    app::{App, AppStorage, ClockEvent, Led, ManagedStorage, MidiSender, ParamSlot, Range},
     storage::ParamStore,
 };
 
@@ -102,7 +102,7 @@ pub async fn run(app: &App<CHANNELS>, params: &Params<'_>, storage: ManagedStora
 
     let midi_chan = params.midi_channel.get().await;
     let cc: u8 = params.midi_cc.get().await as u8;
-    let midi = app.use_midi(midi_chan as u8 - 1);
+    let midi = app.use_midi_output(midi_chan as u8 - 1);
     let curve = params.curve.get().await;
 
     let mut clock = app.use_clock();

--- a/faderpunk/src/apps/clkcvrnd.rs
+++ b/faderpunk/src/apps/clkcvrnd.rs
@@ -7,8 +7,8 @@ use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use serde::{Deserialize, Serialize};
 
 use crate::app::{
-    App, AppStorage, ClockEvent, Led, ManagedStorage, ParamSlot, ParamStore, Range, SceneEvent,
-    RGB8,
+    App, AppStorage, ClockEvent, Led, ManagedStorage, MidiSender, ParamSlot, ParamStore, Range,
+    SceneEvent, RGB8,
 };
 
 use libfp::{
@@ -87,7 +87,7 @@ pub async fn run(app: &App<CHANNELS>, params: &Params<'_>, storage: ManagedStora
 
     let midi_chan = params.midi_channel.get().await;
     let cc = params.cc.get().await;
-    let midi = app.use_midi(midi_chan as u8 - 1);
+    let midi = app.use_midi_output(midi_chan as u8 - 1);
 
     let glob_muted = app.make_global(false);
     let div_glob = app.make_global(6);

--- a/faderpunk/src/apps/clkturing.rs
+++ b/faderpunk/src/apps/clkturing.rs
@@ -13,7 +13,8 @@ use serde::{Deserialize, Serialize};
 use smart_leds::colors::RED;
 
 use crate::app::{
-    App, AppStorage, Led, ManagedStorage, ParamSlot, ParamStore, Range, SceneEvent, RGB8,
+    App, AppStorage, Led, ManagedStorage, MidiSender, ParamSlot, ParamStore, Range, SceneEvent,
+    RGB8,
 };
 
 pub const CHANNELS: usize = 2;
@@ -112,7 +113,7 @@ pub async fn run(app: &App<CHANNELS>, params: &Params<'_>, storage: ManagedStora
     let midi_cc = params.midi_cc.get().await;
 
     let midi_chan = params.midi_channel.get().await;
-    let midi = app.use_midi(midi_chan as u8 - 1);
+    let midi = app.use_midi_output(midi_chan as u8 - 1);
 
     // let mut prob_glob = app.make_global_with_store(0, StorageSlot::A);
     // let mut length_glob = app.make_global_with_store(15, StorageSlot::B);

--- a/faderpunk/src/apps/default.rs
+++ b/faderpunk/src/apps/default.rs
@@ -10,7 +10,8 @@ use libfp::{Config, Curve, Param, Value};
 use smart_leds::colors::RED;
 
 use crate::app::{
-    App, AppStorage, Led, ManagedStorage, ParamSlot, ParamStore, Range, SceneEvent, RGB8,
+    App, AppStorage, Led, ManagedStorage, MidiSender, ParamSlot, ParamStore, Range, SceneEvent,
+    RGB8,
 };
 
 pub const CHANNELS: usize = 1;
@@ -103,7 +104,7 @@ pub async fn run(app: &App<CHANNELS>, params: &Params<'_>, storage: ManagedStora
     let midi_chan = params.midi_channel.get().await;
     let midi_cc = params.midi_cc.get().await;
     let curve = params.curve.get().await;
-    let midi = app.use_midi(midi_chan as u8 - 1);
+    let midi = app.use_midi_output(midi_chan as u8);
 
     let muted_glob = app.make_global(false);
     let att_glob = app.make_global(4095);

--- a/faderpunk/src/apps/probatrigger.rs
+++ b/faderpunk/src/apps/probatrigger.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use smart_leds::{colors::RED, RGB};
 
 use crate::app::{
-    App, AppStorage, ClockEvent, Led, ManagedStorage, ParamSlot, ParamStore, SceneEvent,
+    App, AppStorage, ClockEvent, Led, ManagedStorage, MidiSender, ParamSlot, ParamStore, SceneEvent,
 };
 
 pub const CHANNELS: usize = 1;
@@ -102,7 +102,7 @@ pub async fn run(app: &App<CHANNELS>, params: &Params<'_>, storage: ManagedStora
     let midi_chan = params.midi_channel.get().await;
     let note = params.note.get().await;
     let gatel = params.gatel.get().await;
-    let midi = app.use_midi(midi_chan as u8 - 1);
+    let midi = app.use_midi_output(midi_chan as u8 - 1);
 
     let glob_muted = app.make_global(false);
     let div_glob = app.make_global(6);

--- a/faderpunk/src/apps/seq8.rs
+++ b/faderpunk/src/apps/seq8.rs
@@ -24,7 +24,10 @@ use libfp::{
 };
 
 use crate::{
-    app::{App, AppStorage, Arr, ClockEvent, Global, Led, ManagedStorage, Range, SceneEvent, RGB8},
+    app::{
+        App, AppStorage, Arr, ClockEvent, Global, Led, ManagedStorage, MidiSender, Range,
+        SceneEvent, RGB8,
+    },
     storage::{ParamSlot, ParamStore},
 };
 
@@ -122,10 +125,10 @@ pub async fn run(app: &App<CHANNELS>, params: &Params<'_>, storage: ManagedStora
     let midi_chan4 = params.midi_channel4.get().await;
 
     let midi = [
-        app.use_midi(midi_chan1 as u8 - 1),
-        app.use_midi(midi_chan2 as u8 - 1),
-        app.use_midi(midi_chan3 as u8 - 1),
-        app.use_midi(midi_chan4 as u8 - 1),
+        app.use_midi_output(midi_chan1 as u8 - 1),
+        app.use_midi_output(midi_chan2 as u8 - 1),
+        app.use_midi_output(midi_chan3 as u8 - 1),
+        app.use_midi_output(midi_chan4 as u8 - 1),
     ];
 
     let clockn_glob = app.make_global(0);

--- a/faderpunk/src/apps/turing.rs
+++ b/faderpunk/src/apps/turing.rs
@@ -14,7 +14,8 @@ use libfp::{
 use serde::{Deserialize, Serialize};
 
 use crate::app::{
-    App, AppStorage, ClockEvent, Led, ManagedStorage, ParamSlot, ParamStore, Range, SceneEvent,
+    App, AppStorage, ClockEvent, Led, ManagedStorage, MidiSender, ParamSlot, ParamStore, Range,
+    SceneEvent,
 };
 
 pub const CHANNELS: usize = 1;
@@ -115,7 +116,7 @@ pub async fn run(app: &App<CHANNELS>, params: &Params<'_>, storage: ManagedStora
     let midi_cc = params.midi_cc.get().await;
 
     let midi_chan = params.midi_channel.get().await;
-    let midi = app.use_midi(midi_chan as u8 - 1);
+    let midi = app.use_midi_output(midi_chan as u8 - 1);
 
     // let mut prob_glob = app.make_global_with_store(0, StorageSlot::A);
     // let mut length_glob = app.make_global_with_store(15, StorageSlot::B);

--- a/faderpunk/src/events.rs
+++ b/faderpunk/src/events.rs
@@ -1,6 +1,6 @@
 use embassy_sync::{
     blocking_mutex::raw::CriticalSectionRawMutex,
-    pubsub::{PubSubChannel, Publisher},
+    pubsub::{PubSubChannel, Publisher, Subscriber},
     watch::Watch,
 };
 use midly::live::LiveEvent;
@@ -41,6 +41,14 @@ pub type EventPubSubChannel = PubSubChannel<
 >;
 pub static EVENT_PUBSUB: EventPubSubChannel = PubSubChannel::new();
 pub type EventPubSubPublisher = Publisher<
+    'static,
+    CriticalSectionRawMutex,
+    InputEvent,
+    EVENT_PUBSUB_SIZE,
+    EVENT_PUBSUB_SUBS,
+    EVENT_PUBSUB_SENDERS,
+>;
+pub type EventPubSubSubscriber = Subscriber<
     'static,
     CriticalSectionRawMutex,
     InputEvent,


### PR DESCRIPTION
This adds separate MidiInput, MidiOutput and MidiDuplex structs that can be used accordingly.

Here's how to use `MidiInput::wait_for_message()`:

```rust
    loop {
        match midi_in.wait_for_message().await {
            MidiMessage::NoteOn { key, vel } => {
                // Do something with key, vel
            }
        }
    }
```

Closes #68