### PR TITLE
I2C leader implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,6 +714,7 @@ dependencies = [
  "log",
  "max11300",
  "midly",
+ "mii",
  "panic-probe",
  "pio",
  "portable-atomic",
@@ -1046,6 +1047,12 @@ name = "midly"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "207d755f4cb882d20c4da58d707ca9130a0c9bc5061f657a4f299b8e36362b7a"
+
+[[package]]
+name = "mii"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11e67a72c8f43d89c57894d7177502a7314344fddcae71d30e797166473bd973"
 
 [[package]]
 name = "nb"

--- a/faderpunk/Cargo.toml
+++ b/faderpunk/Cargo.toml
@@ -48,6 +48,7 @@ linreg = { git = "https://github.com/ATOVproject/linreg-rs" }
 log = "0.4.27"
 max11300 = "0.5.0"
 midly = { version = "0.5.3", default-features = false }
+mii = "0.2.0"
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
 pio = "0.3.0"
 portable-atomic = { version = "1.11.1", features = ["critical-section"] }

--- a/faderpunk/src/apps/control.rs
+++ b/faderpunk/src/apps/control.rs
@@ -157,6 +157,7 @@ pub async fn run(
     let fader = app.use_faders();
     let leds = app.use_leds();
     let midi = app.use_midi_output(midi_chan as u8 - 1);
+    let i2c = app.use_i2c_output();
 
     let muted_glob = app.make_global(storage.query(|s| s.muted));
     let output_glob = app.make_global(0);
@@ -316,8 +317,10 @@ pub async fn run(
 
             match latch_layer_glob.get() {
                 LatchLayer::Main => {
-                    // Send MIDI
-                    midi.send_cc(midi_cc as u8, output_glob.get()).await;
+                    let out = output_glob.get();
+                    // Send MIDI & I2C messages
+                    midi.send_cc(midi_cc as u8, out).await;
+                    i2c.send_fader_value(0, out).await;
                 }
                 LatchLayer::Alt => {
                     // Now we commit to storage

--- a/faderpunk/src/layout.rs
+++ b/faderpunk/src/layout.rs
@@ -77,7 +77,7 @@ impl LayoutManager {
                 };
 
                 if should_spawn {
-                    spawn_app_by_id(app_id, start_channel, self.spawner, &self.exit_signals).await;
+                    spawn_app_by_id(app_id, start_channel, self.spawner, &self.exit_signals);
                     let mut current_layout = self.layout.lock().await;
                     current_layout[start_channel] = Some((app_id, channels));
                 }

--- a/faderpunk/src/macros.rs
+++ b/faderpunk/src/macros.rs
@@ -10,7 +10,7 @@ macro_rules! register_apps {
         };
 
         use libfp::ConfigMeta;
-        use crate::{MAX_CHANNEL, MIDI_CHANNEL};
+        use crate::{I2C_LEADER_CHANNEL, MAX_CHANNEL, MIDI_CHANNEL};
         use crate::{app::App, events::EVENT_PUBSUB};
         use embassy_executor::Spawner;
 
@@ -26,8 +26,7 @@ macro_rules! register_apps {
 
         pub const REGISTERED_APP_IDS: [u8; _APP_COUNT] = [$($id),*];
 
-        // IDEA: Currently this doesn't need to be async
-        pub async fn spawn_app_by_id(
+        pub fn spawn_app_by_id(
             app_id: u8,
             start_channel: usize,
             spawner: Spawner,
@@ -40,6 +39,7 @@ macro_rules! register_apps {
                             app_id,
                             start_channel,
                             &EVENT_PUBSUB,
+                            I2C_LEADER_CHANNEL.sender(),
                             MAX_CHANNEL.sender(),
                             MIDI_CHANNEL.sender(),
                         );

--- a/faderpunk/src/main.rs
+++ b/faderpunk/src/main.rs
@@ -34,13 +34,15 @@ use libfp::quantizer::Quantizer;
 use libfp::I2cMode;
 use static_cell::StaticCell;
 
+use crate::tasks::global_config::GLOBAL_CONFIG_WATCH;
+
 use {defmt_rtt as _, panic_probe as _};
 
 use layout::{LayoutManager, LAYOUT_MANAGER, LAYOUT_WATCH};
 use storage::{load_calibration_data, load_global_config, load_layout};
 use tasks::{
-    buttons::BUTTON_PRESSED, fram::MAX_DATA_LEN, global_config::GLOBAL_CONFIG_WATCH,
-    max::MAX_CHANNEL, midi::MIDI_CHANNEL,
+    buttons::BUTTON_PRESSED, fram::MAX_DATA_LEN, i2c::I2C_LEADER_CHANNEL, max::MAX_CHANNEL,
+    midi::MIDI_CHANNEL,
 };
 
 // Program metadata for `picotool info`.

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -272,7 +272,7 @@ impl GlobalConfig {
     pub const fn new() -> Self {
         Self {
             clock: ClockConfig::new(),
-            i2c_mode: I2cMode::Follower,
+            i2c_mode: I2cMode::Leader,
             led_brightness: 150,
             quantizer_key: Key::Chromatic,
             quantizer_tonic: Note::C,


### PR DESCRIPTION
Currently this just adds a 16n compatibility mode to the default app.

I2c devices on the bus are scanned after 10s of uptime. If we send 16 or more unsuccessful i2c requests, i2c is disabled again and can only be enabled by establishing a proper connection and restarting the device again.