### PR TITLE
Make configurator releases with built artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,13 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs['faderpunk--release_created'] }}
-      paths_released: ${{ steps.release.outputs.paths_released }}
-      tag_name: ${{ steps.release.outputs['faderpunk--tag_name'] }}
-      upload_url: ${{ steps.release.outputs['faderpunk--upload_url'] }}
+      faderpunk_release_created: ${{ steps.release.outputs['faderpunk--release_created'] }}
+      libfp_release_created: ${{ steps.release.outputs['libfp--release_created'] }}
+      configurator_release_created: ${{ steps.release.outputs['configurator--release_created'] }}
+      # paths_released: ${{ steps.release.outputs.paths_released }}
+      faderpunk_tag_name: ${{ steps.release.outputs['faderpunk--tag_name'] }}
+      configurator_tag_name: ${{ steps.release.outputs['configurator--tag_name'] }}
+      # upload_url: ${{ steps.release.outputs['faderpunk--upload_url'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -28,7 +31,7 @@ jobs:
   build_picotool_for_release:
     name: Build Picotool for Release
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.faderpunk_release_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -86,7 +89,7 @@ jobs:
   build_firmware_for_release:
     name: Build Firmware for Release
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.faderpunk_release_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -109,7 +112,7 @@ jobs:
   package_and_release_firmware:
     name: Package and Release Firmware
     needs: [release-please, build_firmware_for_release, build_picotool_for_release]
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.faderpunk_release_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Download picotool artifact
@@ -131,14 +134,14 @@ jobs:
       - name: Publish GitHub Release Artifacts
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.release-please.outputs.tag_name }}
+          tag_name: ${{ needs.release-please.outputs.faderpunk_tag_name }}
           files: |
             release_files/faderpunk.elf
             release_files/faderpunk.uf2
   build_configurator_for_release:
     name: Build Configurator for Release
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.configurator_release_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -162,16 +165,43 @@ jobs:
       - name: Build configurator
         run: pnpm run build
         working-directory: ./configurator
+      - name: Create configurator release package
+        run: |
+          mkdir -p release_files
+          cd configurator/dist
+          zip -r ../../release_files/configurator.zip .
+      - name: Upload configurator release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: configurator-release-artifact
+          path: release_files/configurator.zip
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload configurator artifact for GitHub Pages
         uses: actions/upload-pages-artifact@v3
         with:
           path: 'configurator/dist'
+  package_and_release_configurator:
+    name: Package and Release Configurator
+    needs: [release-please, build_configurator_for_release]
+    if: ${{ needs.release-please.outputs.configurator_release_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download configurator release artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: configurator-release-artifact
+          path: configurator_build
+      - name: Publish GitHub Release Artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.release-please.outputs.configurator_tag_name }}
+          files: |
+            configurator_build/configurator.zip
   deploy_configurator_to_pages:
     name: Deploy Configurator to GitHub Pages
     needs: [release-please, build_configurator_for_release]
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.configurator_release_created == 'true' }}
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -183,7 +213,7 @@ jobs:
   publish_libfp_to_crates_io:
     name: Publish libfp to crates.io
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.libfp_release_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
   "faderpunk": "0.6.1",
-  "libfp": "0.3.0"
+  "libfp": "0.3.0",
+  "configurator": "0.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,11 @@
       "release-type": "rust",
       "package-name": "libfp",
       "component": "libfp"
+    },
+    "configurator": {
+      "release-type": "node",
+      "package-name": "configurator",
+      "component": "configurator"
     }
   },
   "plugins": [


### PR DESCRIPTION
This is to only publish the configurator when it was actually changed. Also we're now creating zip files of the configurator, so that people can run older versions of it locally.