### PR TITLE
fix(control): decouple i2c from MIDI and fix NRPN change detection

### DIFF
--- a/faderpunk/src/apps/control.rs
+++ b/faderpunk/src/apps/control.rs
@@ -252,6 +252,7 @@ pub async fn run(
         let mut fad_val = 0;
         let mut out: u16 = 0;
         let mut last_midi = 0u32;
+        let mut last_i2c = 0u16;
 
         loop {
             app.delay_millis(1).await;
@@ -340,8 +341,11 @@ pub async fn run(
             };
             if last_midi != midi_val {
                 midi.send_cc(midi_cc, midi_out).await;
-                i2c.send_fader_value(0, out, range);
                 last_midi = midi_val;
+            }
+            if last_i2c != midi_out {
+                i2c.send_fader_value(0, midi_out, range);
+                last_i2c = midi_out;
             }
 
             // Update LEDs

--- a/faderpunk/src/apps/control.rs
+++ b/faderpunk/src/apps/control.rs
@@ -251,7 +251,7 @@ pub async fn run(
         let mut main_layer_value = fader.get_value();
         let mut fad_val = 0;
         let mut out: u16 = 0;
-        let mut last_out = 0;
+        let mut last_midi = 0u32;
 
         loop {
             app.delay_millis(1).await;
@@ -333,11 +333,16 @@ pub async fn run(
             } else {
                 attenuate_bipolar(main_layer_value, att_layer_value)
             };
-            if last_out != (midi_out as u32 * 127) / 4095 {
+            let midi_val = if nrpn {
+                midi_out as u32
+            } else {
+                (midi_out as u32 * 127) / 4095
+            };
+            if last_midi != midi_val {
                 midi.send_cc(midi_cc, midi_out).await;
                 i2c.send_fader_value(0, out, range);
+                last_midi = midi_val;
             }
-            last_out = (midi_out as u32 * 127) / 4095;
 
             // Update LEDs
             match latch_active_layer {


### PR DESCRIPTION
## Summary

- NRPN outputs were using the 7-bit scaled value for change detection, causing missed updates when the full 12-bit value changed but the scaled one didn't
- i2c operates at full 12-bit resolution and was incorrectly gated behind the 7-bit MIDI change check, causing it to drop updates
- i2c now has its own threshold and sends the attenuated fader value (no curve) independently of MIDI
- Fix i2c bug where the i2c value was not updated when un-muting

