### PR TITLE
feat: per-note midi channels for fp-grids (#511)

### DIFF
--- a/configurator/src/components/ManualTab.tsx
+++ b/configurator/src/components/ManualTab.tsx
@@ -1030,15 +1030,19 @@ Output range can be unipolar (0–10V) or bipolar (-5V to +5V), and MIDI CC foll
     appId: 23,
     title: "FP-Grids",
     description:
-      "Emilie Gillet's renowned Mutable Instruments Grids topographic drum sequencer for the ATOV Faderpunk",
+      "Emilie Gillet's renowned Mutable Instruments Grids topographic drum sequencer for the ATOV Faderpunk, with an extra Drum n' Bass mode",
     color: "Orange",
     icon: "euclid",
     params: [
       "MIDI mode",
-      "MIDI channel",
+      "Note 1 MIDI channel",
       "MIDI Note 1",
+      "Note 2 MIDI Channel",
       "MIDI Note 2",
+      "Note 3 MIDI Channel",
       "MIDI Note 3",
+      "DnB Ghost Note MIDI Channel",
+      "DnB Ghost Note MIDI Note",
       "MIDI Velocity",
       "MIDI velocity (Accent)",
       "Gate %",
@@ -1060,7 +1064,6 @@ Output range can be unipolar (0–10V) or bipolar (-5V to +5V), and MIDI CC foll
 Grids is described as a "topographic drum sequencer" - it generates a variety of drum patterns based on continuous interpolation through a "map" of patterns (Drum Mode) or using Euclidean algorithms (Euclidean Mode).  The original Mutable Instruments module manual is [here](https://pichenettes.github.io/mutable-instruments-documentation/modules/grids/manual/).
 
 * FP-Grids outputs CV gates (0V = off, 10V = on) and, optionally MIDI note on/off messages, with normal and accented velocity levels.
-* The 4th channel provides a global accent CV gate that can be used for triggering other voices or envelopes. This combines the accents from the individual three drum voices in the original Grids firmware into a single mixed Accent signal.
 
 #### Drums Output Mode
 
@@ -1069,6 +1072,7 @@ Generates patterns by interpolating through a 2D map of pre-analyzed drum patter
 * **Map X / Map Y:** Controls the position on the pattern map. Small changes typically result in related rhythmic variations.
 * **Density 1 / Density 2 / Density 3:** Controls the event density (fill) for each of the three main trigger outputs.
 * **Chaos Amount:** Controls the amount of randomness applied. When set to a high value, rolls / ghost notes will be randomly added to the pattern.
+* **Global Accent:** The 4th channel provides a global accent CV gate that can be used for triggering other voices or envelopes. This combines the accents from the individual three drum voices in the original Grids firmware into a single mixed Accent signal.
 
 #### Euclidean Output Mode
 
@@ -1085,12 +1089,13 @@ Generates classic Euclidean rhythms for each of the three main trigger outputs i
 
 A drum and bass pattern generator with 12 preset kick/snare/hi-hat patterns and probabilistic triggering. Cycle through output modes with Shift + Button 4 until the LED shows sand/amber.
 
+* **Outputs:** Kick, Snare, Hats and Ghost Snare CV gates and MIDI notes
 * **Kick / Snare / Ghost Snare:** Faders 1, 2, and 4 set the trigger probability for each voice (0 = never, full = always).
 * **Pattern select:** Fader 3 selects one of 12 DnB patterns. The pattern changes take effect at the start of the next bar.
 * **Vary pattern:** Shift + Button 1 randomly mutates the current pattern.
 * **Restore pattern:** Shift + Button 2 restores the pattern to the last selected base pattern.
 * Clock division is set automatically by the selected pattern — Fader 4 Alt (resolution) has no effect in this mode.
-* The Ghost Snare uses the same MIDI note as Trigger 2 (Snare), at a reduced velocity.
+* The Ghost Snare uses the the "DnB Ghost Note MIDI Note" and MIDI Channel, at a reduced velocity.
 
 #### Patch Ideas
 
@@ -1163,7 +1168,7 @@ Fader functions vary by output mode. Drums / Euclidean / DnB descriptions are sh
           "Euclidean: Shift + Button 3 rotates pattern 3 by one step. Drums / DnB: no function.",
       },
       {
-        jackTitle: "Accent / Ghost Snare gate output",
+        jackTitle: "Accent / Accent / Ghost Snare gate output",
         jackDescription:
           "Global accent gate output (Drums / Euclidean) or Ghost Snare gate output (DnB)",
         faderTitle: "Chaos / Ghost Probability",

--- a/faderpunk/src/apps/fp_grids.rs
+++ b/faderpunk/src/apps/fp_grids.rs
@@ -449,7 +449,7 @@ pub async fn run(
         },
     );
 
-    reset_all_outputs(&midi, leds, notes, &jack, &note_on_glob, &accent_on_glob).await;
+    reset_all_outputs(&midi, leds, notes, ghost_note, &jack, &note_on_glob, &accent_on_glob).await;
 
     let main_loop = async {
         let mut clock = app.use_clock();
@@ -499,7 +499,7 @@ pub async fn run(
                     // defmt::info!("[{}] Clock reset!", ticks());
                     tick_origin = ticks() as u32;
                     output_mode = output_mode_glob.get();
-                    reset_all_outputs(&midi, leds, notes, &jack, &note_on_glob, &accent_on_glob)
+                    reset_all_outputs(&midi, leds, notes, ghost_note, &jack, &note_on_glob, &accent_on_glob)
                         .await;
 
                     generator.set_seed(die.roll());
@@ -511,7 +511,7 @@ pub async fn run(
                 ClockEvent::Stop => {
                     // defmt::info!("[{}] Clock stop", ticks());
                     // Prevent hanging notes / gate CVs if clock is stopped
-                    reset_all_outputs(&midi, leds, notes, &jack, &note_on_glob, &accent_on_glob)
+                    reset_all_outputs(&midi, leds, notes, ghost_note, &jack, &note_on_glob, &accent_on_glob)
                         .await;
                     dnb_vary_pattern_glob.set(false);
                     dnb_reset_pattern_glob.set(false);
@@ -1226,7 +1226,7 @@ pub async fn run(
                             dnb_pattern_glob: &dnb_pattern_glob,
                         },
                     );
-                    reset_all_outputs(&midi, leds, notes, &jack, &note_on_glob, &accent_on_glob)
+                    reset_all_outputs(&midi, leds, notes, ghost_note, &jack, &note_on_glob, &accent_on_glob)
                         .await;
                 }
 
@@ -1244,6 +1244,7 @@ async fn reset_all_outputs(
     midi: &[crate::app::MidiOutput; 4],
     leds: crate::app::Leds<4>,
     notes: [MidiNote; 3],
+    ghost_note: MidiNote,
     jack: &[crate::app::GateJack; 4],
     note_on_glob: &Global<[bool; 3]>,
     accent_on_glob: &Global<bool>,
@@ -1263,7 +1264,7 @@ async fn reset_all_outputs(
         leds.unset(part, Led::Top);
     }
     note_on_glob.set([false; K_NUM_PARTS]);
-    jack[3].set_low().await;
+    join(midi[3].send_note_off(ghost_note), jack[3].set_low()).await;
     accent_on_glob.set(false);
     leds.unset(3, Led::Top);
 }

--- a/faderpunk/src/apps/fp_grids.rs
+++ b/faderpunk/src/apps/fp_grids.rs
@@ -210,26 +210,6 @@ pub struct Params {
     midi_channel4: MidiChannel,
 }
 
-impl Default for Params {
-    fn default() -> Self {
-        Self {
-            midi_channel: MidiChannel::default(),
-            midi_out: MidiOut::default(),
-            note1: MidiNote::from(36),
-            note2: MidiNote::from(37),
-            note3: MidiNote::from(38),
-            velocity: 100,
-            accent: 127,
-            gatel: 50,
-            color: Color::Orange,
-            ghost_note: MidiNote::from(37),
-            midi_channel2: MidiChannel::default(),
-            midi_channel3: MidiChannel::default(),
-            midi_channel4: MidiChannel::default(),
-        }
-    }
-}
-
 impl AppParams for Params {
     fn from_values(values: &[Value]) -> Option<Self> {
         if values.len() < PARAMS {

--- a/faderpunk/src/apps/fp_grids.rs
+++ b/faderpunk/src/apps/fp_grids.rs
@@ -129,7 +129,7 @@ use crate::app::{
 };
 
 pub const CHANNELS: usize = 4; // Number of used faderpunk channels
-pub const PARAMS: usize = 9; // NUmber of app configuration parameters
+pub const PARAMS: usize = 13; // NUmber of app configuration parameters
 
 const DIV_SIXTEENTH_NOTE_COLOR: Color = Color::Yellow;
 
@@ -141,16 +141,26 @@ pub static CONFIG: Config<PARAMS> = Config::new(
     AppIcon::Euclid,
 )
 .add_param(Param::MidiChannel {
-    name: "MIDI Channel",
+    name: "Note 1 MIDI Channel",
 })
 .add_param(Param::MidiNote {
     name: "MIDI Note 1",
-})
-.add_param(Param::MidiNote {
+}).add_param(Param::MidiChannel {
+    name: "Note 2 MIDI Channel",
+}).add_param(Param::MidiNote {
     name: "MIDI Note 2",
+})
+.add_param(Param::MidiChannel {
+    name: "Note 3 MIDI Channel",
 })
 .add_param(Param::MidiNote {
     name: "MIDI Note 3",
+})
+.add_param(Param::MidiChannel {
+    name: "DnB Ghost Note MIDI Channel",
+})
+.add_param(Param::MidiNote {
+    name: "MIDI DnB Ghost Note",
 })
 .add_param(Param::i32 {
     name: "MIDI Velocity",
@@ -192,6 +202,10 @@ pub struct Params {
     accent: i32,
     gatel: i32,
     color: Color,
+    ghost_note: MidiNote,
+    midi_channel2: MidiChannel,
+    midi_channel3: MidiChannel,
+    midi_channel4: MidiChannel,
 }
 
 impl Default for Params {
@@ -206,6 +220,10 @@ impl Default for Params {
             accent: 127,
             gatel: 50,
             color: Color::Orange,
+            ghost_note: MidiNote::from(39),
+            midi_channel2: MidiChannel::default(),
+            midi_channel3: MidiChannel::default(),
+            midi_channel4: MidiChannel::default(),
         }
     }
 }
@@ -218,13 +236,17 @@ impl AppParams for Params {
         Some(Self {
             midi_channel: MidiChannel::from_value(values[0]),
             note1: MidiNote::from_value(values[1]),
-            note2: MidiNote::from_value(values[2]),
-            note3: MidiNote::from_value(values[3]),
-            velocity: i32::from_value(values[4]),
-            accent: i32::from_value(values[5]),
-            gatel: i32::from_value(values[6]),
-            color: Color::from_value(values[7]),
-            midi_out: MidiOut::from_value(values[8]),
+            midi_channel2: MidiChannel::from_value(values[2]),
+            note2: MidiNote::from_value(values[3]),
+            midi_channel3: MidiChannel::from_value(values[4]),
+            note3: MidiNote::from_value(values[5]),
+            midi_channel4: MidiChannel::from_value(values[6]),
+            ghost_note: MidiNote::from_value(values[7]),
+            velocity: i32::from_value(values[8]),
+            accent: i32::from_value(values[9]),
+            gatel: i32::from_value(values[10]),
+            color: Color::from_value(values[11]),
+            midi_out: MidiOut::from_value(values[12]),
         })
     }
 
@@ -232,8 +254,12 @@ impl AppParams for Params {
         let mut vec = Vec::new();
         vec.push(self.midi_channel.into()).unwrap();
         vec.push(self.note1.into()).unwrap();
+        vec.push(self.midi_channel2.into()).unwrap();
         vec.push(self.note2.into()).unwrap();
+        vec.push(self.midi_channel3.into()).unwrap();
         vec.push(self.note3.into()).unwrap();
+        vec.push(self.midi_channel4.into()).unwrap();
+        vec.push(self.ghost_note.into()).unwrap();
         vec.push(self.velocity.into()).unwrap();
         vec.push(self.accent.into()).unwrap();
         vec.push(self.gatel.into()).unwrap();
@@ -289,6 +315,10 @@ pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMut
             accent: 127,
             gatel: 50,
             color: Color::Orange,
+            ghost_note: MidiNote::from(39),
+            midi_channel2: MidiChannel::default(),
+            midi_channel3: MidiChannel::default(),
+            midi_channel4: MidiChannel::default(),           
         },
     );
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
@@ -329,6 +359,10 @@ pub async fn run(
         velocityi32,
         accent_velocityi32,
         led_color,
+        ghost_note,
+        midi_channel2,
+        midi_channel3,  
+        midi_channel4
     ) = params.query(|p| {
         (
             p.midi_out,
@@ -340,6 +374,10 @@ pub async fn run(
             p.velocity,
             p.accent,
             p.color,
+            p.ghost_note,
+            p.midi_channel2,
+            p.midi_channel3,
+            p.midi_channel4,
         )
     });
     let alt_led_color = if led_color == Color::Blue {
@@ -355,7 +393,13 @@ pub async fn run(
     let midi_velocity = ((velocityi32.abs().clamp(1, 127) as u32 * 4095) / 127) as u16;
     let accent_velocity = ((accent_velocityi32.abs().clamp(1, 127) as u32 * 4095) / 127) as u16;
 
-    let midi = app.use_midi_output(midi_out, midi_channel, false);
+    let midi = [
+        app.use_midi_output(midi_out, midi_channel, false),
+        app.use_midi_output(midi_out, midi_channel2, false),
+        app.use_midi_output(midi_out, midi_channel3, false),
+        app.use_midi_output(midi_out, midi_channel4, false),
+    ];
+
     let notes = [note1, note2, note3];
     let jack = [
         app.make_gate_jack(0, 4095).await,
@@ -403,7 +447,7 @@ pub async fn run(
         },
     );
 
-    reset_all_outputs(midi, leds, notes, &jack, &note_on_glob, &accent_on_glob).await;
+    reset_all_outputs(&midi, leds, notes, &jack, &note_on_glob, &accent_on_glob).await;
 
     let main_loop = async {
         let mut clock = app.use_clock();
@@ -412,7 +456,6 @@ pub async fn run(
         let mut output_mode = output_mode_glob.get();
         let mut dnb_pattern = dnb_pattern_glob.get();
         let mut tick_origin = ticks() as u32;
-        let ghost_note = notes[1];
         let ghost_velocity = (midi_velocity - (midi_velocity / 4)).clamp(1, 127);
 
         let mut generator = PatternGenerator::default();
@@ -441,11 +484,11 @@ pub async fn run(
         // Decide if need to send MIDI note off events after a re-spawn, assume MIDI notes have not changed since last restore
         for (part, note) in notes.iter().enumerate().take(K_NUM_PARTS) {
             if restored_note_on_[part] {
-                midi.send_note_off(*note).await;
+                midi[part].send_note_off(*note).await;
             }
         }
         if output_mode == OutputMode::OutputModeDnB && restored_accent_on_ {
-            midi.send_note_off(ghost_note).await;
+            midi[3].send_note_off(ghost_note).await;
         }
 
         loop {
@@ -454,7 +497,7 @@ pub async fn run(
                     // defmt::info!("[{}] Clock reset!", ticks());
                     tick_origin = ticks() as u32;
                     output_mode = output_mode_glob.get();
-                    reset_all_outputs(midi, leds, notes, &jack, &note_on_glob, &accent_on_glob)
+                    reset_all_outputs(&midi, leds, notes, &jack, &note_on_glob, &accent_on_glob)
                         .await;
 
                     generator.set_seed(die.roll());
@@ -466,7 +509,7 @@ pub async fn run(
                 ClockEvent::Stop => {
                     // defmt::info!("[{}] Clock stop", ticks());
                     // Prevent hanging notes / gate CVs if clock is stopped
-                    reset_all_outputs(midi, leds, notes, &jack, &note_on_glob, &accent_on_glob)
+                    reset_all_outputs(&midi, leds, notes, &jack, &note_on_glob, &accent_on_glob)
                         .await;
                     dnb_vary_pattern_glob.set(false);
                     dnb_reset_pattern_glob.set(false);
@@ -539,12 +582,12 @@ pub async fn run(
                                 // Send Note Off first if re-triggering
                                 let mut note_on_ = note_on_glob.get();
                                 if note_on_[part] {
-                                    midi.send_note_off(*note).await;
+                                    midi[part].send_note_off(*note).await;
                                 }
                                 jack[part].set_high().await;
                                 note_on_[part] = true;
                                 note_on_glob.set(note_on_);
-                                midi.send_note_on(*note, velocity_).await;
+                                midi[part].send_note_on(*note, velocity_).await;
                                 leds.set(
                                     part,
                                     Led::Top,
@@ -566,7 +609,7 @@ pub async fn run(
                             leds.set(3, Led::Top, led_color, Brightness::Mid);
                             if output_mode == OutputMode::OutputModeDnB {
                                 // Send Ghost Snare MIDI out, use next MIDI note up from Trigger 3
-                                midi.send_note_on(ghost_note, ghost_velocity).await;
+                                midi[3].send_note_on(ghost_note, ghost_velocity).await;
                             }
                         }
 
@@ -609,7 +652,7 @@ pub async fn run(
                         let mut note_on_ = note_on_glob.get();
                         for (part, note) in notes.iter().enumerate().take(K_NUM_PARTS) {
                             if note_on_[part] {
-                                midi.send_note_off(*note).await;
+                                midi[part].send_note_off(*note).await;
                                 note_on_[part] = false;
                                 jack[part].set_low().await;
                             }
@@ -622,7 +665,7 @@ pub async fn run(
                             jack[3].set_low().await;
                             leds.unset(3, Led::Top);
                             if output_mode == OutputMode::OutputModeDnB {
-                                midi.send_note_off(ghost_note).await;
+                                midi[3].send_note_off(ghost_note).await;
                             }
                         }
                         if glob_latch_layer.get() == LatchLayer::Alt {
@@ -996,7 +1039,7 @@ pub async fn run(
                     if note_on_glob.get()[part] {
                         let mut note_on_ = note_on_glob.get();
                         if note_on_[part] {
-                            midi.send_note_off(notes[part]).await;
+                            midi[part].send_note_off(notes[part]).await;
                             note_on_[part] = false;
                             note_on_glob.set(note_on_);
                             jack[part].set_low().await;
@@ -1181,7 +1224,7 @@ pub async fn run(
                             dnb_pattern_glob: &dnb_pattern_glob,
                         },
                     );
-                    reset_all_outputs(midi, leds, notes, &jack, &note_on_glob, &accent_on_glob)
+                    reset_all_outputs(&midi, leds, notes, &jack, &note_on_glob, &accent_on_glob)
                         .await;
                 }
 
@@ -1196,7 +1239,7 @@ pub async fn run(
 }
 
 async fn reset_all_outputs(
-    midi: crate::app::MidiOutput,
+    midi: &[crate::app::MidiOutput; 4],
     leds: crate::app::Leds<4>,
     notes: [MidiNote; 3],
     jack: &[crate::app::GateJack; 4],
@@ -1208,7 +1251,7 @@ async fn reset_all_outputs(
         if note_on_[part] {
             join(
                 // Only send a MIDI note off if we think we have previously sent a note on
-                midi.send_note_off(notes[part]),
+                midi[part].send_note_off(notes[part]),
                 jack[part].set_low(),
             )
             .await;

--- a/faderpunk/src/apps/fp_grids.rs
+++ b/faderpunk/src/apps/fp_grids.rs
@@ -140,27 +140,29 @@ pub static CONFIG: Config<PARAMS> = Config::new(
     Color::SkyBlue,
     AppIcon::Euclid,
 )
-.add_param(Param::MidiChannel {
-    name: "Note 1 MIDI Channel",
-})
 .add_param(Param::MidiNote {
     name: "MIDI Note 1",
-}).add_param(Param::MidiChannel {
-    name: "Note 2 MIDI Channel",
-}).add_param(Param::MidiNote {
-    name: "MIDI Note 2",
 })
-.add_param(Param::MidiChannel {
-    name: "Note 3 MIDI Channel",
+.add_param(Param::MidiNote {
+    name: "MIDI Note 2",
 })
 .add_param(Param::MidiNote {
     name: "MIDI Note 3",
 })
-.add_param(Param::MidiChannel {
-    name: "DnB Ghost Note MIDI Channel",
-})
 .add_param(Param::MidiNote {
     name: "MIDI DnB Ghost Note",
+})
+.add_param(Param::MidiChannel {
+    name: "Note 1 MIDI Channel",
+})
+.add_param(Param::MidiChannel {
+    name: "Note 2 MIDI Channel",
+})
+.add_param(Param::MidiChannel {
+    name: "Note 3 MIDI Channel",
+})
+.add_param(Param::MidiChannel {
+    name: "DnB Ghost Note MIDI Channel",
 })
 .add_param(Param::i32 {
     name: "MIDI Velocity",
@@ -220,7 +222,7 @@ impl Default for Params {
             accent: 127,
             gatel: 50,
             color: Color::Orange,
-            ghost_note: MidiNote::from(39),
+            ghost_note: MidiNote::from(37),
             midi_channel2: MidiChannel::default(),
             midi_channel3: MidiChannel::default(),
             midi_channel4: MidiChannel::default(),
@@ -234,14 +236,14 @@ impl AppParams for Params {
             return None;
         }
         Some(Self {
-            midi_channel: MidiChannel::from_value(values[0]),
-            note1: MidiNote::from_value(values[1]),
-            midi_channel2: MidiChannel::from_value(values[2]),
-            note2: MidiNote::from_value(values[3]),
-            midi_channel3: MidiChannel::from_value(values[4]),
-            note3: MidiNote::from_value(values[5]),
-            midi_channel4: MidiChannel::from_value(values[6]),
-            ghost_note: MidiNote::from_value(values[7]),
+            note1: MidiNote::from_value(values[0]),
+            note2: MidiNote::from_value(values[1]),
+            note3: MidiNote::from_value(values[2]),
+            ghost_note: MidiNote::from_value(values[3]),
+            midi_channel: MidiChannel::from_value(values[4]),
+            midi_channel2: MidiChannel::from_value(values[5]),
+            midi_channel3: MidiChannel::from_value(values[6]),
+            midi_channel4: MidiChannel::from_value(values[7]),
             velocity: i32::from_value(values[8]),
             accent: i32::from_value(values[9]),
             gatel: i32::from_value(values[10]),
@@ -252,14 +254,14 @@ impl AppParams for Params {
 
     fn to_values(&self) -> Vec<Value, APP_MAX_PARAMS> {
         let mut vec = Vec::new();
-        vec.push(self.midi_channel.into()).unwrap();
         vec.push(self.note1.into()).unwrap();
-        vec.push(self.midi_channel2.into()).unwrap();
         vec.push(self.note2.into()).unwrap();
-        vec.push(self.midi_channel3.into()).unwrap();
         vec.push(self.note3.into()).unwrap();
-        vec.push(self.midi_channel4.into()).unwrap();
         vec.push(self.ghost_note.into()).unwrap();
+        vec.push(self.midi_channel.into()).unwrap();
+        vec.push(self.midi_channel2.into()).unwrap();
+        vec.push(self.midi_channel3.into()).unwrap();
+        vec.push(self.midi_channel4.into()).unwrap();
         vec.push(self.velocity.into()).unwrap();
         vec.push(self.accent.into()).unwrap();
         vec.push(self.gatel.into()).unwrap();
@@ -318,7 +320,7 @@ pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMut
             ghost_note: MidiNote::from(39),
             midi_channel2: MidiChannel::default(),
             midi_channel3: MidiChannel::default(),
-            midi_channel4: MidiChannel::default(),           
+            midi_channel4: MidiChannel::default(),
         },
     );
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
@@ -361,8 +363,8 @@ pub async fn run(
         led_color,
         ghost_note,
         midi_channel2,
-        midi_channel3,  
-        midi_channel4
+        midi_channel3,
+        midi_channel4,
     ) = params.query(|p| {
         (
             p.midi_out,

--- a/gen-bindings/Cargo.lock
+++ b/gen-bindings/Cargo.lock
@@ -323,7 +323,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libfp"
-version = "0.10.1"
+version = "0.10.2-beta.0"
 dependencies = [
  "embassy-time",
  "enum-ordinalize",


### PR DESCRIPTION
Closes #511

<img width="1142" height="568" alt="image" src="https://github.com/user-attachments/assets/c9441669-70b4-4a3b-b8d3-130f743b4cad" />

Example MIDI monitor output from DnB mode with different configured MIDI channels
```
20:48:21.095 | RECEIVE    | ENDPOINT(Faderpunk) TYPE(NOTE_ON) CHANNEL(1) DATA1(36) DATA2(99)
20:48:21.095 | RECEIVE    | ENDPOINT(Faderpunk) TYPE(NOTE_ON) CHANNEL(3) DATA1(38) DATA2(99)
20:48:21.139 | RECEIVE    | ENDPOINT(Faderpunk) TYPE(NOTE_OFF) CHANNEL(1) DATA1(36) DATA2(0)
20:48:21.139 | RECEIVE    | ENDPOINT(Faderpunk) TYPE(NOTE_OFF) CHANNEL(3) DATA1(38) DATA2(0)
20:48:21.271 | RECEIVE    | ENDPOINT(Faderpunk) TYPE(NOTE_ON) CHANNEL(3) DATA1(38) DATA2(99)
20:48:21.315 | RECEIVE    | ENDPOINT(Faderpunk) TYPE(NOTE_OFF) CHANNEL(3) DATA1(38) DATA2(0)
20:48:21.446 | RECEIVE    | ENDPOINT(Faderpunk) TYPE(NOTE_ON) CHANNEL(3) DATA1(38) DATA2(99)
20:48:21.490 | RECEIVE    | ENDPOINT(Faderpunk) TYPE(NOTE_OFF) CHANNEL(3) DATA1(38) DATA2(0)
20:48:21.621 | RECEIVE    | ENDPOINT(Faderpunk) TYPE(NOTE_ON) CHANNEL(3) DATA1(38) DATA2(99)
20:48:21.665 | RECEIVE    | ENDPOINT(Faderpunk) TYPE(NOTE_OFF) CHANNEL(3) DATA1(38) DATA2(0)
20:48:21.797 | RECEIVE    | ENDPOINT(Faderpunk) TYPE(NOTE_ON) CHANNEL(3) DATA1(38) DATA2(99)
20:48:21.841 | RECEIVE    | ENDPOINT(Faderpunk) TYPE(NOTE_OFF) CHANNEL(3) DATA1(38) DATA2(0)
20:48:21.973 | RECEIVE    | ENDPOINT(Faderpunk) TYPE(NOTE_ON) CHANNEL(2) DATA1(37) DATA2(99)
20:48:21.973 | RECEIVE    | ENDPOINT(Faderpunk) TYPE(NOTE_ON) CHANNEL(3) DATA1(38) DATA2(99)
20:48:22.017 | RECEIVE    | ENDPOINT(Faderpunk) TYPE(NOTE_OFF) CHANNEL(2) DATA1(37) DATA2(0)
20:48:22.017 | RECEIVE    | ENDPOINT(Faderpunk) TYPE(NOTE_OFF) CHANNEL(3) DATA1(38) DATA2(0)
20:48:22.148 | RECEIVE    | ENDPOINT(Faderpunk) TYPE(NOTE_ON) CHANNEL(3) DATA1(38) DATA2(99)
20:48:22.148 | RECEIVE    | ENDPOINT(Faderpunk) TYPE(NOTE_ON) CHANNEL(4) DATA1(39) DATA2(3)
20:48:22.191 | RECEIVE    | ENDPOINT(Faderpunk) TYPE(NOTE_OFF) CHANNEL(3) DATA1(38) DATA2(0)
20:48:22.191 | RECEIVE    | ENDPOINT(Faderpunk) TYPE(NOTE_OFF) CHANNEL(4) DATA1(39) DATA2(0)
```