### PR TITLE
fix(rndcvcc): correct inverted mute LED logic in scene handler

### DIFF
--- a/faderpunk/src/apps/rndcvcc.rs
+++ b/faderpunk/src/apps/rndcvcc.rs
@@ -300,9 +300,11 @@ pub async fn run(
                     glob_muted.set(mute);
                     div_glob.set(resolution[res as usize / 345]);
                     if mute {
-                        leds.set(0, Led::Button, LED_COLOR, Brightness::Mid);
+                        leds.unset(0, Led::Button);
                         leds.unset(0, Led::Top);
                         leds.unset(0, Led::Bottom);
+                    } else {
+                        leds.set(0, Led::Button, LED_COLOR, Brightness::Mid);
                     }
                     latched_glob.set(false);
                 }


### PR DESCRIPTION
The scene handler was incorrectly turning on the button LED when mute
was true and not handling the false case. This fix inverts the logic to
match the initialization behavior: unset LEDs when muted, set button LED
when not muted.