### PR TITLE
increase EVENT_PUBSUB_SUBS to 80 to support 16 concurrent apps and add overhead 

### DIFF
--- a/faderpunk/src/events.rs
+++ b/faderpunk/src/events.rs
@@ -19,8 +19,8 @@ pub enum InputEvent {
 }
 
 const EVENT_PUBSUB_SIZE: usize = 64;
-// 64 receivers (ephemeral)
-const EVENT_PUBSUB_SUBS: usize = 64;
+// 16 apps × 4 concurrent subscribers + headroom for system tasks (input_handlers, etc.)
+const EVENT_PUBSUB_SUBS: usize = 80;
 // 19 senders (16 apps for scenes, 1 buttons, 1 max, 1 midi)
 const EVENT_PUBSUB_SENDERS: usize = 19;
 


### PR DESCRIPTION
This fixes the crash when users are loading 16 LFO at the same time 