### PR TITLE
fix(faderpunk): migrate v1.8.2 GlobalConfig in place on first v1.9 boot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ checksum = "e37549a379a9e0e6e576fd208ee60394ccb8be963889eebba3ffe0980364f472"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -320,7 +320,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -331,7 +331,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -369,7 +369,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -485,7 +485,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -753,7 +753,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -815,6 +815,7 @@ dependencies = [
  "max11300",
  "midly",
  "mii",
+ "minicbor",
  "panic-probe",
  "pio",
  "portable-atomic",
@@ -908,7 +909,7 @@ checksum = "43eaff6bbc0b3a878361aced5ec6a2818ee7c541c5b33b5880dfa9a86c23e9e7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1059,7 +1060,7 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1121,6 +1122,7 @@ dependencies = [
  "log",
  "max11300",
  "midly",
+ "minicbor",
  "postcard",
  "postcard-bindgen",
  "serde",
@@ -1197,6 +1199,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11e67a72c8f43d89c57894d7177502a7314344fddcae71d30e797166473bd973"
 
 [[package]]
+name = "minicbor"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70eae6d4f18f7d76877fe7b13f0bc21f7c2b7239d2041c338335f7b388d0dd7"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "294f0a0c161c510e9746adf546b8b044fbb0b00677d7dfc9a2452f9fdf63439b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,7 +1265,7 @@ checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1379,7 +1401,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1442,7 +1464,7 @@ dependencies = [
  "regex-macro",
  "serde",
  "serde_derive_internals",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1470,23 +1492,23 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1674,7 +1696,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1685,7 +1707,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1799,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1844,7 +1866,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2100,5 +2122,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]

--- a/faderpunk/Cargo.toml
+++ b/faderpunk/Cargo.toml
@@ -51,6 +51,7 @@ log = "0.4.29"
 max11300 = "0.5.2"
 midly = { version = "0.5.3", default-features = false }
 mii = "0.2.0"
+minicbor = { version = "2.2.1", default-features = false, features = ["derive"] }
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
 pio = "0.3.0"
 portable-atomic = { version = "1.13.1", features = ["critical-section"] }

--- a/faderpunk/src/main.rs
+++ b/faderpunk/src/main.rs
@@ -37,7 +37,7 @@ use {defmt_rtt as _, panic_probe as _};
 use crate::storage::{factory_reset, store_layout};
 
 use layout::{LayoutManager, FORCE_RESPAWN_SIGNAL, LAYOUT_MANAGER, LAYOUT_WATCH};
-use storage::{load_calibration_data, load_global_config, load_layout};
+use storage::{load_calibration_data, load_global_config, load_layout, migrate_fram};
 use tasks::{
     buttons::{is_channel_button_pressed, is_scene_button_pressed},
     fram::MAX_DATA_LEN,
@@ -182,6 +182,11 @@ async fn main(spawner: Spawner) {
 
     // Initialize the buttons, otherwise we can't detect a press during startup
     tasks::buttons::start_buttons(&spawner, buttons).await;
+
+    // Migrate stored data from older firmware versions (e.g. v1.8.2's
+    // GlobalConfig that didn't yet have ClockConfig::swing_amount). Runs once
+    // per device, then short-circuits via the FRAM schema header.
+    migrate_fram().await;
 
     let calibration_data = load_calibration_data().await;
     let mut global_config = load_global_config().await;

--- a/faderpunk/src/state.rs
+++ b/faderpunk/src/state.rs
@@ -4,9 +4,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::storage;
 
+/// Persisted to FRAM as CBOR. Adding/removing fields is migration-free as long
+/// as every field carries `#[cbor(default)]` and a fresh `#[n(N)]`. See the
+/// `GlobalConfig` doc comment in `libfp::lib` for the full convention.
 #[derive(Serialize, Deserialize, Encode, Decode, Clone, Copy, Default, Debug)]
 pub struct RuntimeState {
     #[n(0)]
+    #[cbor(default)]
     pub clock_is_running: bool,
 }
 

--- a/faderpunk/src/state.rs
+++ b/faderpunk/src/state.rs
@@ -1,10 +1,12 @@
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
+use minicbor::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 use crate::storage;
 
-#[derive(Serialize, Deserialize, Clone, Copy, Default, Debug)]
+#[derive(Serialize, Deserialize, Encode, Decode, Clone, Copy, Default, Debug)]
 pub struct RuntimeState {
+    #[n(0)]
     pub clock_is_running: bool,
 }
 

--- a/faderpunk/src/storage.rs
+++ b/faderpunk/src/storage.rs
@@ -10,8 +10,8 @@ use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializ
 
 use libfp::{
     types::{CalibFile, MaxCalibration, MaxCalibrationV1},
-    AuxJackMode, ClockConfig, ClockSrc, GlobalConfig, I2cMode, Layout, MidiConfig,
-    QuantizerConfig, ResetSrc, TakeoverMode, Value, APP_MAX_PARAMS, CALIB_FILE_MAGIC,
+    AuxJackMode, ClockConfig, ClockSrc, GlobalConfig, I2cMode, Layout, MidiConfig, QuantizerConfig,
+    ResetSrc, TakeoverMode, Value, APP_MAX_PARAMS, CALIB_FILE_MAGIC,
 };
 
 use crate::{

--- a/faderpunk/src/storage.rs
+++ b/faderpunk/src/storage.rs
@@ -4,6 +4,7 @@ use embassy_futures::select::{select, Either};
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use embassy_time::Timer;
 use heapless::Vec;
+use minicbor::{Decode, Encode};
 use postcard::{from_bytes, to_slice};
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializer};
 
@@ -99,11 +100,44 @@ impl From<GlobalConfigV0> for GlobalConfig {
     }
 }
 
+/// `minicbor::encode::Write` impl that tracks bytes written into a borrowed
+/// slice. We avoid `minicbor::len`/`CborLen` so we don't have to derive a
+/// third trait on every persisted type — `minicbor::encode` only requires
+/// `Encode`, and a counting writer recovers the encoded length for free.
+struct SliceWriter<'a> {
+    buf: &'a mut [u8],
+    pos: usize,
+}
+
+impl minicbor::encode::Write for SliceWriter<'_> {
+    type Error = ();
+
+    fn write_all(&mut self, data: &[u8]) -> Result<(), Self::Error> {
+        let end = self.pos.checked_add(data.len()).ok_or(())?;
+        if end > self.buf.len() {
+            return Err(());
+        }
+        self.buf[self.pos..end].copy_from_slice(data);
+        self.pos = end;
+        Ok(())
+    }
+}
+
+/// Encodes `value` as CBOR into `buf` and returns the byte length. Errors are
+/// mapped to `postcard::Error` so the result threads back through
+/// `write_with`'s closure type without a custom error enum.
+fn cbor_encode<T: Encode<()>>(value: &T, buf: &mut [u8]) -> Result<usize, postcard::Error> {
+    let mut writer = SliceWriter { buf, pos: 0 };
+    minicbor::encode(value, &mut writer).map_err(|_| postcard::Error::SerializeBufferFull)?;
+    Ok(writer.pos)
+}
+
+fn cbor_decode<'b, T: Decode<'b, ()>>(bytes: &'b [u8]) -> Option<T> {
+    minicbor::decode(bytes).ok()
+}
+
 pub async fn store_global_config(config: &GlobalConfig) {
-    let res = write_with(GLOBAL_CONFIG_RANGE.start, |buf| {
-        Ok(to_slice(&config, &mut *buf)?.len())
-    })
-    .await;
+    let res = write_with(GLOBAL_CONFIG_RANGE.start, |buf| cbor_encode(config, buf)).await;
 
     if res.is_err() {
         defmt::error!("Could not save GlobalConfig");
@@ -114,7 +148,7 @@ pub async fn load_global_config() -> GlobalConfig {
     if let Ok(guard) = read_data(GLOBAL_CONFIG_RANGE.start).await {
         let data = guard.data();
         if !data.is_empty() {
-            if let Ok(mut config) = from_bytes::<GlobalConfig>(data) {
+            if let Some(mut config) = cbor_decode::<GlobalConfig>(data) {
                 config.validate();
                 return config;
             }
@@ -124,10 +158,7 @@ pub async fn load_global_config() -> GlobalConfig {
 }
 
 pub async fn store_runtime_state(state: &RuntimeState) {
-    let res = write_with(RUNTIME_STATE_RANGE.start, |buf| {
-        Ok(to_slice(&state, &mut *buf)?.len())
-    })
-    .await;
+    let res = write_with(RUNTIME_STATE_RANGE.start, |buf| cbor_encode(state, buf)).await;
 
     if res.is_err() {
         defmt::error!("Could not save runtime state");
@@ -138,7 +169,7 @@ pub async fn load_runtime_state() -> RuntimeState {
     if let Ok(guard) = read_data(RUNTIME_STATE_RANGE.start).await {
         let data = guard.data();
         if !data.is_empty() {
-            if let Ok(state) = from_bytes::<RuntimeState>(data) {
+            if let Some(state) = cbor_decode::<RuntimeState>(data) {
                 return state;
             }
         }
@@ -147,10 +178,7 @@ pub async fn load_runtime_state() -> RuntimeState {
 }
 
 pub async fn store_layout(layout: &Layout) {
-    let res = write_with(LAYOUT_RANGE.start, |buf| {
-        Ok(to_slice(&layout, &mut *buf)?.len())
-    })
-    .await;
+    let res = write_with(LAYOUT_RANGE.start, |buf| cbor_encode(layout, buf)).await;
 
     if res.is_err() {
         defmt::error!("Could not save Layout");
@@ -161,7 +189,7 @@ pub async fn load_layout() -> Layout {
     if let Ok(guard) = read_data(LAYOUT_RANGE.start).await {
         let data = guard.data();
         if !data.is_empty() {
-            if let Ok(mut layout) = from_bytes::<Layout>(data) {
+            if let Some(mut layout) = cbor_decode::<Layout>(data) {
                 drop(guard);
                 // Validate the layout after loading it from fram
                 if layout.validate(get_channels) {
@@ -303,45 +331,63 @@ async fn read_schema_version() -> u8 {
 }
 
 /// One-shot migration for `GlobalConfig` written by v1.8.2 / pre-fix v1.9
-/// betas. The stored bytes were laid out without `swing_amount`, so a current
-/// `from_bytes::<GlobalConfig>` either fails or, worse, succeeds with every
-/// field after `internal_bpm` shifted by one byte.
-///
-/// We deserialize as `GlobalConfigV0`, fill in `swing_amount = 0`, save the
-/// result in the current format, and return it. On any failure we fall back to
-/// `GlobalConfig::new()` and persist that — the v0 blob is left untouched on
-/// disk by the read, so the only data lost on failure is the global config
-/// (layouts, calibration, app params, app storage are all untouched).
-async fn migrate_legacy_global_config() -> GlobalConfig {
-    let migrated = read_data(GLOBAL_CONFIG_RANGE.start)
-        .await
-        .ok()
-        .and_then(|guard| from_bytes::<GlobalConfigV0>(guard.data()).ok())
-        .map(GlobalConfig::from);
-
-    let mut config = match migrated {
-        Some(config) => {
-            defmt::info!("Migrated GlobalConfig from pre-v1.9 (v0) layout");
-            config
-        }
-        None => {
-            defmt::warn!("Could not migrate legacy GlobalConfig; using defaults");
-            GlobalConfig::new()
-        }
+/// betas. The stored bytes were postcard-encoded without `swing_amount`, so a
+/// current `cbor_decode::<GlobalConfig>` would fail and a postcard
+/// `from_bytes::<GlobalConfig>` would succeed-with-shift. We deserialize as
+/// `GlobalConfigV0`, fill in `swing_amount = 0`, and re-save as CBOR. If the
+/// postcard read fails we leave the existing bytes alone — they may already be
+/// in CBOR format from a previous (header-less) migration attempt.
+async fn migrate_legacy_global_config() {
+    let Ok(guard) = read_data(GLOBAL_CONFIG_RANGE.start).await else {
+        return;
     };
+    let Ok(legacy) = from_bytes::<GlobalConfigV0>(guard.data()) else {
+        return;
+    };
+    drop(guard);
+    let mut config: GlobalConfig = legacy.into();
     config.validate();
     store_global_config(&config).await;
-    config
+    defmt::info!("Migrated GlobalConfig: postcard v0 → CBOR");
+}
+
+/// One-shot re-encode of `Layout` from postcard to CBOR. The struct shape
+/// didn't change between v1.8.2 and v1.9, so the same `Layout` type
+/// deserializes both — we just need to rewrite it in the new on-FRAM format.
+async fn migrate_legacy_layout() {
+    let Ok(guard) = read_data(LAYOUT_RANGE.start).await else {
+        return;
+    };
+    let Ok(mut layout) = from_bytes::<Layout>(guard.data()) else {
+        return;
+    };
+    drop(guard);
+    layout.validate(get_channels);
+    store_layout(&layout).await;
+    defmt::info!("Migrated Layout: postcard → CBOR");
+}
+
+/// One-shot re-encode of `RuntimeState` from postcard to CBOR.
+async fn migrate_legacy_runtime_state() {
+    let Ok(guard) = read_data(RUNTIME_STATE_RANGE.start).await else {
+        return;
+    };
+    let Ok(state) = from_bytes::<RuntimeState>(guard.data()) else {
+        return;
+    };
+    drop(guard);
+    store_runtime_state(&state).await;
+    defmt::info!("Migrated RuntimeState: postcard → CBOR");
 }
 
 /// Runs FRAM migrations needed to bring stored data forward to
-/// `SCHEMA_VERSION`. Migrations are non-destructive: only the data structures
-/// known to have changed shape are rewritten in place. Layouts, calibration,
-/// and per-app storage are left alone — apps that load mismatched param/state
-/// blobs already fall back to defaults gracefully.
+/// `SCHEMA_VERSION`. Migrations are non-destructive: each step reads the old
+/// format, rewrites in the current format, and is a no-op if the stored bytes
+/// don't match the legacy shape. Calibration and per-app storage are left
+/// alone — apps already fall back to defaults gracefully on bad data.
 ///
-/// On a fresh device (no header, but no stored data either) this is
-/// effectively a no-op apart from writing the header.
+/// On a fresh device (no header, no stored data) this is effectively a no-op
+/// apart from writing the header.
 pub async fn migrate_fram() {
     let version = read_schema_version().await;
     if version >= SCHEMA_VERSION {
@@ -349,9 +395,12 @@ pub async fn migrate_fram() {
     }
 
     if version < 1 {
-        // v0 → v1: ClockConfig gained `swing_amount`, shifting every field
-        // after it inside GlobalConfig. Migrate the global config in place.
+        // v0 → v1: switch top-level types from postcard to CBOR. Lifts
+        // GlobalConfig (which also gained ClockConfig::swing_amount, hence the
+        // legacy v0 type), Layout, and RuntimeState in place.
         migrate_legacy_global_config().await;
+        migrate_legacy_layout().await;
+        migrate_legacy_runtime_state().await;
     }
 
     write_schema_header(SCHEMA_VERSION).await;

--- a/faderpunk/src/storage.rs
+++ b/faderpunk/src/storage.rs
@@ -9,7 +9,8 @@ use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializ
 
 use libfp::{
     types::{CalibFile, MaxCalibration, MaxCalibrationV1},
-    GlobalConfig, Layout, Value, APP_MAX_PARAMS, CALIB_FILE_MAGIC,
+    AuxJackMode, ClockConfig, ClockSrc, GlobalConfig, I2cMode, Layout, MidiConfig,
+    QuantizerConfig, ResetSrc, TakeoverMode, Value, APP_MAX_PARAMS, CALIB_FILE_MAGIC,
 };
 
 use crate::{
@@ -26,11 +27,77 @@ const RUNTIME_STATE_RANGE: Range<u32> = GLOBAL_CONFIG_RANGE.end..384;
 const LAYOUT_RANGE: Range<u32> = RUNTIME_STATE_RANGE.end..512;
 const CALIBRATION_RANGE: Range<u32> = LAYOUT_RANGE.end..1024;
 const APP_STORAGE_RANGE: Range<u32> = CALIBRATION_RANGE.end..122_880;
-const APP_PARAM_RANGE: Range<u32> = APP_STORAGE_RANGE.end..131_072;
+const APP_PARAM_RANGE: Range<u32> = APP_STORAGE_RANGE.end..SCHEMA_HEADER_RANGE.start;
+/// Reserved region at the very end of FRAM holding `SchemaHeader`. Everything
+/// before it is data laid out by the firmware version that wrote it; this
+/// header is what tells us whether that layout matches the running firmware.
+const SCHEMA_HEADER_RANGE: Range<u32> = 131_056..131_072;
 
 const APP_STORAGE_MAX_BYTES: u32 = 400;
 const APP_PARAMS_MAX_BYTES: u32 = 128;
 const SCENES_PER_APP: u32 = 16;
+
+/// Magic bytes identifying a valid `SchemaHeader` (FaderPunk Schema Version).
+const SCHEMA_MAGIC: [u8; 4] = *b"FPSV";
+
+/// Version of the on-FRAM data layout. Bump this whenever a serialized struct
+/// stored in FRAM changes in a way that isn't backwards compatible under
+/// postcard. The migration logic in `migrate_legacy_global_config` runs once
+/// per device when the stored version is older than this.
+const SCHEMA_VERSION: u8 = 1;
+
+#[derive(Serialize, Deserialize)]
+struct SchemaHeader {
+    magic: [u8; 4],
+    version: u8,
+}
+
+/// v0 layout = anything older than `SCHEMA_VERSION = 1` (i.e. v1.8.2 and the
+/// pre-fix v1.9 betas, which never wrote a header).
+const SCHEMA_VERSION_V0: u8 = 0;
+
+/// On-FRAM layout of `ClockConfig` as it existed before v1.9 added
+/// `swing_amount`. Used only by `migrate_legacy_global_config` to deserialize
+/// stored v1.8.2 `GlobalConfig` blobs without the byte shift that would
+/// otherwise corrupt every field after `internal_bpm`.
+#[derive(Deserialize)]
+struct ClockConfigV0 {
+    clock_src: ClockSrc,
+    ext_ppqn: u8,
+    reset_src: ResetSrc,
+    internal_bpm: f32,
+}
+
+#[derive(Deserialize)]
+struct GlobalConfigV0 {
+    aux: [AuxJackMode; 3],
+    clock: ClockConfigV0,
+    i2c_mode: I2cMode,
+    led_brightness: u8,
+    midi: MidiConfig,
+    quantizer: QuantizerConfig,
+    takeover_mode: TakeoverMode,
+}
+
+impl From<GlobalConfigV0> for GlobalConfig {
+    fn from(old: GlobalConfigV0) -> Self {
+        Self {
+            aux: old.aux,
+            clock: ClockConfig {
+                clock_src: old.clock.clock_src,
+                ext_ppqn: old.clock.ext_ppqn,
+                reset_src: old.clock.reset_src,
+                internal_bpm: old.clock.internal_bpm,
+                swing_amount: 0,
+            },
+            i2c_mode: old.i2c_mode,
+            led_brightness: old.led_brightness,
+            midi: old.midi,
+            quantizer: old.quantizer,
+            takeover_mode: old.takeover_mode,
+        }
+    }
+}
 
 pub async fn store_global_config(config: &GlobalConfig) {
     let res = write_with(GLOBAL_CONFIG_RANGE.start, |buf| {
@@ -203,13 +270,102 @@ async fn erase_range(range: Range<u32>) {
     }
 }
 
-/// Erases all data from FRAM except for the calibration data.
+async fn write_schema_header(version: u8) {
+    let header = SchemaHeader {
+        magic: SCHEMA_MAGIC,
+        version,
+    };
+    let res = write_with(SCHEMA_HEADER_RANGE.start, |buf| {
+        Ok(to_slice(&header, &mut *buf)?.len())
+    })
+    .await;
+
+    if res.is_err() {
+        defmt::error!("Could not save FRAM schema header");
+    }
+}
+
+/// Returns the schema version recorded in FRAM, or `SCHEMA_VERSION_V0` if no
+/// valid header is present. A missing/garbled header means the stored data was
+/// written by a firmware predating the schema-version mechanism (v1.8.2 or the
+/// pre-fix v1.9 betas).
+async fn read_schema_version() -> u8 {
+    let Ok(guard) = read_data(SCHEMA_HEADER_RANGE.start).await else {
+        return SCHEMA_VERSION_V0;
+    };
+    let Ok(header) = from_bytes::<SchemaHeader>(guard.data()) else {
+        return SCHEMA_VERSION_V0;
+    };
+    if header.magic != SCHEMA_MAGIC {
+        return SCHEMA_VERSION_V0;
+    }
+    header.version
+}
+
+/// One-shot migration for `GlobalConfig` written by v1.8.2 / pre-fix v1.9
+/// betas. The stored bytes were laid out without `swing_amount`, so a current
+/// `from_bytes::<GlobalConfig>` either fails or, worse, succeeds with every
+/// field after `internal_bpm` shifted by one byte.
+///
+/// We deserialize as `GlobalConfigV0`, fill in `swing_amount = 0`, save the
+/// result in the current format, and return it. On any failure we fall back to
+/// `GlobalConfig::new()` and persist that — the v0 blob is left untouched on
+/// disk by the read, so the only data lost on failure is the global config
+/// (layouts, calibration, app params, app storage are all untouched).
+async fn migrate_legacy_global_config() -> GlobalConfig {
+    let migrated = read_data(GLOBAL_CONFIG_RANGE.start)
+        .await
+        .ok()
+        .and_then(|guard| from_bytes::<GlobalConfigV0>(guard.data()).ok())
+        .map(GlobalConfig::from);
+
+    let mut config = match migrated {
+        Some(config) => {
+            defmt::info!("Migrated GlobalConfig from pre-v1.9 (v0) layout");
+            config
+        }
+        None => {
+            defmt::warn!("Could not migrate legacy GlobalConfig; using defaults");
+            GlobalConfig::new()
+        }
+    };
+    config.validate();
+    store_global_config(&config).await;
+    config
+}
+
+/// Runs FRAM migrations needed to bring stored data forward to
+/// `SCHEMA_VERSION`. Migrations are non-destructive: only the data structures
+/// known to have changed shape are rewritten in place. Layouts, calibration,
+/// and per-app storage are left alone — apps that load mismatched param/state
+/// blobs already fall back to defaults gracefully.
+///
+/// On a fresh device (no header, but no stored data either) this is
+/// effectively a no-op apart from writing the header.
+pub async fn migrate_fram() {
+    let version = read_schema_version().await;
+    if version >= SCHEMA_VERSION {
+        return;
+    }
+
+    if version < 1 {
+        // v0 → v1: ClockConfig gained `swing_amount`, shifting every field
+        // after it inside GlobalConfig. Migrate the global config in place.
+        migrate_legacy_global_config().await;
+    }
+
+    write_schema_header(SCHEMA_VERSION).await;
+}
+
+/// Erases all data from FRAM except for the calibration data and reboots.
 pub async fn factory_reset() {
     erase_range(GLOBAL_CONFIG_RANGE).await;
     erase_range(RUNTIME_STATE_RANGE).await;
     erase_range(LAYOUT_RANGE).await;
     erase_range(APP_STORAGE_RANGE).await;
     erase_range(APP_PARAM_RANGE).await;
+    erase_range(SCHEMA_HEADER_RANGE).await;
+    write_schema_header(SCHEMA_VERSION).await;
     // Wait a bit
     Timer::after_millis(100).await;
     // Then restart the unit

--- a/faderpunk/src/storage.rs
+++ b/faderpunk/src/storage.rs
@@ -58,9 +58,10 @@ struct SchemaHeader {
 const SCHEMA_VERSION_V0: u8 = 0;
 
 /// On-FRAM layout of `ClockConfig` as it existed before v1.9 added
-/// `swing_amount`. Used only by `migrate_legacy_global_config` to deserialize
-/// stored v1.8.2 `GlobalConfig` blobs without the byte shift that would
-/// otherwise corrupt every field after `internal_bpm`.
+/// `swing_amount`. Used by both `GlobalConfigV0` (v1.8.x) and
+/// `GlobalConfigV170` (v1.7.0) to deserialize their stored `clock` field
+/// without the byte shift that would otherwise corrupt every field after
+/// `internal_bpm`.
 #[derive(Deserialize)]
 struct ClockConfigV0 {
     clock_src: ClockSrc,
@@ -69,6 +70,8 @@ struct ClockConfigV0 {
     internal_bpm: f32,
 }
 
+/// `GlobalConfig` as written by v1.8.x: same as v1.7.0 plus `takeover_mode`,
+/// still missing `ClockConfig::swing_amount` (added in v1.9).
 #[derive(Deserialize)]
 struct GlobalConfigV0 {
     aux: [AuxJackMode; 3],
@@ -96,6 +99,39 @@ impl From<GlobalConfigV0> for GlobalConfig {
             midi: old.midi,
             quantizer: old.quantizer,
             takeover_mode: old.takeover_mode,
+        }
+    }
+}
+
+/// `GlobalConfig` as written by v1.7.0: missing both `takeover_mode` (added in
+/// v1.8.0) and `ClockConfig::swing_amount` (added in v1.9). Both fields fall
+/// back to their `Default::default()` on migration.
+#[derive(Deserialize)]
+struct GlobalConfigV170 {
+    aux: [AuxJackMode; 3],
+    clock: ClockConfigV0,
+    i2c_mode: I2cMode,
+    led_brightness: u8,
+    midi: MidiConfig,
+    quantizer: QuantizerConfig,
+}
+
+impl From<GlobalConfigV170> for GlobalConfig {
+    fn from(old: GlobalConfigV170) -> Self {
+        Self {
+            aux: old.aux,
+            clock: ClockConfig {
+                clock_src: old.clock.clock_src,
+                ext_ppqn: old.clock.ext_ppqn,
+                reset_src: old.clock.reset_src,
+                internal_bpm: old.clock.internal_bpm,
+                swing_amount: 0,
+            },
+            i2c_mode: old.i2c_mode,
+            led_brightness: old.led_brightness,
+            midi: old.midi,
+            quantizer: old.quantizer,
+            takeover_mode: TakeoverMode::Pickup,
         }
     }
 }
@@ -330,13 +366,17 @@ async fn read_schema_version() -> u8 {
     header.version
 }
 
-/// One-shot migration for `GlobalConfig` written by v1.8.2 / pre-fix v1.9
-/// betas. Both layouts are postcard, but they differ by one byte:
-/// `ClockConfig` gained `swing_amount` in v1.9. We try the v1.9 (current)
-/// layout first — pre-fix v1.9 data decodes cleanly there, and v1.8.2 data
-/// either runs out of bytes or hits an invalid `i2c_mode` varint and fails,
-/// at which point we fall back to `GlobalConfigV0` (v1.8.2 layout) and fill
-/// in `swing_amount = 0`.
+/// One-shot migration for `GlobalConfig` written by v1.7.0 / v1.8.x / pre-fix
+/// v1.9 betas. All three are postcard, differing by trailing fields:
+///
+/// - v1.7.0 → no `takeover_mode`, no `swing_amount` (2 bytes shorter).
+/// - v1.8.x → has `takeover_mode`, no `swing_amount` (1 byte shorter).
+/// - pre-fix v1.9 → matches the current shape.
+///
+/// Fallback order matters: postcard's `from_bytes` does not check for trailing
+/// bytes, so the largest layout must be tried first. We try current → V0 →
+/// V170; if V170 ran first it would falsely accept v1.8.x data (silently
+/// dropping `takeover_mode`).
 ///
 /// On any failure the stored bytes are left alone, so a partially-migrated
 /// state (cbor data, no header) self-heals on the next boot: postcard decode
@@ -347,11 +387,18 @@ async fn migrate_legacy_global_config() {
         return;
     };
     let data = guard.data();
-    let migrated: Option<GlobalConfig> = from_bytes::<GlobalConfig>(data).ok().or_else(|| {
-        from_bytes::<GlobalConfigV0>(data)
-            .ok()
-            .map(GlobalConfig::from)
-    });
+    let migrated: Option<GlobalConfig> = from_bytes::<GlobalConfig>(data)
+        .ok()
+        .or_else(|| {
+            from_bytes::<GlobalConfigV0>(data)
+                .ok()
+                .map(GlobalConfig::from)
+        })
+        .or_else(|| {
+            from_bytes::<GlobalConfigV170>(data)
+                .ok()
+                .map(GlobalConfig::from)
+        });
     let Some(mut config) = migrated else {
         return;
     };

--- a/faderpunk/src/storage.rs
+++ b/faderpunk/src/storage.rs
@@ -331,24 +331,34 @@ async fn read_schema_version() -> u8 {
 }
 
 /// One-shot migration for `GlobalConfig` written by v1.8.2 / pre-fix v1.9
-/// betas. The stored bytes were postcard-encoded without `swing_amount`, so a
-/// current `cbor_decode::<GlobalConfig>` would fail and a postcard
-/// `from_bytes::<GlobalConfig>` would succeed-with-shift. We deserialize as
-/// `GlobalConfigV0`, fill in `swing_amount = 0`, and re-save as CBOR. If the
-/// postcard read fails we leave the existing bytes alone — they may already be
-/// in CBOR format from a previous (header-less) migration attempt.
+/// betas. Both layouts are postcard, but they differ by one byte:
+/// `ClockConfig` gained `swing_amount` in v1.9. We try the v1.9 (current)
+/// layout first — pre-fix v1.9 data decodes cleanly there, and v1.8.2 data
+/// either runs out of bytes or hits an invalid `i2c_mode` varint and fails,
+/// at which point we fall back to `GlobalConfigV0` (v1.8.2 layout) and fill
+/// in `swing_amount = 0`.
+///
+/// On any failure the stored bytes are left alone, so a partially-migrated
+/// state (cbor data, no header) self-heals on the next boot: postcard decode
+/// of cbor bytes fails on the first byte, this is a no-op, and the schema
+/// header eventually gets written.
 async fn migrate_legacy_global_config() {
     let Ok(guard) = read_data(GLOBAL_CONFIG_RANGE.start).await else {
         return;
     };
-    let Ok(legacy) = from_bytes::<GlobalConfigV0>(guard.data()) else {
+    let data = guard.data();
+    let migrated: Option<GlobalConfig> = from_bytes::<GlobalConfig>(data).ok().or_else(|| {
+        from_bytes::<GlobalConfigV0>(data)
+            .ok()
+            .map(GlobalConfig::from)
+    });
+    let Some(mut config) = migrated else {
         return;
     };
     drop(guard);
-    let mut config: GlobalConfig = legacy.into();
     config.validate();
     store_global_config(&config).await;
-    defmt::info!("Migrated GlobalConfig: postcard v0 → CBOR");
+    defmt::info!("Migrated GlobalConfig: postcard → CBOR");
 }
 
 /// One-shot re-encode of `Layout` from postcard to CBOR. The struct shape

--- a/gen-bindings/Cargo.lock
+++ b/gen-bindings/Cargo.lock
@@ -332,6 +332,7 @@ dependencies = [
  "log",
  "max11300",
  "midly",
+ "minicbor",
  "postcard",
  "postcard-bindgen",
  "serde",
@@ -391,6 +392,26 @@ name = "midly"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "207d755f4cb882d20c4da58d707ca9130a0c9bc5061f657a4f299b8e36362b7a"
+
+[[package]]
+name = "minicbor"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70eae6d4f18f7d76877fe7b13f0bc21f7c2b7239d2041c338335f7b388d0dd7"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "294f0a0c161c510e9746adf546b8b044fbb0b00677d7dfc9a2452f9fdf63439b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "nb"
@@ -477,18 +498,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -662,9 +683,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/libfp/Cargo.toml
+++ b/libfp/Cargo.toml
@@ -13,6 +13,7 @@ libm = "0.2.16"
 log = { version = "0.4", default-features = false }
 max11300 = "0.5.2"
 midly = { version = "0.5.3", default-features = false }
+minicbor = { version = "2.2.1", default-features = false, features = ["derive"] }
 postcard = "1.1.3"
 postcard-bindgen = "0.7.1"
 serde = { version = "1.0.219", features = ["derive"], default-features = false }

--- a/libfp/src/latch.rs
+++ b/libfp/src/latch.rs
@@ -20,7 +20,12 @@ impl From<bool> for LatchLayer {
     }
 }
 
-/// Defines how a fader should take control of a value when switching layers or starting a session.
+/// Defines how a fader should take control of a value when switching layers
+/// or starting a session.
+///
+/// Persisted in `GlobalConfig` via CBOR. New variants may be appended with the
+/// next free `#[n(N)]` tag without a migration. **Removing** a variant
+/// requires a one-shot FRAM migration (see `storage::migrate_fram`).
 #[derive(
     Clone,
     Copy,

--- a/libfp/src/latch.rs
+++ b/libfp/src/latch.rs
@@ -1,3 +1,4 @@
+use minicbor::{Decode, Encode};
 use postcard_bindgen::PostcardBindings;
 use serde::{Deserialize, Serialize};
 
@@ -20,14 +21,30 @@ impl From<bool> for LatchLayer {
 }
 
 /// Defines how a fader should take control of a value when switching layers or starting a session.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize, Deserialize, PostcardBindings)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Default,
+    Serialize,
+    Deserialize,
+    PostcardBindings,
+    Encode,
+    Decode,
+)]
+#[cbor(index_only)]
 pub enum TakeoverMode {
     /// Wait until fader crosses target value, then sync (default behavior)
     #[default]
+    #[n(0)]
     Pickup,
     /// Value immediately jumps to fader position (no pickup delay)
+    #[n(1)]
     Jump,
     /// Gradually scale value toward fader position based on movement and runway
+    #[n(2)]
     Scale,
 }
 

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -166,6 +166,10 @@ impl<'a> IntoIterator for &'a Layout {
     }
 }
 
+/// Persisted in `GlobalConfig` via CBOR. New variants may be appended with the
+/// next free `#[n(N)]` tag without a migration. **Removing** a variant
+/// requires a one-shot FRAM migration (see `storage::migrate_fram`) — old
+/// stored data containing the removed tag would otherwise fail to decode.
 #[derive(
     Clone, Copy, Default, PartialEq, Serialize, Deserialize, PostcardBindings, Encode, Decode,
 )]
@@ -200,6 +204,9 @@ impl From<ResetSrc> for ClockSrc {
     }
 }
 
+/// Persisted in `GlobalConfig` via CBOR. New variants may be appended with the
+/// next free `#[n(N)]` tag without a migration. **Removing** a variant
+/// requires a one-shot FRAM migration (see `storage::migrate_fram`).
 #[derive(
     Clone, Copy, Default, PartialEq, Serialize, Deserialize, PostcardBindings, Encode, Decode,
 )]
@@ -217,6 +224,9 @@ pub enum ResetSrc {
     Cube,
 }
 
+/// Persisted in `GlobalConfig` via CBOR. New variants may be appended with the
+/// next free `#[n(N)]` tag without a migration. **Removing** a variant
+/// requires a one-shot FRAM migration (see `storage::migrate_fram`).
 #[derive(Clone, Default, Serialize, Deserialize, PostcardBindings, Encode, Decode)]
 #[cbor(index_only)]
 #[repr(u8)]
@@ -230,6 +240,10 @@ pub enum I2cMode {
     Follower,
 }
 
+/// Persisted in `GlobalConfig` via CBOR (inside `QuantizerConfig`). New
+/// variants may be appended with the next free `#[n(N)]` tag without a
+/// migration. **Removing** a variant requires a one-shot FRAM migration (see
+/// `storage::migrate_fram`).
 #[derive(
     Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize, PostcardBindings, Encode, Decode,
 )]
@@ -292,6 +306,10 @@ impl FromValue for Note {
     }
 }
 
+/// Persisted in `GlobalConfig` via CBOR (inside `QuantizerConfig`). New
+/// variants may be appended with the next free `#[n(N)]` tag without a
+/// migration. **Removing** a variant requires a one-shot FRAM migration (see
+/// `storage::migrate_fram`).
 #[derive(
     Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize, PostcardBindings, Encode, Decode,
 )]
@@ -357,6 +375,10 @@ impl Key {
     }
 }
 
+/// Persisted in `GlobalConfig` via CBOR (inside `MidiOutConfig`). New variants
+/// may be appended with the next free `#[n(N)]` tag without a migration.
+/// **Removing** a variant requires a one-shot FRAM migration (see
+/// `storage::migrate_fram`).
 #[derive(Clone, Copy, Default, Serialize, Deserialize, PostcardBindings, PartialEq, Encode, Decode)]
 pub enum MidiOutMode {
     #[n(0)]
@@ -488,6 +510,10 @@ impl QuantizerConfig {
     }
 }
 
+/// Persisted in `GlobalConfig` via CBOR (inside `AuxJackMode::ClockOut`). New
+/// variants may be appended with the next free `#[n(N)]` tag without a
+/// migration. **Removing** a variant requires a one-shot FRAM migration (see
+/// `storage::migrate_fram`).
 #[derive(
     Copy, Clone, Default, Serialize, PartialEq, Deserialize, PostcardBindings, Encode, Decode,
 )]
@@ -521,6 +547,10 @@ pub enum ClockDivision {
     _384 = 384,
 }
 
+/// Persisted in `GlobalConfig` via CBOR (inside `aux: [AuxJackMode; 3]`). New
+/// variants may be appended with the next free `#[n(N)]` tag without a
+/// migration. **Removing** a variant requires a one-shot FRAM migration (see
+/// `storage::migrate_fram`).
 #[derive(Clone, Default, Serialize, PartialEq, Deserialize, PostcardBindings, Encode, Decode)]
 #[repr(u8)]
 pub enum AuxJackMode {

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -1713,4 +1713,101 @@ mod tests {
         let decoded: GlobalConfig = minicbor::decode(&encoded).unwrap();
         assert_eq!(decoded.led_brightness, 111);
     }
+
+    /// Mirror of v1.7.0's `GlobalConfig` shape (no `takeover_mode`, no
+    /// `swing_amount`).
+    #[derive(Serialize, Deserialize)]
+    struct GlobalConfigV170 {
+        aux: [AuxJackMode; 3],
+        clock: ClockConfigPreSwing,
+        i2c_mode: I2cMode,
+        led_brightness: u8,
+        midi: MidiConfig,
+        quantizer: QuantizerConfig,
+    }
+
+    fn make_v17_default() -> GlobalConfigV170 {
+        GlobalConfigV170 {
+            aux: [
+                AuxJackMode::ClockOut(ClockDivision::_1),
+                AuxJackMode::None,
+                AuxJackMode::None,
+            ],
+            clock: ClockConfigPreSwing {
+                clock_src: ClockSrc::Internal,
+                ext_ppqn: 24,
+                reset_src: ResetSrc::None,
+                internal_bpm: 120.0,
+            },
+            i2c_mode: I2cMode::Leader,
+            led_brightness: 150,
+            midi: MidiConfig::new(),
+            quantizer: QuantizerConfig::new(),
+        }
+    }
+
+    #[test]
+    fn v17_postcard_data_fails_current_and_v18_postcard_decode() {
+        // v1.7.0 data is 2 bytes shorter than current and 1 byte shorter than
+        // v1.8.x. Both larger shapes must fail so the V170 fallback is the one
+        // that actually runs.
+        let v17 = make_v17_default();
+        let mut buf = [0u8; 256];
+        let bytes = postcard::to_slice(&v17, &mut buf).unwrap();
+
+        let current: Result<GlobalConfig, _> = postcard::from_bytes(bytes);
+        assert!(current.is_err(), "v1.7.0 must NOT decode as current");
+        let v18: Result<GlobalConfigPreSwing, _> = postcard::from_bytes(bytes);
+        assert!(v18.is_err(), "v1.7.0 must NOT decode as v1.8.x");
+    }
+
+    #[test]
+    fn v17_postcard_data_decodes_as_v170_shape() {
+        let v17 = make_v17_default();
+        let mut buf = [0u8; 256];
+        let bytes = postcard::to_slice(&v17, &mut buf).unwrap();
+
+        let decoded: GlobalConfigV170 = postcard::from_bytes(bytes).unwrap();
+        assert_eq!(decoded.led_brightness, 150);
+        assert_eq!(decoded.clock.internal_bpm.to_bits(), 120.0_f32.to_bits());
+    }
+
+    #[test]
+    fn brightness_round_trips_through_v170_migration() {
+        // Same hardware-bug regression as the v1.8.x test, one version older:
+        // brightness 111 set on v1.7.0 must survive the postcard-V170 → CBOR
+        // migration unchanged. `swing_amount` and `takeover_mode` come back as
+        // their `Default::default()` values.
+        let mut v17 = make_v17_default();
+        v17.led_brightness = 111;
+        let mut buf = [0u8; 256];
+        let bytes = postcard::to_slice(&v17, &mut buf).unwrap();
+
+        let decoded_v17: GlobalConfigV170 = postcard::from_bytes(bytes).unwrap();
+        assert_eq!(decoded_v17.led_brightness, 111);
+
+        // Mirror the From<GlobalConfigV170> conversion from storage.rs.
+        let migrated = GlobalConfig {
+            aux: decoded_v17.aux,
+            clock: ClockConfig {
+                clock_src: decoded_v17.clock.clock_src,
+                ext_ppqn: decoded_v17.clock.ext_ppqn,
+                reset_src: decoded_v17.clock.reset_src,
+                internal_bpm: decoded_v17.clock.internal_bpm,
+                swing_amount: 0,
+            },
+            i2c_mode: decoded_v17.i2c_mode,
+            led_brightness: decoded_v17.led_brightness,
+            midi: decoded_v17.midi,
+            quantizer: decoded_v17.quantizer,
+            takeover_mode: TakeoverMode::Pickup,
+        };
+        assert_eq!(migrated.led_brightness, 111);
+        assert_eq!(migrated.clock.swing_amount, 0);
+
+        let encoded = cbor_encode_to_vec(&migrated);
+        let decoded: GlobalConfig = minicbor::decode(&encoded).unwrap();
+        assert_eq!(decoded.led_brightness, 111);
+        assert_eq!(decoded.clock.swing_amount, 0);
+    }
 }

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -166,7 +166,9 @@ impl<'a> IntoIterator for &'a Layout {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Serialize, Deserialize, PostcardBindings, Encode, Decode)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Serialize, Deserialize, PostcardBindings, Encode, Decode,
+)]
 #[cbor(index_only)]
 #[repr(u8)]
 pub enum ClockSrc {
@@ -178,6 +180,7 @@ pub enum ClockSrc {
     Meteor,
     #[n(3)]
     Cube,
+    #[default]
     #[n(4)]
     Internal,
     #[n(5)]
@@ -197,10 +200,13 @@ impl From<ResetSrc> for ClockSrc {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Serialize, Deserialize, PostcardBindings, Encode, Decode)]
+#[derive(
+    Clone, Copy, Default, PartialEq, Serialize, Deserialize, PostcardBindings, Encode, Decode,
+)]
 #[cbor(index_only)]
 #[repr(u8)]
 pub enum ResetSrc {
+    #[default]
     #[n(0)]
     None,
     #[n(1)]
@@ -211,12 +217,13 @@ pub enum ResetSrc {
     Cube,
 }
 
-#[derive(Clone, Serialize, Deserialize, PostcardBindings, Encode, Decode)]
+#[derive(Clone, Default, Serialize, Deserialize, PostcardBindings, Encode, Decode)]
 #[cbor(index_only)]
 #[repr(u8)]
 pub enum I2cMode {
     #[n(0)]
     Calibration,
+    #[default]
     #[n(1)]
     Leader,
     #[n(2)]
@@ -350,10 +357,11 @@ impl Key {
     }
 }
 
-#[derive(Clone, Copy, Serialize, Deserialize, PostcardBindings, PartialEq, Encode, Decode)]
+#[derive(Clone, Copy, Default, Serialize, Deserialize, PostcardBindings, PartialEq, Encode, Decode)]
 pub enum MidiOutMode {
     #[n(0)]
     None,
+    #[default]
     #[n(1)]
     Local,
     #[n(2)]
@@ -371,11 +379,20 @@ pub enum MidiOutMode {
 #[derive(Clone, Copy, Serialize, Deserialize, PostcardBindings, PartialEq, Encode, Decode)]
 pub struct MidiOutConfig {
     #[n(0)]
+    #[cbor(default)]
     pub send_clock: bool,
     #[n(1)]
+    #[cbor(default)]
     pub send_transport: bool,
     #[n(2)]
+    #[cbor(default)]
     pub mode: MidiOutMode,
+}
+
+impl Default for MidiOutConfig {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[allow(clippy::new_without_default)]
@@ -393,7 +410,14 @@ impl MidiOutConfig {
 pub struct MidiConfig {
     // [usb, out1, out2]
     #[n(0)]
+    #[cbor(default)]
     pub outs: [MidiOutConfig; 3],
+}
+
+impl Default for MidiConfig {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[allow(clippy::new_without_default)]
@@ -408,16 +432,27 @@ impl MidiConfig {
 #[derive(Clone, Serialize, Deserialize, PostcardBindings, PartialEq, Encode, Decode)]
 pub struct ClockConfig {
     #[n(0)]
+    #[cbor(default)]
     pub clock_src: ClockSrc,
     #[n(1)]
+    #[cbor(default)]
     pub ext_ppqn: u8,
     #[n(2)]
+    #[cbor(default)]
     pub reset_src: ResetSrc,
     #[n(3)]
+    #[cbor(default)]
     pub internal_bpm: f32,
     /// Deluge-style swing amount in `[-35, 35]`. `0` = straight.
     #[n(4)]
+    #[cbor(default)]
     pub swing_amount: i8,
+}
+
+impl Default for ClockConfig {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[allow(clippy::new_without_default)]
@@ -436,8 +471,10 @@ impl ClockConfig {
 #[derive(Clone, Default, Serialize, Deserialize, PostcardBindings, PartialEq, Encode, Decode)]
 pub struct QuantizerConfig {
     #[n(0)]
+    #[cbor(default)]
     pub key: Key,
     #[n(1)]
+    #[cbor(default)]
     pub tonic: Note,
 }
 
@@ -451,10 +488,13 @@ impl QuantizerConfig {
     }
 }
 
-#[derive(Copy, Clone, Serialize, PartialEq, Deserialize, PostcardBindings, Encode, Decode)]
+#[derive(
+    Copy, Clone, Default, Serialize, PartialEq, Deserialize, PostcardBindings, Encode, Decode,
+)]
 #[cbor(index_only)]
 #[repr(u16)]
 pub enum ClockDivision {
+    #[default]
     #[n(1)]
     _1 = 1,
     #[n(2)]
@@ -481,9 +521,10 @@ pub enum ClockDivision {
     _384 = 384,
 }
 
-#[derive(Clone, Serialize, PartialEq, Deserialize, PostcardBindings, Encode, Decode)]
+#[derive(Clone, Default, Serialize, PartialEq, Deserialize, PostcardBindings, Encode, Decode)]
 #[repr(u8)]
 pub enum AuxJackMode {
+    #[default]
     #[n(0)]
     None,
     #[n(1)]
@@ -492,22 +533,56 @@ pub enum AuxJackMode {
     ResetOut,
 }
 
+/// `GlobalConfig` is persisted to FRAM as CBOR. To keep the on-FRAM format
+/// forward/backward compatible without writing a migration:
+///
+/// - **Every field has `#[cbor(default)]`.** Missing tags decode as
+///   `Default::default()` instead of erroring. Removing a field is just
+///   deleting the field; old stored data with that tag is silently skipped.
+///   Adding a field is just declaring it with the next free tag — old data
+///   without the tag falls back to its `Default`.
+/// - **Tags are append-only.** Never reuse an `#[n(N)]` for a different
+///   purpose; pick the next unused integer. Reusing a tag would silently
+///   reinterpret old stored data.
+/// - **Field types must implement `Default`** with a value that's safe if it
+///   ever shows up on a device that's missing the field in FRAM.
+///
+/// This convention applies recursively to every type reachable from
+/// `GlobalConfig` through fields tagged `#[cbor(default)]`. Things that *do*
+/// require a one-shot migration (handled in `storage::migrate_fram`):
+///
+/// - Changing the type of an existing field (e.g. `u8 → u16`).
+/// - Resizing fixed-size arrays (`[T; N]`) or tuples.
+/// - Removing an enum variant while old data may still contain it.
 #[derive(Clone, Serialize, Deserialize, PostcardBindings, Encode, Decode)]
 pub struct GlobalConfig {
     #[n(0)]
+    #[cbor(default)]
     pub aux: [AuxJackMode; 3],
     #[n(1)]
+    #[cbor(default)]
     pub clock: ClockConfig,
     #[n(2)]
+    #[cbor(default)]
     pub i2c_mode: I2cMode,
     #[n(3)]
+    #[cbor(default)]
     pub led_brightness: u8,
     #[n(4)]
+    #[cbor(default)]
     pub midi: MidiConfig,
     #[n(5)]
+    #[cbor(default)]
     pub quantizer: QuantizerConfig,
     #[n(6)]
+    #[cbor(default)]
     pub takeover_mode: TakeoverMode,
+}
+
+impl Default for GlobalConfig {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[allow(clippy::new_without_default)]

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -6,6 +6,7 @@ use embassy_time::Duration;
 use heapless::Vec;
 use max11300::config::{ADCRANGE, DACRANGE};
 use midly::num::{u4, u7};
+use minicbor::{Decode, Encode};
 use postcard_bindgen::PostcardBindings;
 use serde::{Deserialize, Serialize};
 
@@ -60,8 +61,9 @@ pub type ConfigMeta<'a> = (usize, &'a str, &'a str, Color, AppIcon, &'a [Param])
 // (app_id, channels, layout_id)
 pub type InnerLayout = [Option<(u8, usize, u8)>; GLOBAL_CHANNELS];
 
-#[derive(Clone, Serialize, Deserialize, PostcardBindings)]
-pub struct Layout(pub InnerLayout);
+#[derive(Clone, Serialize, Deserialize, PostcardBindings, Encode, Decode)]
+#[cbor(transparent)]
+pub struct Layout(#[n(0)] pub InnerLayout);
 
 impl Layout {
     pub fn validate(&mut self, get_channels: fn(u8) -> Option<usize>) -> bool {
@@ -164,15 +166,23 @@ impl<'a> IntoIterator for &'a Layout {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Serialize, Deserialize, PostcardBindings)]
+#[derive(Clone, Copy, PartialEq, Serialize, Deserialize, PostcardBindings, Encode, Decode)]
+#[cbor(index_only)]
 #[repr(u8)]
 pub enum ClockSrc {
+    #[n(0)]
     None,
+    #[n(1)]
     Atom,
+    #[n(2)]
     Meteor,
+    #[n(3)]
     Cube,
+    #[n(4)]
     Internal,
+    #[n(5)]
     MidiIn,
+    #[n(6)]
     MidiUsb,
 }
 
@@ -187,38 +197,62 @@ impl From<ResetSrc> for ClockSrc {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Serialize, Deserialize, PostcardBindings)]
+#[derive(Clone, Copy, PartialEq, Serialize, Deserialize, PostcardBindings, Encode, Decode)]
+#[cbor(index_only)]
 #[repr(u8)]
 pub enum ResetSrc {
+    #[n(0)]
     None,
+    #[n(1)]
     Atom,
+    #[n(2)]
     Meteor,
+    #[n(3)]
     Cube,
 }
 
-#[derive(Clone, Serialize, Deserialize, PostcardBindings)]
+#[derive(Clone, Serialize, Deserialize, PostcardBindings, Encode, Decode)]
+#[cbor(index_only)]
 #[repr(u8)]
 pub enum I2cMode {
+    #[n(0)]
     Calibration,
+    #[n(1)]
     Leader,
+    #[n(2)]
     Follower,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize, PostcardBindings)]
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize, PostcardBindings, Encode, Decode,
+)]
+#[cbor(index_only)]
 #[repr(u8)]
 pub enum Note {
     #[default]
+    #[n(0)]
     C = 0,
+    #[n(1)]
     CSharp = 1,
+    #[n(2)]
     D = 2,
+    #[n(3)]
     DSharp = 3,
+    #[n(4)]
     E = 4,
+    #[n(5)]
     F = 5,
+    #[n(6)]
     FSharp = 6,
+    #[n(7)]
     G = 7,
+    #[n(8)]
     GSharp = 8,
+    #[n(9)]
     A = 9,
+    #[n(10)]
     ASharp = 10,
+    #[n(11)]
     B = 11,
 }
 
@@ -251,25 +285,44 @@ impl FromValue for Note {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize, PostcardBindings)]
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize, PostcardBindings, Encode, Decode,
+)]
+#[cbor(index_only)]
 #[repr(u8)]
 pub enum Key {
     #[default]
+    #[n(0)]
     Chromatic,
+    #[n(1)]
     Ionian,
+    #[n(2)]
     Dorian,
+    #[n(3)]
     Phrygian,
+    #[n(4)]
     Lydian,
+    #[n(5)]
     Mixolydian,
+    #[n(6)]
     Aeolian,
+    #[n(7)]
     Locrian,
+    #[n(8)]
     BluesMaj,
+    #[n(9)]
     BluesMin,
+    #[n(10)]
     PentatonicMaj,
+    #[n(11)]
     PentatonicMin,
+    #[n(12)]
     Folk,
+    #[n(13)]
     Japanese,
+    #[n(14)]
     Gamelan,
+    #[n(15)]
     HungarianMin,
 }
 
@@ -297,18 +350,31 @@ impl Key {
     }
 }
 
-#[derive(Clone, Copy, Serialize, Deserialize, PostcardBindings, PartialEq)]
+#[derive(Clone, Copy, Serialize, Deserialize, PostcardBindings, PartialEq, Encode, Decode)]
 pub enum MidiOutMode {
+    #[n(0)]
     None,
+    #[n(1)]
     Local,
-    MidiThru { sources: MidiIn },
-    MidiMerge { sources: MidiIn },
+    #[n(2)]
+    MidiThru {
+        #[n(0)]
+        sources: MidiIn,
+    },
+    #[n(3)]
+    MidiMerge {
+        #[n(0)]
+        sources: MidiIn,
+    },
 }
 
-#[derive(Clone, Copy, Serialize, Deserialize, PostcardBindings, PartialEq)]
+#[derive(Clone, Copy, Serialize, Deserialize, PostcardBindings, PartialEq, Encode, Decode)]
 pub struct MidiOutConfig {
+    #[n(0)]
     pub send_clock: bool,
+    #[n(1)]
     pub send_transport: bool,
+    #[n(2)]
     pub mode: MidiOutMode,
 }
 
@@ -323,9 +389,10 @@ impl MidiOutConfig {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, PostcardBindings, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, PostcardBindings, PartialEq, Encode, Decode)]
 pub struct MidiConfig {
     // [usb, out1, out2]
+    #[n(0)]
     pub outs: [MidiOutConfig; 3],
 }
 
@@ -338,13 +405,18 @@ impl MidiConfig {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, PostcardBindings, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, PostcardBindings, PartialEq, Encode, Decode)]
 pub struct ClockConfig {
+    #[n(0)]
     pub clock_src: ClockSrc,
+    #[n(1)]
     pub ext_ppqn: u8,
+    #[n(2)]
     pub reset_src: ResetSrc,
+    #[n(3)]
     pub internal_bpm: f32,
     /// Deluge-style swing amount in `[-35, 35]`. `0` = straight.
+    #[n(4)]
     pub swing_amount: i8,
 }
 
@@ -361,9 +433,11 @@ impl ClockConfig {
     }
 }
 
-#[derive(Clone, Default, Serialize, Deserialize, PostcardBindings, PartialEq)]
+#[derive(Clone, Default, Serialize, Deserialize, PostcardBindings, PartialEq, Encode, Decode)]
 pub struct QuantizerConfig {
+    #[n(0)]
     pub key: Key,
+    #[n(1)]
     pub tonic: Note,
 }
 
@@ -377,41 +451,62 @@ impl QuantizerConfig {
     }
 }
 
-#[derive(Copy, Clone, Serialize, PartialEq, Deserialize, PostcardBindings)]
+#[derive(Copy, Clone, Serialize, PartialEq, Deserialize, PostcardBindings, Encode, Decode)]
+#[cbor(index_only)]
 #[repr(u16)]
 pub enum ClockDivision {
+    #[n(1)]
     _1 = 1,
+    #[n(2)]
     _2 = 2,
+    #[n(4)]
     _4 = 4,
+    #[n(6)]
     _6 = 6,
+    #[n(8)]
     _8 = 8,
+    #[n(12)]
     _12 = 12,
     // 1 quarter note at 24 ppqn
+    #[n(24)]
     _24 = 24,
     // 1 bar at 24 ppqn
+    #[n(96)]
     _96 = 96,
     // 2 bars
+    #[n(192)]
     _192 = 192,
     // 4 bars
+    #[n(384)]
     _384 = 384,
 }
 
-#[derive(Clone, Serialize, PartialEq, Deserialize, PostcardBindings)]
+#[derive(Clone, Serialize, PartialEq, Deserialize, PostcardBindings, Encode, Decode)]
 #[repr(u8)]
 pub enum AuxJackMode {
+    #[n(0)]
     None,
-    ClockOut(ClockDivision),
+    #[n(1)]
+    ClockOut(#[n(0)] ClockDivision),
+    #[n(2)]
     ResetOut,
 }
 
-#[derive(Clone, Serialize, Deserialize, PostcardBindings)]
+#[derive(Clone, Serialize, Deserialize, PostcardBindings, Encode, Decode)]
 pub struct GlobalConfig {
+    #[n(0)]
     pub aux: [AuxJackMode; 3],
+    #[n(1)]
     pub clock: ClockConfig,
+    #[n(2)]
     pub i2c_mode: I2cMode,
+    #[n(3)]
     pub led_brightness: u8,
+    #[n(4)]
     pub midi: MidiConfig,
+    #[n(5)]
     pub quantizer: QuantizerConfig,
+    #[n(6)]
     pub takeover_mode: TakeoverMode,
 }
 
@@ -1032,9 +1127,10 @@ impl From<MidiChannel> for u4 {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, PostcardBindings)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, PostcardBindings, Encode, Decode)]
+#[cbor(transparent)]
 // [usb, din]
-pub struct MidiIn(pub [bool; 2]);
+pub struct MidiIn(#[n(0)] pub [bool; 2]);
 
 impl Default for MidiIn {
     fn default() -> Self {

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -1672,4 +1672,45 @@ mod tests {
         assert_eq!(decoded.clock.swing_amount, 0);
         assert_eq!(decoded.i2c_mode as u8, I2cMode::Leader as u8);
     }
+
+    #[test]
+    fn brightness_round_trips_through_v18_migration() {
+        // Reproduction of a real hardware report: brightness 111 on v1.8.2
+        // came back as 100 after upgrading to fixed v1.9. Pin down that the
+        // postcard-V0 → CBOR migration preserves an arbitrary u8 brightness
+        // exactly (no clamping, no off-by-one).
+        let mut v18 = make_v18_default();
+        v18.led_brightness = 111;
+        let mut buf = [0u8; 256];
+        let bytes = postcard::to_slice(&v18, &mut buf).unwrap();
+
+        // Step 1: migration reads the legacy bytes via GlobalConfigPreSwing.
+        let decoded_v0: GlobalConfigPreSwing = postcard::from_bytes(bytes).unwrap();
+        assert_eq!(decoded_v0.led_brightness, 111);
+
+        // Step 2: migration would convert to current GlobalConfig (we mirror
+        // the From<GlobalConfigV0> conversion in storage.rs here).
+        let migrated = GlobalConfig {
+            aux: decoded_v0.aux,
+            clock: ClockConfig {
+                clock_src: decoded_v0.clock.clock_src,
+                ext_ppqn: decoded_v0.clock.ext_ppqn,
+                reset_src: decoded_v0.clock.reset_src,
+                internal_bpm: decoded_v0.clock.internal_bpm,
+                swing_amount: 0,
+            },
+            i2c_mode: decoded_v0.i2c_mode,
+            led_brightness: decoded_v0.led_brightness,
+            midi: decoded_v0.midi,
+            quantizer: decoded_v0.quantizer,
+            takeover_mode: decoded_v0.takeover_mode,
+        };
+        assert_eq!(migrated.led_brightness, 111);
+
+        // Step 3: round-trip through CBOR (what migration actually writes,
+        // and what every subsequent boot reads).
+        let encoded = cbor_encode_to_vec(&migrated);
+        let decoded: GlobalConfig = minicbor::decode(&encoded).unwrap();
+        assert_eq!(decoded.led_brightness, 111);
+    }
 }

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -1127,7 +1127,9 @@ impl From<MidiChannel> for u4 {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, PostcardBindings, Encode, Decode)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Serialize, Deserialize, PostcardBindings, Encode, Decode,
+)]
 #[cbor(transparent)]
 // [usb, din]
 pub struct MidiIn(#[n(0)] pub [bool; 2]);

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -379,7 +379,9 @@ impl Key {
 /// may be appended with the next free `#[n(N)]` tag without a migration.
 /// **Removing** a variant requires a one-shot FRAM migration (see
 /// `storage::migrate_fram`).
-#[derive(Clone, Copy, Default, Serialize, Deserialize, PostcardBindings, PartialEq, Encode, Decode)]
+#[derive(
+    Clone, Copy, Default, Serialize, Deserialize, PostcardBindings, PartialEq, Encode, Decode,
+)]
 pub enum MidiOutMode {
     #[n(0)]
     None,

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -1471,4 +1471,205 @@ mod tests {
             final_ids.push(layout_id).unwrap();
         }
     }
+
+    // ---- CBOR storage / migration tests ----
+    //
+    // These pin down the behaviour the rest of the storage layer relies on:
+    //   1. CBOR round-trips current persisted types.
+    //   2. Adding a `#[cbor(default)]` field is forward-compatible: data written
+    //      by an older shape decodes into the newer shape with the new field
+    //      defaulted.
+    //   3. Removing a field is backward-compatible: data written by an older
+    //      shape decodes into the newer (slimmer) shape with the dropped field
+    //      silently skipped.
+    //   4. v1.8.2 postcard `GlobalConfig` data fails to decode as the current
+    //      postcard `GlobalConfig` (which is what makes the migration's
+    //      "current first, V0 fallback" strategy safe).
+
+    use super::*;
+    use minicbor::{Decode, Encode};
+    use serde::{Deserialize, Serialize};
+
+    fn cbor_encode_to_vec<T: Encode<()>>(value: &T) -> heapless::Vec<u8, 256> {
+        let mut buf = [0u8; 256];
+        let initial = buf.len();
+        let mut writer: &mut [u8] = &mut buf[..];
+        minicbor::encode(value, &mut writer).unwrap();
+        let written = initial - writer.len();
+        heapless::Vec::from_slice(&buf[..written]).unwrap()
+    }
+
+    #[test]
+    fn cbor_round_trip_default_global_config() {
+        let original = GlobalConfig::new();
+        let encoded = cbor_encode_to_vec(&original);
+        let decoded: GlobalConfig = minicbor::decode(&encoded).unwrap();
+
+        assert_eq!(decoded.led_brightness, original.led_brightness);
+        assert_eq!(
+            decoded.clock.internal_bpm.to_bits(),
+            original.clock.internal_bpm.to_bits()
+        );
+        assert_eq!(decoded.clock.swing_amount, original.clock.swing_amount);
+        assert_eq!(decoded.i2c_mode as u8, I2cMode::Leader as u8);
+    }
+
+    #[test]
+    fn cbor_field_added_decodes_with_default() {
+        // V1: a struct shaped like an "older" version.
+        #[derive(Encode, Decode)]
+        struct V1 {
+            #[n(0)]
+            x: u32,
+            #[n(1)]
+            y: u32,
+        }
+
+        // V2: same tags, plus a new field that uses cbor(default).
+        #[derive(Encode, Decode, Debug, PartialEq)]
+        struct V2 {
+            #[n(0)]
+            #[cbor(default)]
+            x: u32,
+            #[n(1)]
+            #[cbor(default)]
+            y: u32,
+            #[n(2)]
+            #[cbor(default)]
+            z: u32,
+        }
+
+        let v1 = V1 { x: 42, y: 7 };
+        let bytes = cbor_encode_to_vec(&v1);
+        let v2: V2 = minicbor::decode(&bytes).unwrap();
+        assert_eq!(v2, V2 { x: 42, y: 7, z: 0 });
+    }
+
+    #[test]
+    fn cbor_field_removed_skips_unknown_tag() {
+        // V2: an "older" version that wrote a y field.
+        #[derive(Encode, Decode)]
+        struct V2 {
+            #[n(0)]
+            x: u32,
+            #[n(1)]
+            y: u32,
+        }
+
+        // V3: the y field has been removed.
+        #[derive(Encode, Decode, Debug, PartialEq)]
+        struct V3 {
+            #[n(0)]
+            x: u32,
+        }
+
+        let v2 = V2 { x: 42, y: 999 };
+        let bytes = cbor_encode_to_vec(&v2);
+        let v3: V3 = minicbor::decode(&bytes).unwrap();
+        assert_eq!(v3, V3 { x: 42 });
+    }
+
+    #[test]
+    fn cbor_postcard_data_does_not_decode_as_cbor() {
+        // After migration, FRAM holds CBOR. If the schema header somehow gets
+        // lost and migrate_fram runs on already-migrated data, the postcard
+        // legacy decoders must reject the CBOR bytes (so we don't clobber).
+        let original = GlobalConfig::new();
+        let cbor_bytes = cbor_encode_to_vec(&original);
+
+        let postcard_result: Result<GlobalConfig, _> = postcard::from_bytes(&cbor_bytes);
+        assert!(
+            postcard_result.is_err(),
+            "postcard must reject CBOR-encoded GlobalConfig bytes"
+        );
+    }
+
+    /// Mirror of v1.8.2's `ClockConfig` shape, used only by the migration
+    /// regression tests below.
+    #[derive(Serialize, Deserialize)]
+    struct ClockConfigPreSwing {
+        clock_src: ClockSrc,
+        ext_ppqn: u8,
+        reset_src: ResetSrc,
+        internal_bpm: f32,
+    }
+
+    /// Mirror of v1.8.2's `GlobalConfig` shape (no `swing_amount` in clock).
+    #[derive(Serialize, Deserialize)]
+    struct GlobalConfigPreSwing {
+        aux: [AuxJackMode; 3],
+        clock: ClockConfigPreSwing,
+        i2c_mode: I2cMode,
+        led_brightness: u8,
+        midi: MidiConfig,
+        quantizer: QuantizerConfig,
+        takeover_mode: TakeoverMode,
+    }
+
+    fn make_v18_default() -> GlobalConfigPreSwing {
+        GlobalConfigPreSwing {
+            aux: [
+                AuxJackMode::ClockOut(ClockDivision::_1),
+                AuxJackMode::None,
+                AuxJackMode::None,
+            ],
+            clock: ClockConfigPreSwing {
+                clock_src: ClockSrc::Internal,
+                ext_ppqn: 24,
+                reset_src: ResetSrc::None,
+                internal_bpm: 120.0,
+            },
+            i2c_mode: I2cMode::Leader,
+            led_brightness: 150,
+            midi: MidiConfig::new(),
+            quantizer: QuantizerConfig::new(),
+            takeover_mode: TakeoverMode::Pickup,
+        }
+    }
+
+    #[test]
+    fn v18_postcard_data_fails_current_postcard_decode() {
+        // The migration's correctness rests on this invariant: v1.8.2 stored
+        // bytes are always 1 byte short of what the current GlobalConfig
+        // postcard decoder needs (the missing `swing_amount`). Without it,
+        // the "try current first" path could mis-decode v1.8.2 data as
+        // pre-fix v1.9 data with shifted fields.
+        let v18 = make_v18_default();
+        let mut buf = [0u8; 256];
+        let bytes = postcard::to_slice(&v18, &mut buf).unwrap();
+
+        let result: Result<GlobalConfig, _> = postcard::from_bytes(bytes);
+        assert!(
+            result.is_err(),
+            "v1.8.2 postcard data must NOT decode as current postcard GlobalConfig"
+        );
+    }
+
+    #[test]
+    fn v18_postcard_data_decodes_as_pre_swing_shape() {
+        // The fallback path: same legacy bytes, decoded with the v1.8.2-shaped
+        // type, must succeed.
+        let v18 = make_v18_default();
+        let mut buf = [0u8; 256];
+        let bytes = postcard::to_slice(&v18, &mut buf).unwrap();
+
+        let decoded: GlobalConfigPreSwing = postcard::from_bytes(bytes).unwrap();
+        assert_eq!(decoded.led_brightness, 150);
+        assert_eq!(decoded.clock.ext_ppqn, 24);
+        assert_eq!(decoded.clock.internal_bpm.to_bits(), 120.0_f32.to_bits());
+    }
+
+    #[test]
+    fn pre_fix_v19_postcard_data_decodes_as_current() {
+        // Pre-fix v1.9 betas wrote postcard `GlobalConfig` with the swing
+        // field present. The "try current first" path must accept it as-is.
+        let original = GlobalConfig::new();
+        let mut buf = [0u8; 256];
+        let bytes = postcard::to_slice(&original, &mut buf).unwrap();
+
+        let decoded: GlobalConfig = postcard::from_bytes(bytes).unwrap();
+        assert_eq!(decoded.led_brightness, 150);
+        assert_eq!(decoded.clock.swing_amount, 0);
+        assert_eq!(decoded.i2c_mode as u8, I2cMode::Leader as u8);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a 16-byte schema header (`FPSV` magic + `u8` version) at the tail of FRAM, plus a one-shot, non-destructive migration that runs once per device on first boot of v1.9.
- Switches top-level FRAM storage (`GlobalConfig`, `Layout`, `RuntimeState`) from postcard to **minicbor**, so adding/removing fields in the future is migration-free as long as they carry `#[cbor(default)]` and a fresh `#[n(N)]`. The convention is documented at the top of `GlobalConfig` in `libfp/src/lib.rs`.
- Migrates legacy `GlobalConfig` from both **v1.7.0** and **v1.8.x** in place (the v1.7.0 layout is missing both `takeover_mode` and `swing_amount`; v1.8.x is missing only `swing_amount`). Fallback chain is current → V0 → V170; postcard's `from_bytes` does not check trailing bytes, so order matters.
- Wire protocol (WebUSB) still uses postcard. Per-app `AppStorage` / `AppParams` also still use postcard — they already fall back to defaults gracefully on bad data, and can be ported to CBOR in a follow-up.
- Future breaking changes can bump `SCHEMA_VERSION` and add a step to `migrate_fram` instead of asking users to factory reset.

## Test plan

### Host tests
- [x] `cargo test -p libfp` — covers CBOR round-trips, field add/remove, postcard↔CBOR rejection, and the v1.7.0 / v1.8.x → CBOR migrations including a brightness=111 regression.

### Hardware: upgrading from v1.8.x

> ⚠️ **Before opening the configurator on this branch, run `./gen-bindings.sh`.** Stale bindings will misread the postcard wire format (no `swing_amount` field) and shift every byte after `clock` by one — this is exactly what produced the "brightness 111 → 100, swing field empty" symptom during my own testing.

- [ ] Flash v1.8.2 (release UF2)
- [ ] Factory reset (hold both leftmost channel buttons during boot)
- [ ] In the v1.8.2 configurator, change a few values across the whole config:
  - LED brightness to something distinctive (e.g. 111)
  - All three aux jacks (one ClockOut with a non-default division, one ResetOut, one None)
  - Internal BPM (e.g. 137.5)
  - Clock source / reset source
  - I²C mode (Leader → Follower)
  - Takeover mode (Pickup → Jump)
  - Quantizer key + tonic
  - At least one MIDI out's mode + clock/transport flags
- [ ] Set up a custom Layout (drag a couple of apps around, leave a slot empty)
- [ ] Toggle the clock with the play button so `RuntimeState` actually gets persisted
- [ ] Flash this branch
- [ ] On first boot, look in the defmt log for **one** of:
  - `Migrated GlobalConfig: postcard → CBOR`
  - `Migrated Layout: postcard → CBOR`
  - `Migrated RuntimeState: postcard → CBOR` (only if the clock was toggled)
- [ ] Open the configurator (with regenerated bindings) and verify **every value above** matches what was set on v1.8.2 — pay attention to brightness, aux jacks, takeover mode, and MIDI flags since those are the byte-position canaries.
- [ ] Verify the swing field shows `0` (new field, default).
- [ ] Verify the Layout is preserved.
- [ ] Reboot the device and confirm there are **no** migration log lines on the second boot (proves the schema header is stamped and the migration short-circuits).

### Hardware: upgrading from v1.7.0
- [ ] Same flow as above with v1.7.0 instead of v1.8.2 — note that v1.7.0 has no `takeover_mode`, so after migration that field will show its default (`Pickup`); everything else should be preserved.

### Hardware: fresh device & factory reset
- [ ] Flash this branch on a device that's never run v1.7.0/v1.8.x (or after a full erase) — should boot cleanly with all defaults, no migration log.
- [ ] Trigger a factory reset on this branch and confirm it still completes (the schema header range is now also wiped + rewritten).

https://claude.ai/code/session_0178GEX42f8Jy48LKzmEVAnw