### PR TITLE
fix(euclid): restore div_saved on boot, refresh mute LED on scene load

### DIFF
--- a/faderpunk/src/apps/euclid.rs
+++ b/faderpunk/src/apps/euclid.rs
@@ -185,13 +185,21 @@ pub async fn run(
 
     let resolution = [384, 192, 96, 48, 24, 16, 12, 8, 6, 4, 3, 2];
 
-    let (fader_saved, shift_fader_saved, mute) =
-        storage.query(|s| (s.fader_saved, s.shift_fader_saved, s.mute_saved));
+    let (fader_saved, shift_fader_saved, mute, div_saved) = storage.query(|s| {
+        (
+            s.fader_saved,
+            s.shift_fader_saved,
+            s.mute_saved,
+            s.div_saved,
+        )
+    });
 
     num_beat_glob.set((fader_saved[0] as u32 * 15 / 4095) as u8 + 1);
     num_step_glob.set((fader_saved[1] as u32 * num_beat_glob.get() as u32 / 4095) as u8);
 
     rotation_glob.set((shift_fader_saved[0] as u32 * num_beat_glob.get() as u32 / 4095) as u8);
+
+    div_glob.set(resolution[div_saved as usize / 345]);
 
     glob_muted.set(mute);
 
@@ -449,7 +457,13 @@ pub async fn run(
                             * num_beat_glob.get() as u32
                             / 4095) as u8,
                     );
-                    glob_muted.set(storage.query(|s| s.mute_saved));
+                    let muted = storage.query(|s| s.mute_saved);
+                    glob_muted.set(muted);
+                    if muted {
+                        leds.unset(1, Led::Button);
+                    } else {
+                        leds.set(1, Led::Button, led_color, LED_BRIGHTNESS);
+                    }
 
                     let division = storage.query(|s| s.div_saved);
                     div_glob.set(resolution[division as usize / 345]);


### PR DESCRIPTION
## Summary

- **Boot path now restores `div_saved`** from storage. Previously, the user's clock division setting was saved correctly but never read back on app boot — `div_glob` always initialized to the hardcoded default (6 / 16th notes), so any custom division reverted on layout reload. The scene-load path already handled this; only the initial run() path was missing it.
- **Scene load refreshes the channel-1 button LED** to match the loaded mute state immediately, instead of leaving it stale until the next interaction.
- **CI compat**: adds `configurator/pnpm-workspace.yaml` and pins `packageManager` to pnpm 11.1.1 — required for the configurator CI step to install successfully under pnpm 11's new build-script approval policy.

## Test plan

- [ ] Set a non-default clock division (Third layer: button 0 + fader 0)
- [ ] Power-cycle / reload the layout
- [ ] Confirm the saved division is restored (LED color in Third layer + observed clock rate)
- [ ] Mute via channel-1 button, save scene, load a different scene with unmuted state, confirm button LED reflects loaded state immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)