### PR TITLE
Add factory reset function to configurator

### DIFF
--- a/configurator/src/components/SettingsTab.tsx
+++ b/configurator/src/components/SettingsTab.tsx
@@ -20,6 +20,7 @@ import { QuantizerSettings } from "./settings/QuantizerSettings";
 import { AuxSettings } from "./settings/AuxSettings";
 import { MiscSettings } from "./settings/MiscSettings";
 import { setGlobalConfig } from "../utils/config";
+import { FactoryReset } from "./settings/FactoryReset";
 
 interface SettingsFormProps {
   config: GlobalConfig;
@@ -100,6 +101,7 @@ const SettingsForm = ({ config }: SettingsFormProps) => {
         <I2cSettings />
         <AuxSettings />
         <MiscSettings />
+        <FactoryReset />
         <div className="flex justify-between">
           <p>
             Your current version: Faderpunk v{deviceVersion}, Configurator v

--- a/configurator/src/components/settings/FactoryReset.tsx
+++ b/configurator/src/components/settings/FactoryReset.tsx
@@ -1,0 +1,103 @@
+import { type ChangeEvent, useCallback, useState } from "react";
+
+import { ButtonPrimary, ButtonSecondary } from "../Button";
+import { factoryReset } from "../../utils/config";
+import { useStore } from "../../store";
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/modal";
+import { Switch } from "@heroui/switch";
+import { delay } from "../../utils/utils";
+import { useNavigate } from "react-router-dom";
+
+export const FactoryReset = () => {
+  const { disconnect, usbDevice } = useStore();
+  const navigate = useNavigate();
+  const [isOpen, setOpen] = useState(false);
+  const [isSure, setSure] = useState(false);
+  const [isLoading, setLoading] = useState(false);
+
+  const handleConfirm = useCallback(async () => {
+    if (!usbDevice) {
+      return;
+    }
+    setLoading(true);
+    try {
+      await factoryReset(usbDevice);
+      // 3 seconds should be plenty enough
+      await delay(3000);
+      setSure(false);
+      setOpen(false);
+      disconnect();
+      navigate("/");
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setLoading(false);
+    }
+  }, [disconnect, navigate, usbDevice]);
+
+  const handleOpenChange = useCallback((shouldOpen: boolean) => {
+    setSure(false);
+    setOpen(shouldOpen);
+  }, []);
+
+  const handleButtonPress = useCallback(() => {
+    setOpen(true);
+  }, []);
+
+  const handleSureChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    setSure(e.target.checked);
+  }, []);
+
+  return (
+    <div className="mb-12">
+      <h2 className="text-yellow-fp mb-4 text-sm font-bold uppercase">
+        Factory Reset
+      </h2>
+      <div className="grid grid-cols-4 gap-x-16 gap-y-8 px-4">
+        <ButtonPrimary onPress={handleButtonPress}>
+          Reset to factory settings
+        </ButtonPrimary>
+      </div>
+      <Modal isOpen={isOpen} onOpenChange={handleOpenChange}>
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader>Factory reset</ModalHeader>
+              <ModalBody>
+                Are you sure you want to perform a full factory reset? All
+                settings will be deleted. This action can't be undone.
+                <Switch
+                  defaultSelected={isSure}
+                  color="danger"
+                  onChange={handleSureChange}
+                >
+                  I'm sure
+                </Switch>
+                <span className="text-sm">
+                  The device will restart after the factory reset.
+                </span>
+              </ModalBody>
+              <ModalFooter>
+                <ButtonPrimary
+                  isLoading={isLoading}
+                  isDisabled={!isSure}
+                  color="danger"
+                  onPress={handleConfirm}
+                >
+                  Delete
+                </ButtonPrimary>
+                <ButtonSecondary onPress={onClose}>Cancel</ButtonSecondary>
+              </ModalFooter>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
+    </div>
+  );
+};

--- a/configurator/src/store.ts
+++ b/configurator/src/store.ts
@@ -14,6 +14,7 @@ interface State {
   apps: AllApps | undefined;
   connect: () => Promise<void>;
   config: GlobalConfig | undefined;
+  disconnect: () => void;
   deviceVersion: string | undefined;
   layout: AppLayout | undefined;
   params: ParamValues | undefined;
@@ -55,6 +56,16 @@ export const useStore = create<State>((set) => ({
         usbDevice: undefined,
       });
     }
+  },
+  disconnect: () => {
+    set({
+      apps: undefined,
+      config: undefined,
+      deviceVersion: undefined,
+      layout: undefined,
+      params: undefined,
+      usbDevice: undefined,
+    });
   },
   setLayout: (layout) => set({ layout }),
   setParams: (id, newParams) =>

--- a/configurator/src/utils/config.ts
+++ b/configurator/src/utils/config.ts
@@ -349,3 +349,9 @@ export const deserializeLayout = (json: string) => {
     return value;
   });
 };
+
+export const factoryReset = async (dev: USBDevice) => {
+  await sendMessage(dev, {
+    tag: "FactoryReset",
+  });
+};

--- a/faderpunk/src/tasks/configure.rs
+++ b/faderpunk/src/tasks/configure.rs
@@ -13,6 +13,7 @@ use libfp::{ConfigMsgIn, ConfigMsgOut, Value, APP_MAX_PARAMS, GLOBAL_CHANNELS};
 
 use crate::apps::{get_channels, get_config, REGISTERED_APP_IDS};
 use crate::layout::LAYOUT_WATCH;
+use crate::storage::factory_reset;
 use crate::tasks::global_config::{get_global_config, GLOBAL_CONFIG_WATCH};
 
 use super::transport::{WebEndpoints, USB_MAX_PACKET_SIZE};
@@ -155,6 +156,9 @@ pub async fn start_webusb_loop<'a>(webusb: WebEndpoints<'a, Driver<'a, USB>>) {
                     .await
                     .unwrap();
                 sender.send(layout);
+            }
+            ConfigMsgIn::FactoryReset => {
+                factory_reset().await;
             }
         }
     }

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -734,6 +734,7 @@ pub enum ConfigMsgIn {
         layout_id: u8,
         values: [Option<Value>; APP_MAX_PARAMS],
     },
+    FactoryReset,
 }
 
 #[derive(Clone, Serialize, PostcardBindings)]


### PR DESCRIPTION
This PR adds a setting to the configurator to perform a factory reset for the device. This deletes all settings, params, scenes and storage but keeps the calibration data.