### PR TITLE
feat(genseq): add GenSeq generative sequencer app

### DIFF
--- a/configurator/.claude/settings.local.json
+++ b/configurator/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh run list:*)"
+    ]
+  }
+}

--- a/configurator/src/components/ManualTab.tsx
+++ b/configurator/src/components/ManualTab.tsx
@@ -1553,7 +1553,8 @@ On load, the pitch sequence is restored at the next phrase boundary so the recal
         fnTitle: "Toggle mute",
         fnDescription:
           "Press to toggle mute. While muted, no new gates open and CV holds its last value. Button LED off = muted, dim = active.",
-        ledTop: "Legato indicator — lit when the current step is a legato slide",
+        ledTop:
+          "Legato indicator — lit when the current step is a legato slide",
         ledBottom: "",
       },
     ],

--- a/configurator/src/components/ManualTab.tsx
+++ b/configurator/src/components/ManualTab.tsx
@@ -1416,6 +1416,148 @@ The resolution parameter controls how many samples are recorded per bar. Higher 
       },
     ],
   },
+  {
+    appId: 26,
+    title: "GenSeq",
+    description: "Generative sequencer with Turing machine registers",
+    color: "Blue",
+    icon: "sequence-square",
+    params: ["MIDI Channel", "Base Note", "Color", "MIDI Out"],
+    storage: [
+      "Pitch range",
+      "Length attenuator",
+      "Beat density",
+      "Pitch loop length (fader)",
+      "Legato density threshold",
+      "Accent density threshold",
+      "Clock resolution",
+      "Octave shift",
+      "Gate length",
+      "Pitch register (persisted)",
+      "Length register",
+      "Pitch TM register width (1–16)",
+      "Length TM register width (1–16)",
+      "Muted",
+    ],
+    text: `GenSeq is a generative melodic sequencer built around two Turing machines. One controls the space between notes and the other controls which note is played. Legato and accents evolve automatically from the same material, so the whole sequence — melody, rhythm, slides and accents — grows from just two seeds.
+
+#### Faders
+
+* **Fader 1 (Pitch range):** How far apart the lowest and highest notes can be, like the CV attenuator on a Turing machine. Fully down clusters all notes near the base note; fully up opens the full pitch range.
+* **Fader 2 (Phrase length):** How long the rhythmic pattern is. The internal register evolves this automatically — use the attenuator to keep it shorter.
+* **Fader 3 (Beat density):** How many notes fall inside the phrase, from a single pulse up to every step.
+
+#### Buttons
+
+* **Button 1 — hold:** Randomizes the pitch sequence. Release to lock the current melody in place.
+* **Button 2 — hold:** Randomizes the phrase length and rhythm.
+* **Button 3 — press:** Toggles mute. While muted no new gates open and the CV holds its last value. Button LED off = muted, dim = active.
+
+#### Slides and accents
+
+Slides and accents are generated automatically from the evolving pitch and rhythm material.
+
+* **Shift + Fader 2:** How many notes slide into each other (legato density).
+* **Shift + Fader 3:** How many notes are accented.
+
+#### Shift layer (hold Shift)
+
+* **Fader 1:** Pitch loop length — how many cycles before the melody repeats (1–16). Also set by Shift+Button 1 counting (see below).
+* **Fader 2:** Legato density.
+* **Fader 3:** Accent density.
+
+#### Button 1 layer (hold Button 1)
+
+* **Fader 1:** Clock resolution — Ch 1 bottom flashes orange (straight) or blue (triplet) in sync with the clock.
+* **Fader 2:** Octave shift (−2 to +2) — Ch 2 button color shows the current octave (blue=−2, cyan=−1, green=0, yellow=+1, red=+2).
+* **Fader 3:** Gate length (1–99%) — Ch 3 top brightness shows the current value.
+
+#### Setting register lengths
+
+Hold Shift and press buttons to count — each press adds one step. Release Shift to commit. Button LEDs brighten with each press to show the count.
+
+* **Shift + Button 1:** Sets how many cycles the pitch melody runs before repeating (1–16).
+* **Shift + Button 2:** Sets the rhythm register length (1–16). Setting this to 1 activates bypass mode: Fader 2 then directly controls the phrase length (1–16 steps) instead of evolving it generatively.
+
+#### LED feedback
+
+**Main layer:**
+* **Ch 1 Top:** Pitch level — brightness tracks the current note position.
+* **Ch 2 Top:** Gate indicator — lit while the gate is open.
+* **Ch 3 Top:** Legato indicator — lit when the current step is a slide.
+
+**Shift held:**
+* **Ch 1 Top:** Pitch loop length (white, brightness).
+* **Ch 2 Top:** Legato density (cyan, brightness).
+* **Ch 3 Top:** Accent density (yellow, brightness).
+* **Button 1 / Button 2:** Brightness shows the current count while setting register lengths.
+
+**Button 1 held:**
+* **Ch 1 Bottom:** Flashes orange (straight division) or blue (triplet) in sync with the clock.
+* **Ch 2 Button:** Current octave by color.
+* **Ch 3 Top:** Gate length as brightness.
+
+#### Scene recall
+
+On load, the pitch sequence is restored at the next phrase boundary so the recalled melody re-enters in time. The rhythm register restarts from its saved state.`,
+    channels: [
+      {
+        jackTitle: "CV Output",
+        jackDescription: "Quantized pitch, 0–10V (1V/Oct)",
+        faderTitle: "Pitch range",
+        faderDescription:
+          "Controls the spread between the lowest and highest notes — fully down clusters all notes near the base note, fully up uses the full pitch range",
+        faderPlusShiftTitle: "Pitch loop length",
+        faderPlusShiftDescription:
+          "Sets how many pitch register rotations before the melody repeats (1–16). Also set by Shift+Button 1 counting.",
+        faderPlusFnTitle: "Clock resolution",
+        faderPlusFnDescription:
+          "Selects the step rate: 1/1, 1/2, 1/4T, 1/4, 1/6, 1/8, 1/12, 1/16 — bottom LED flashes orange (straight) or blue (triplet)",
+        fnTitle: "Mutate pitch",
+        fnDescription:
+          "Hold to raise pitch register mutation probability to 50% — release to lock the current melody",
+        ledTop: "Pitch register level (brightness = current note height)",
+        ledBottom:
+          "Flashes orange (straight) or blue (triplet) in sync with the clock while in Button 1 layer",
+      },
+      {
+        jackTitle: "Gate Output",
+        jackDescription: "Gate signal, 0–10V",
+        faderTitle: "Length attenuator",
+        faderDescription:
+          "Scales the Euclidean pattern length from the length register. In bypass mode (length TM width = 1) directly sets the pattern length (1–16 steps).",
+        faderPlusShiftTitle: "Legato density",
+        faderPlusShiftDescription:
+          "Threshold controlling how many steps are legato — higher = more slides",
+        faderPlusFnTitle: "Octave shift",
+        faderPlusFnDescription:
+          "Transposes CV and MIDI output by −2 to +2 octaves — button LED color shows current octave",
+        fnTitle: "Mutate length",
+        fnDescription:
+          "Hold to raise length register mutation probability — evolves the Euclidean pattern length over time",
+        ledTop: "Gate indicator — lit while gate is open",
+        ledBottom: "",
+      },
+      {
+        jackTitle: "Accent CV Output",
+        jackDescription: "10V on accented steps, 0V otherwise",
+        faderTitle: "Beat density",
+        faderDescription:
+          "Sets what fraction of Euclidean steps trigger a gate (1 pulse minimum to 100% of pattern length)",
+        faderPlusShiftTitle: "Accent density",
+        faderPlusShiftDescription:
+          "Threshold controlling how many steps are accented — higher = more accents",
+        faderPlusFnTitle: "Gate length",
+        faderPlusFnDescription:
+          "Sets how long the gate stays high as a percentage of the step (1–99%) — top LED brightness shows current value",
+        fnTitle: "Toggle mute",
+        fnDescription:
+          "Press to toggle mute. While muted, no new gates open and CV holds its last value. Button LED off = muted, dim = active.",
+        ledTop: "Legato indicator — lit when the current step is a legato slide",
+        ledBottom: "",
+      },
+    ],
+  },
 ];
 
 export const ManualTab = () => {

--- a/configurator/src/components/ManualTab.tsx
+++ b/configurator/src/components/ManualTab.tsx
@@ -1422,7 +1422,14 @@ The resolution parameter controls how many samples are recorded per bar. Higher 
     description: "Generative sequencer with Turing machine registers",
     color: "Blue",
     icon: "sequence-square",
-    params: ["MIDI Channel", "Base Note", "Color", "MIDI Out", "1V/Oct", "Bypass quantizer"],
+    params: [
+      "MIDI Channel",
+      "Base Note",
+      "Color",
+      "MIDI Out",
+      "1V/Oct",
+      "Bypass quantizer",
+    ],
     storage: [
       "Pitch range",
       "Length attenuator",
@@ -1438,125 +1445,61 @@ The resolution parameter controls how many samples are recorded per bar. Higher 
       "Length TM register width (1–16)",
       "Muted",
     ],
-    text: `GenSeq is a generative melodic sequencer built around two Turing machines. One controls the space between notes and the other controls which note is played. Legato and accents evolve automatically from the same material, so the whole sequence — melody, rhythm, slides and accents — grows from just two seeds.
+    text: `GenSeq is a generative melodic sequencer built around two Turing machine shift registers. The pitch TM determines which note plays; the length TM determines the Euclidean pattern length. Both evolve slowly each cycle, so the melody and rhythm drift together over time. Legato and accents are derived automatically from the same TMs, so the whole sequence, melody, rhythm, slides and accents, come from just two seeds.
 
-#### Faders
+#### Register lengths
 
-* **Fader 1 (Pitch range):** How far apart the lowest and highest notes can be, like the CV attenuator on a Turing machine. Fully down clusters all notes near the base note; fully up opens the full pitch range.
-* **Fader 2 (Phrase length):** How long the rhythmic pattern is. The internal register evolves this automatically — use the attenuator to keep it shorter.
-* **Fader 3 (Beat density):** How many notes fall inside the phrase, from a single pulse up to every step.
+Hold Shift and tap Button 1 or Button 2 to count out a TM length (1–16 steps); release Shift to commit. The button LED brightens with each tap and shows the stored value before you start counting. If the length of the length TM is set to 1 then the euclidean generator behaves the same as a standard one with Fader 2 controlling the length and Fader 3 the pulse count.
 
-#### Buttons
+#### Mute
 
-* **Button 1 — hold:** Randomizes the pitch sequence. Release to lock the current melody in place.
-* **Button 2 — hold:** Randomizes the phrase length and rhythm.
-* **Button 3 — tap (release):** Toggles mute. While muted no new gates open and the CV holds its last value. Button LED off = muted, dim = active. Holding Button 3 to access the Button 3 layer does not trigger mute.
-
-#### Slides and accents
-
-Slides and accents are generated automatically from the evolving pitch and rhythm material.
-
-* **Shift + Fader 2:** How many notes slide into each other (legato density).
-* **Shift + Fader 3:** How many notes are accented.
-
-#### Shift layer (hold Shift)
-
-* **Fader 1:** Pitch loop length — how many cycles before the melody repeats (1–16). Also set by Shift+Button 1 counting (see below).
-* **Fader 2:** Legato density.
-* **Fader 3:** Accent density.
-
-#### Button 3 layer (hold Button 3)
-
-* **Fader 1:** Clock resolution — Ch 1 bottom flashes orange (straight) or blue (triplet) in sync with the clock.
-* **Fader 2:** Octave shift (−2 to +2) — Ch 2 bottom LED color shows the current octave (blue=−2, cyan=−1, green=0, yellow=+1, red=+2).
-* **Fader 3:** Gate length (1–99%) — Ch 3 top brightness shows the current value.
-
-#### Setting register lengths
-
-Hold Shift and press buttons to count — each press adds one step. Release Shift to commit. Button LEDs brighten with each press to show the count.
-
-* **Shift + Button 1:** Sets how many cycles the pitch melody runs before repeating (1–16).
-* **Shift + Button 2:** Sets the rhythm register length (1–16). Setting this to 1 activates bypass mode: Fader 2 then directly controls the phrase length (1–16 steps) instead of evolving it generatively.
-
-#### LED feedback
-
-**Main layer:**
-* **Ch 1 Top:** Pitch level — brightness tracks the current note position.
-* **Ch 2 Top:** Gate indicator — lit while the gate is open.
-* **Ch 3 Top:** Legato indicator — lit when the current step is a slide.
-* **Ch 1 Bottom:** Pitch TM cycle progress — bright at the start of each pitch cycle, dims to off at the end.
-* **Ch 2 Bottom:** Length TM cycle progress — bright at the start of each length cycle, dims to off at the end.
-
-**Shift held:**
-* **Ch 1 Top:** Pitch loop length (white, brightness).
-* **Ch 2 Top:** Legato density (cyan, brightness).
-* **Ch 3 Top:** Accent density (yellow, brightness).
-* **Button 1 / Button 2:** Shows the stored register length; switches to live count once you begin tapping.
-
-**Button 3 held:**
-* **Ch 1 Bottom:** Flashes orange (straight division) or blue (triplet) in sync with the clock.
-* **Ch 2 Bottom:** Current octave by color (blue=−2, cyan=−1, green=0, yellow=+1, red=+2).
-* **Ch 3 Top:** Gate length as brightness.
+Mute is inhibit-only. Tapping Button 3 stops new gates from opening and holds the CV at its last value, but the current note rings out naturally. Holding Button 3 to access the third layer does not toggle mute.
 
 #### Scene recall
 
-On load, the pitch sequence is restored at the next phrase boundary so the recalled melody re-enters in time. The rhythm register restarts from its saved state.`,
+On load, both registers are restored at the next phrase boundary so the recalled sequence re-enters in time.`,
     channels: [
       {
         jackTitle: "CV Output",
-        jackDescription: "Quantized pitch, 0–10V (1V/Oct)",
+        jackDescription: "Quantized pitch, 0–10V",
         faderTitle: "Pitch range",
-        faderDescription:
-          "Controls the spread between the lowest and highest notes — fully down clusters all notes near the base note, fully up uses the full pitch range",
+        faderDescription: "Spread between lowest and highest notes",
         faderPlusShiftTitle: "Pitch loop length",
-        faderPlusShiftDescription:
-          "Sets how many pitch register rotations before the melody repeats (1–16). Also set by Shift+Button 1 counting.",
+        faderPlusShiftDescription: "Melody repeat length (1–16)",
         faderPlusFnTitle: "Clock resolution",
-        faderPlusFnDescription:
-          "Selects the step rate: 1/1, 1/2, 1/4T, 1/4, 1/6, 1/8, 1/12, 1/16 — bottom LED flashes orange (straight) or blue (triplet)",
+        faderPlusFnDescription: "Step rate (1/1 to 1/16)",
         fnTitle: "Mutate pitch",
-        fnDescription:
-          "Hold to raise pitch register mutation probability to 50% — release to lock the current melody",
-        ledTop: "Pitch register level (brightness = current note height)",
-        ledBottom:
-          "Flashes orange (straight) or blue (triplet) in sync with the clock while in Button 3 layer",
+        fnDescription: "Hold to mutate, release to lock",
+        ledTop: "Current note height",
+        ledBottom: "Clock flash (Button 3 layer)",
       },
       {
         jackTitle: "Gate Output",
         jackDescription: "Gate signal, 0–10V",
         faderTitle: "Length attenuator",
-        faderDescription:
-          "Scales the Euclidean pattern length from the length register. In bypass mode (length TM width = 1) directly sets the pattern length (1–16 steps).",
+        faderDescription: "Euclidean pattern length",
         faderPlusShiftTitle: "Legato density",
-        faderPlusShiftDescription:
-          "Threshold controlling how many steps are legato — higher = more slides",
+        faderPlusShiftDescription: "How many steps slide",
         faderPlusFnTitle: "Octave shift",
-        faderPlusFnDescription:
-          "Transposes CV and MIDI output by −2 to +2 octaves — bottom LED color shows current octave",
+        faderPlusFnDescription: "−2 to +2 octaves",
         fnTitle: "Mutate length",
-        fnDescription:
-          "Hold to raise length register mutation probability — evolves the Euclidean pattern length over time",
-        ledTop: "Gate indicator — lit while gate is open",
-        ledBottom: "",
+        fnDescription: "Hold to mutate rhythm",
+        ledTop: "Gate open",
+        ledBottom: "Length TM cycle progress",
       },
       {
         jackTitle: "Accent CV Output",
         jackDescription: "10V on accented steps, 0V otherwise",
         faderTitle: "Beat density",
-        faderDescription:
-          "Sets what fraction of Euclidean steps trigger a gate (1 pulse minimum to 100% of pattern length)",
+        faderDescription: "How many steps trigger a gate",
         faderPlusShiftTitle: "Accent density",
-        faderPlusShiftDescription:
-          "Threshold controlling how many steps are accented — higher = more accents",
+        faderPlusShiftDescription: "How many steps are accented",
         faderPlusFnTitle: "Gate length",
-        faderPlusFnDescription:
-          "Sets how long the gate stays high as a percentage of the step (1–99%) — top LED brightness shows current value",
+        faderPlusFnDescription: "Gate duration (1–99%)",
         fnTitle: "Toggle mute",
-        fnDescription:
-          "Tap (release) to toggle mute. While muted, no new gates open and CV holds its last value. Button LED off = muted, dim = active. Holding for Button 3 layer does not trigger mute.",
-        ledTop:
-          "Legato indicator — lit when the current step is a legato slide",
-        ledBottom: "",
+        fnDescription: "Tap to toggle mute",
+        ledTop: "Legato slide",
+        ledBottom: "Euclidean cycle progress",
       },
     ],
   },

--- a/configurator/src/components/ManualTab.tsx
+++ b/configurator/src/components/ManualTab.tsx
@@ -1422,12 +1422,11 @@ The resolution parameter controls how many samples are recorded per bar. Higher 
     description: "Generative sequencer with Turing machine registers",
     color: "Blue",
     icon: "sequence-square",
-    params: ["MIDI Channel", "Base Note", "Color", "MIDI Out"],
+    params: ["MIDI Channel", "Base Note", "Color", "MIDI Out", "1V/Oct", "Bypass quantizer"],
     storage: [
       "Pitch range",
       "Length attenuator",
       "Beat density",
-      "Pitch loop length (fader)",
       "Legato density threshold",
       "Accent density threshold",
       "Clock resolution",
@@ -1451,7 +1450,7 @@ The resolution parameter controls how many samples are recorded per bar. Higher 
 
 * **Button 1 — hold:** Randomizes the pitch sequence. Release to lock the current melody in place.
 * **Button 2 — hold:** Randomizes the phrase length and rhythm.
-* **Button 3 — press:** Toggles mute. While muted no new gates open and the CV holds its last value. Button LED off = muted, dim = active.
+* **Button 3 — tap (release):** Toggles mute. While muted no new gates open and the CV holds its last value. Button LED off = muted, dim = active. Holding Button 3 to access the Button 3 layer does not trigger mute.
 
 #### Slides and accents
 
@@ -1466,10 +1465,10 @@ Slides and accents are generated automatically from the evolving pitch and rhyth
 * **Fader 2:** Legato density.
 * **Fader 3:** Accent density.
 
-#### Button 1 layer (hold Button 1)
+#### Button 3 layer (hold Button 3)
 
 * **Fader 1:** Clock resolution — Ch 1 bottom flashes orange (straight) or blue (triplet) in sync with the clock.
-* **Fader 2:** Octave shift (−2 to +2) — Ch 2 button color shows the current octave (blue=−2, cyan=−1, green=0, yellow=+1, red=+2).
+* **Fader 2:** Octave shift (−2 to +2) — Ch 2 bottom LED color shows the current octave (blue=−2, cyan=−1, green=0, yellow=+1, red=+2).
 * **Fader 3:** Gate length (1–99%) — Ch 3 top brightness shows the current value.
 
 #### Setting register lengths
@@ -1485,16 +1484,18 @@ Hold Shift and press buttons to count — each press adds one step. Release Shif
 * **Ch 1 Top:** Pitch level — brightness tracks the current note position.
 * **Ch 2 Top:** Gate indicator — lit while the gate is open.
 * **Ch 3 Top:** Legato indicator — lit when the current step is a slide.
+* **Ch 1 Bottom:** Pitch TM cycle progress — bright at the start of each pitch cycle, dims to off at the end.
+* **Ch 2 Bottom:** Length TM cycle progress — bright at the start of each length cycle, dims to off at the end.
 
 **Shift held:**
 * **Ch 1 Top:** Pitch loop length (white, brightness).
 * **Ch 2 Top:** Legato density (cyan, brightness).
 * **Ch 3 Top:** Accent density (yellow, brightness).
-* **Button 1 / Button 2:** Brightness shows the current count while setting register lengths.
+* **Button 1 / Button 2:** Shows the stored register length; switches to live count once you begin tapping.
 
-**Button 1 held:**
+**Button 3 held:**
 * **Ch 1 Bottom:** Flashes orange (straight division) or blue (triplet) in sync with the clock.
-* **Ch 2 Button:** Current octave by color.
+* **Ch 2 Bottom:** Current octave by color (blue=−2, cyan=−1, green=0, yellow=+1, red=+2).
 * **Ch 3 Top:** Gate length as brightness.
 
 #### Scene recall
@@ -1518,7 +1519,7 @@ On load, the pitch sequence is restored at the next phrase boundary so the recal
           "Hold to raise pitch register mutation probability to 50% — release to lock the current melody",
         ledTop: "Pitch register level (brightness = current note height)",
         ledBottom:
-          "Flashes orange (straight) or blue (triplet) in sync with the clock while in Button 1 layer",
+          "Flashes orange (straight) or blue (triplet) in sync with the clock while in Button 3 layer",
       },
       {
         jackTitle: "Gate Output",
@@ -1531,7 +1532,7 @@ On load, the pitch sequence is restored at the next phrase boundary so the recal
           "Threshold controlling how many steps are legato — higher = more slides",
         faderPlusFnTitle: "Octave shift",
         faderPlusFnDescription:
-          "Transposes CV and MIDI output by −2 to +2 octaves — button LED color shows current octave",
+          "Transposes CV and MIDI output by −2 to +2 octaves — bottom LED color shows current octave",
         fnTitle: "Mutate length",
         fnDescription:
           "Hold to raise length register mutation probability — evolves the Euclidean pattern length over time",
@@ -1552,7 +1553,7 @@ On load, the pitch sequence is restored at the next phrase boundary so the recal
           "Sets how long the gate stays high as a percentage of the step (1–99%) — top LED brightness shows current value",
         fnTitle: "Toggle mute",
         fnDescription:
-          "Press to toggle mute. While muted, no new gates open and CV holds its last value. Button LED off = muted, dim = active.",
+          "Tap (release) to toggle mute. While muted, no new gates open and CV holds its last value. Button LED off = muted, dim = active. Holding for Button 3 layer does not trigger mute.",
         ledTop:
           "Legato indicator — lit when the current step is a legato slide",
         ledBottom: "",

--- a/configurator/src/components/manual/Apps.tsx
+++ b/configurator/src/components/manual/Apps.tsx
@@ -22,7 +22,7 @@ export const Apps = ({ apps }: Props) => (
         <strong>Short press (no shift)</strong> — Control (when Button mode =
         Mute), Clock Divider, Clock Divider+, Random CC/CV, Random Trigger,
         Euclid, Envelope Follower, Turing, Turing+, MIDI to CV, CV2MIDI, CV/OCT
-        to MIDI, Panner, FP-Grids (per-channel trigger mutes), TB-3PO
+        to MIDI, Panner, FP-Grids (per-channel trigger mutes), TB-3PO, GenSeq
       </li>
       <li>
         <strong>Long press (no shift)</strong> — AD Envelope, LFO, LFO+

--- a/faderpunk/src/apps/clkturing.rs
+++ b/faderpunk/src/apps/clkturing.rs
@@ -10,8 +10,11 @@ use heapless::Vec;
 use serde::{Deserialize, Serialize};
 
 use libfp::{
-    ext::FromValue, latch::LatchLayer, AppIcon, Brightness, Color, Config, Curve, MidiCc,
-    MidiChannel, MidiMode, MidiNote, MidiOut, Param, Range, Value, VoltPerOct, APP_MAX_PARAMS,
+    ext::FromValue,
+    latch::LatchLayer,
+    utils::{rotate_select_bit, scale_to_12bit},
+    AppIcon, Brightness, Color, Config, Curve, MidiCc, MidiChannel, MidiMode, MidiNote, MidiOut,
+    Param, Range, Value, VoltPerOct, APP_MAX_PARAMS,
 };
 
 use crate::app::{App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
@@ -403,38 +406,4 @@ pub async fn run(
     };
 
     join(long_press, join5(fut1, fut2, fut3, fut4, scene_handler)).await;
-}
-
-fn rotate_select_bit(x: u16, a: u16, b: u16, bit_index: u16) -> (u16, bool) {
-    let bit_index = (15 - bit_index).clamp(0, 15);
-
-    // Extract the original bit
-    let original_bit = ((x >> bit_index) & 1) as u8;
-    let mut bit = original_bit;
-
-    // Invert the bit if a > b
-    if a > b {
-        bit ^= 1;
-    }
-
-    // Shift x right by 1
-    let shifted = x >> 1;
-
-    // Insert the (possibly inverted) bit into the MSB
-    let result = shifted | ((bit as u16) << 15);
-
-    // Return the new value and whether the bit was flipped
-    let flipped = bit != original_bit;
-    (result, flipped)
-}
-
-fn scale_to_12bit(input: u16, x: u8) -> u16 {
-    let x = x.clamp(1, 16);
-
-    // Shift to keep the top `x` bits
-    let top_x_bits = input >> (16 - x);
-
-    // Scale to 12-bit
-    let max_x_val = (1 << x) - 1;
-    ((top_x_bits as u32 * 4095) / max_x_val as u32) as u16
 }

--- a/faderpunk/src/apps/genseq.rs
+++ b/faderpunk/src/apps/genseq.rs
@@ -256,7 +256,7 @@ pub async fn run(
                     register_pitch = storage.query(|s| s.register_pitch);
                 }
                 ClockEvent::Tick => {
-                    if clkn % div == 0 {
+                    if clkn.is_multiple_of(div) {
                         clkn_euclid = (clkn_euclid + 1) % euclid_length.max(1) as u16;
 
                         if clkn_euclid == 0 {
@@ -377,7 +377,7 @@ pub async fn run(
 
                     // Resolution flash on Ch0 Bottom while in Third layer
                     if matches!(glob_latch_layer.get(), LatchLayer::Third) {
-                        if clkn % div == 0 {
+                        if clkn.is_multiple_of(div) {
                             let color = if matches!(div, 2 | 4 | 8 | 16) {
                                 Color::Orange
                             } else {
@@ -577,7 +577,7 @@ pub async fn run(
                         Led::Top,
                         Color::White,
                         Brightness::Custom(
-                            (storage.query(|s| s.pitch_tm_length) as u8 * 16).saturating_sub(1),
+                            (storage.query(|s| s.pitch_tm_length) * 16).saturating_sub(1),
                         ),
                     );
                     leds.set(

--- a/faderpunk/src/apps/genseq.rs
+++ b/faderpunk/src/apps/genseq.rs
@@ -1,0 +1,688 @@
+// TODO :
+// Fix MIDI note off
+// Confirm the Velocity stuff
+
+use defmt::info;
+use embassy_futures::{
+    join::join5,
+    select::{select, select3},
+};
+use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
+use heapless::Vec;
+use serde::{Deserialize, Serialize};
+
+use libfp::{
+    constants::BJORKLUND_PATTERNS,
+    ext::FromValue,
+    latch::LatchLayer,
+    quantizer::Pitch,
+    utils::{attenuate, attenuate_bipolar},
+    AppIcon, Brightness, ClockDivision, Color, Config, Curve, MidiChannel, MidiNote, MidiOut,
+    Param, Range, Value, APP_MAX_PARAMS,
+};
+use midly::num::u7;
+
+use crate::app::{
+    App, AppParams, AppStorage, ClockEvent, Led, ManagedStorage, ParamStore, SceneEvent,
+};
+
+pub const CHANNELS: usize = 3;
+pub const PARAMS: usize = 5;
+
+// TODO: How to add param for midi-cc base number that it just works as a default?
+pub static CONFIG: Config<PARAMS> = Config::new(
+    "GenSeq",
+    "Turing machine, synched to internal clock",
+    Color::Blue,
+    AppIcon::SequenceSquare,
+)
+.add_param(Param::MidiChannel {
+    //is it possible to have this apear only if CC or note are selected
+    name: "Midi channel",
+})
+.add_param(Param::MidiNote { name: "Base Note" })
+.add_param(Param::i32 {
+    name: "GATE %",
+    min: 1,
+    max: 100,
+})
+.add_param(Param::Color {
+    name: "Color",
+    variants: &[
+        Color::Blue,
+        Color::Green,
+        Color::Rose,
+        Color::Orange,
+        Color::Cyan,
+        Color::Pink,
+        Color::Violet,
+        Color::Yellow,
+    ],
+})
+.add_param(Param::MidiOut);
+
+pub struct Params {
+    midi_channel: MidiChannel,
+    note: MidiNote,
+    gatel: i32,
+    color: Color,
+    midi_out: MidiOut,
+}
+
+impl Default for Params {
+    fn default() -> Self {
+        Self {
+            midi_channel: MidiChannel::default(),
+            note: MidiNote::from(36),
+            gatel: 50,
+            color: Color::Blue,
+            midi_out: MidiOut::default(),
+        }
+    }
+}
+
+impl AppParams for Params {
+    fn from_values(values: &[Value]) -> Option<Self> {
+        if values.len() < PARAMS {
+            return None;
+        }
+        Some(Self {
+            midi_channel: MidiChannel::from_value(values[0]),
+            note: MidiNote::from_value(values[1]),
+            gatel: i32::from_value(values[2]),
+            color: Color::from_value(values[3]),
+            midi_out: MidiOut::from_value(values[4]),
+        })
+    }
+
+    fn to_values(&self) -> Vec<Value, APP_MAX_PARAMS> {
+        let mut vec = Vec::new();
+        vec.push(self.midi_channel.into()).unwrap();
+        vec.push(self.note.into()).unwrap();
+        vec.push(self.gatel.into()).unwrap();
+        vec.push(self.color.into()).unwrap();
+        vec.push(self.midi_out.into()).unwrap();
+        vec
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Storage {
+    pitch_att: u16,
+    length_att: u16,
+    beat_att: u16,
+    pitch_length_saved: u16,
+    beat_length_saved: u16,
+    register_pitch: u16,
+    register_rhythm_length: u16,
+    register_rhythm_beat: u16,
+    register_legato: u16,
+    legato_att: u16,
+    res_saved: u16,
+}
+
+impl Default for Storage {
+    fn default() -> Self {
+        Self {
+            pitch_att: 3000,
+            length_att: 2045,
+            beat_att: 2045,
+            pitch_length_saved: 8,
+            beat_length_saved: 8,
+            register_pitch: 7632,
+            register_rhythm_length: 534,
+            register_rhythm_beat: 2342,
+            register_legato: 2821,
+            legato_att: 2048,
+            res_saved: 2048,
+        }
+    }
+}
+impl AppStorage for Storage {}
+
+#[embassy_executor::task(pool_size = 16/CHANNELS)]
+pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMutex, bool>) {
+    let param_store = ParamStore::<Params>::new(app.app_id, app.layout_id, Params::default());
+    let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
+
+    param_store.load().await;
+    storage.load().await;
+
+    let app_loop = async {
+        loop {
+            select3(
+                run(&app, &param_store, &storage),
+                param_store.param_handler(),
+                storage.saver_task(),
+            )
+            .await;
+        }
+    };
+
+    select(app_loop, app.exit_handler(exit_signal)).await;
+}
+
+pub async fn run(
+    app: &App<CHANNELS>,
+    params: &ParamStore<Params>,
+    storage: &ManagedStorage<Storage>,
+) {
+    let (led_color, midi_chan, base_note, gatel, midi_out) =
+        params.query(|p| (p.color, p.midi_channel, p.note, p.gatel, p.midi_out));
+    let range = Range::_0_10V;
+
+    let buttons = app.use_buttons();
+    let fader = app.use_faders();
+    let leds = app.use_leds();
+    let mut clock = app.use_clock();
+    let die = app.use_die();
+    let quantizer = app.use_quantizer(range);
+
+    let midi = app.use_midi_output(midi_out, midi_chan, false);
+
+    let prob_pitch_glob = app.make_global(0);
+    let prob_beat_glob = app.make_global(0);
+    let legato_beat_glob = app.make_global(0);
+
+    let recall_flag = app.make_global(false);
+    let div_glob = app.make_global(4);
+    let midi_note = app.make_global(MidiNote::from(0));
+    let last_note_on = app.make_global(MidiNote::from(0));
+    let glob_latch_layer = app.make_global(LatchLayer::Main);
+
+    let latched_glob = app.make_global(true);
+
+    let resolution = [24, 16, 12, 8, 6, 4, 3, 2];
+
+    leds.set(0, Led::Button, led_color, Brightness::Low);
+    leds.set(1, Led::Button, led_color, Brightness::Low);
+    leds.set(2, Led::Button, led_color, Brightness::Low);
+
+    let cv_out = app.make_out_jack(0, Range::_0_10V).await;
+    let gate_out = app.make_out_jack(1, Range::_0_10V).await;
+    let aux_out = app.make_out_jack(2, Range::_0_10V).await;
+
+    let curve = Curve::Linear;
+
+    let (mut register_pitch, mut register_length, mut register_beat, mut register_legato) = storage
+        .query(|s| {
+            (
+                s.register_pitch,
+                s.register_rhythm_length,
+                s.register_rhythm_beat,
+                s.register_legato,
+            )
+        });
+    let res = storage.query(|s| (s.res_saved));
+
+    div_glob.set(resolution[res as usize / 512]);
+
+    let fut1 = async {
+        let mut clkn: u32 = 0;
+        let mut att_reg: u16;
+        let mut gate_on = false;
+        let mut clkn_euclid: u16 = 0;
+        let mut euclid_length = 7;
+        let mut euclid_beat = 3;
+        let mut legato_beat = 5;
+        let mut pending_note_off = false;
+
+        let beat_reg_length = 16;
+        let mut length = storage.query(|s| (s.pitch_length_saved)).max(1);
+        let mut legato = false;
+        let mut aux_val: u16;
+
+        let mut out: Pitch;
+
+        let mut register_aux = ((register_length as u32 + register_beat as u32) / 2) as u16;
+
+        loop {
+            let div = div_glob.get();
+            match clock.wait_for_event(ClockDivision::_1).await {
+                ClockEvent::Reset => {
+                    clkn = 0;
+                    if gate_on {
+                        midi.send_note_off(last_note_on.get()).await;
+                        gate_on = false;
+                    }
+                    register_pitch = storage.query(|s| (s.register_pitch));
+                }
+                ClockEvent::Tick => {
+                    if clkn % div == 0 {
+                        let beat_length = storage.query(|s| (s.beat_length_saved)) as u16;
+                        clkn_euclid += 1;
+                        clkn_euclid = clkn_euclid % euclid_length.max(1) as u16;
+
+                        //euclidean generator
+                        if euclidean_filter(euclid_length, euclid_beat, 0, clkn_euclid as u32) {
+                            gate_out.set_value(4095);
+                            gate_on = true;
+                            leds.set(1, Led::Top, led_color, Brightness::Low);
+                            register_aux =
+                                rotate_select_bit(register_aux, 100, 0, euclid_beat as u16).0;
+                            aux_val = scale_to_12bit(register_aux, euclid_beat);
+                            aux_val = attenuate_bipolar(aux_val, 2095);
+                            aux_out.set_value(aux_val);
+                            let note = midi_note.get();
+                            if gate_on {
+                                midi.send_note_off(last_note_on.get()).await;
+                            }
+                            last_note_on.set(note);
+                            pending_note_off = false;
+                            info!("Note on = {}", u7::from(note).as_int());
+                            midi.send_note_on(note, aux_val).await;
+
+                            // // // // info!("aux_val = {}, reg = {}", aux_val, register_aux);
+                        }
+                        //legato generator
+                        if euclidean_filter(
+                            euclid_length,
+                            legato_beat,
+                            (euclid_length + 5) % euclid_length,
+                            clkn_euclid as u32,
+                        ) {
+                            legato = true;
+                            leds.set(2, Led::Top, led_color, Brightness::Low);
+                        } else {
+                            legato = false;
+                            leds.set(2, Led::Top, led_color, Brightness::Custom(0));
+                            if pending_note_off && gate_on {
+                                let note = last_note_on.get();
+                                gate_out.set_value(0);
+                                gate_on = false;
+                                pending_note_off = false;
+                                leds.set(1, Led::Top, led_color, Brightness::Custom(0));
+                                info!("Note off = {}", u7::from(note).as_int());
+                                midi.send_note_off(note).await;
+                            }
+                        }
+
+                        //rotate all turing registers
+                        if clkn_euclid == 0 {
+                            let prob_pitch = prob_pitch_glob.get();
+                            let prob_beat = prob_beat_glob.get();
+                            let prob_legato = legato_beat_glob.get();
+                            let rand = die.roll().clamp(100, 3900);
+                            length = (storage.query(|s| (s.pitch_length_saved))) as u16;
+
+                            register_length =
+                                rotate_select_bit(register_length, prob_beat, rand, beat_length).0;
+                            let rand = die.roll().clamp(100, 3900);
+                            register_beat =
+                                rotate_select_bit(register_beat, prob_beat, rand, beat_length).0;
+                            let rand = die.roll().clamp(100, 3900);
+                            register_legato =
+                                rotate_select_bit(register_legato, prob_legato, rand, beat_length)
+                                    .0;
+                            register_aux =
+                                ((register_length as u32 + register_beat as u32) / 2) as u16;
+                            // // // // info!("register aux = {}", register_aux);
+
+                            euclid_length = if beat_length == 1 {
+                                (storage.query(|s| (s.length_att)) as u32 * 16 / 4095).max(1) as u8
+                            } else {
+                                attenuate(
+                                    (scale_to_12bit(register_length, beat_reg_length) as u32 * 16
+                                        / 4095) as u16,
+                                    storage.query(|s| (s.length_att)),
+                                )
+                                .max(1) as u8
+                            };
+
+                            euclid_beat = if beat_length == 1 {
+                                (storage.query(|s| (s.beat_att)) as u32 * euclid_length as u32
+                                    / 4095)
+                                    .max(1) as u8
+                            } else {
+                                attenuate(
+                                    ((scale_to_12bit(register_beat, beat_reg_length)
+                                        * euclid_length as u16)
+                                        as u32
+                                        / 2048) as u16,
+                                    storage.query(|s| (s.beat_att)),
+                                )
+                                .clamp(1, euclid_length as u16)
+                                    as u8
+                            };
+
+                            legato_beat = attenuate(
+                                ((scale_to_12bit(register_legato, beat_reg_length)
+                                    * euclid_length as u16) as u32
+                                    / 2048) as u16,
+                                storage.query(|s| (s.legato_att)),
+                            )
+                            .clamp(0, euclid_length as u16)
+                                as u8;
+
+                            //pitch register
+                            register_pitch = rotate_select_bit(
+                                register_pitch,
+                                prob_pitch,
+                                rand,
+                                (storage.query(|s| (s.pitch_length_saved))) as u16,
+                            )
+                            .0;
+
+                            let register_scaled = scale_to_12bit(register_pitch, length as u8);
+                            att_reg = ((register_scaled as u32
+                                * curve.at(storage.query(|s| (s.pitch_att))) as u32)
+                                / 4095) as u16;
+
+                            out = quantizer.get_quantized_note(att_reg / 2).await;
+                            let base_note_u7 = u7::from(base_note).as_int() as i32;
+                            let out_note_u7 = u7::from(out.as_midi()).as_int() as i32;
+                            let note = MidiNote::from(base_note_u7 + out_note_u7 - 12);
+                            midi_note.set(note);
+
+                            cv_out.set_value(out.as_counts(Range::_0_10V));
+                            leds.set(
+                                0,
+                                Led::Top,
+                                led_color,
+                                Brightness::Custom((register_scaled / 16) as u8),
+                            );
+
+                            if buttons.is_button_pressed(0) && !buttons.is_shift_pressed() {
+                                leds.set(0, Led::Bottom, Color::Red, Brightness::Low);
+                            }
+                        }
+                    }
+                    // note off
+                    if clkn % div == (div * gatel as u32 / 100).clamp(1, div - 1) {
+                        let note = last_note_on.get();
+                        if gate_on && !legato {
+                            gate_out.set_value(0);
+                            gate_on = false;
+                            leds.set(1, Led::Top, led_color, Brightness::Custom(0));
+                            info!("Note off = {}", u7::from(note).as_int());
+                            midi.send_note_off(note).await;
+                        } else if gate_on && legato {
+                            pending_note_off = true;
+                        }
+                    }
+
+                    if (clkn / div) % length.max(1) as u32 == 0 {
+                        let reg_old = storage.query(|s| (s.register_pitch));
+                        if recall_flag.get() {
+                            register_pitch = reg_old;
+                            recall_flag.set(false);
+                        }
+
+                        if register_pitch != reg_old {
+                            storage.modify_and_save(|s| s.register_pitch = register_pitch);
+                        }
+                    }
+
+                    clkn += 1;
+                }
+                _ => {}
+            }
+        }
+    };
+
+    let fut2 = async {
+        let mut latch = [
+            app.make_latch(fader.get_value_at(0)),
+            app.make_latch(fader.get_value_at(1)),
+            app.make_latch(fader.get_value_at(2)),
+        ];
+
+        loop {
+            let chan = fader.wait_for_any_change().await;
+            if chan == 0 {
+                let latch_layer = glob_latch_layer.get();
+
+                let target_value = match latch_layer {
+                    LatchLayer::Main => storage.query(|s| s.pitch_att),
+                    LatchLayer::Alt => storage.query(|s| s.pitch_length_saved),
+                    LatchLayer::Third => storage.query(|s| s.res_saved),
+                };
+
+                if let Some(new_value) =
+                    latch[chan].update(fader.get_value_at(chan), latch_layer, target_value)
+                {
+                    match latch_layer {
+                        LatchLayer::Main => {
+                            storage.modify_and_save(|s| s.pitch_att = new_value);
+                        }
+                        LatchLayer::Alt => {
+                            // storage.modify_and_save(|s| s.pitch_length_saved = new_value)
+                        }
+                        LatchLayer::Third => {
+                            div_glob.set(resolution[new_value as usize / 512]);
+                            let note = last_note_on.get();
+                            midi.send_note_off(note).await;
+                            storage.modify_and_save(|s| s.res_saved = new_value);
+                        }
+                    }
+                }
+            }
+            if chan == 1 {
+                let latch_layer = glob_latch_layer.get();
+
+                let target_value = match latch_layer {
+                    LatchLayer::Alt => storage.query(|s| s.length_att),
+                    LatchLayer::Main => storage.query(|s| s.beat_att),
+                    LatchLayer::Third => storage.query(|s| s.res_saved),
+                };
+
+                if let Some(new_value) =
+                    latch[chan].update(fader.get_value_at(chan), latch_layer, target_value)
+                {
+                    match latch_layer {
+                        LatchLayer::Alt => storage.modify_and_save(|s| s.length_att = new_value),
+                        LatchLayer::Main => storage.modify_and_save(|s| s.beat_att = new_value),
+                        LatchLayer::Third => {}
+                    }
+                }
+            }
+            if chan == 2 {
+                let latch_layer = glob_latch_layer.get();
+
+                let target_value = match latch_layer {
+                    LatchLayer::Main => storage.query(|s| s.legato_att),
+                    LatchLayer::Alt => 0,
+                    LatchLayer::Third => 0,
+                };
+
+                if let Some(new_value) =
+                    latch[chan].update(fader.get_value_at(chan), latch_layer, target_value)
+                {
+                    match latch_layer {
+                        LatchLayer::Main => storage.modify_and_save(|s| s.legato_att = new_value),
+                        LatchLayer::Alt => {}
+                        LatchLayer::Third => {}
+                    }
+                }
+            }
+        }
+    };
+
+    let rec_flag = app.make_global(false);
+    let pitch_length_rec = app.make_global(0);
+    let beat_length_rec = app.make_global(0);
+
+    let fut3 = async {
+        loop {
+            let (chan, shift) = buttons.wait_for_any_down().await;
+            if chan == 0 {
+                let mut length = pitch_length_rec.get();
+                if shift && rec_flag.get() {
+                    length += 1;
+                    pitch_length_rec.set(length.min(16));
+                }
+            }
+            if chan == 1 {
+                let mut length = beat_length_rec.get();
+                if shift && rec_flag.get() {
+                    length += 1;
+                    beat_length_rec.set(length.min(16));
+                }
+            }
+        }
+    };
+
+    let fut4 = async {
+        let mut shift_old = false;
+        let mut button_old = false;
+        loop {
+            app.delay_millis(1).await;
+
+            let latch_active_layer = if buttons.is_shift_pressed() && !buttons.is_button_pressed(0)
+            {
+                LatchLayer::Alt
+            } else if !buttons.is_shift_pressed() && buttons.is_button_pressed(0) {
+                LatchLayer::Third
+            } else {
+                LatchLayer::Main
+            };
+            glob_latch_layer.set(latch_active_layer);
+
+            if buttons.is_shift_pressed() {
+                if !shift_old {
+                    // latched_glob.set(false);
+                    shift_old = true;
+                    rec_flag.set(true);
+                    pitch_length_rec.set(0);
+                    beat_length_rec.set(0);
+                }
+                leds.set(
+                    0,
+                    Led::Top,
+                    Color::Red,
+                    Brightness::Custom((storage.query(|s| (s.pitch_att)) / 16) as u8),
+                );
+            }
+
+            if shift_old {
+                if !buttons.is_shift_pressed() && shift_old {
+                    // latched_glob.set(false);
+                    shift_old = false;
+                    rec_flag.set(false);
+
+                    if pitch_length_rec.get() >= 1 {
+                        storage.modify_and_save(|s| s.pitch_length_saved = pitch_length_rec.get());
+                    }
+                    if beat_length_rec.get() >= 1 {
+                        storage.modify_and_save(|s| s.beat_length_saved = beat_length_rec.get());
+                    }
+                }
+            } else {
+                if buttons.is_button_pressed(0) {
+                    //button going down
+                    if !button_old {
+                        // latched_glob.set(false);
+                        button_old = true;
+                    }
+                    prob_pitch_glob.set(2048);
+                } else {
+                    prob_pitch_glob.set(0);
+                }
+
+                if buttons.is_button_pressed(1) {
+                    prob_beat_glob.set(2048);
+                } else {
+                    prob_beat_glob.set(0);
+                }
+
+                if buttons.is_button_pressed(2) {
+                    legato_beat_glob.set(2048);
+                } else {
+                    legato_beat_glob.set(0);
+                }
+                if !buttons.is_button_pressed(0) && button_old {
+                    // latched_glob.set(false);
+                    button_old = false;
+                    leds.unset(0, Led::Bottom);
+                }
+            }
+        }
+    };
+
+    let scene_handler = async {
+        loop {
+            match app.wait_for_scene_event().await {
+                SceneEvent::LoadScene(scene) => {
+                    storage.load_from_scene(scene).await;
+                    let res = storage.query(|s| (s.res_saved));
+
+                    recall_flag.set(true);
+
+                    div_glob.set(resolution[res as usize / 512]);
+
+                    //Add recall routine
+                    latched_glob.set(false);
+                }
+
+                SceneEvent::SaveScene(scene) => {
+                    storage.save_to_scene(scene).await;
+                }
+            }
+        }
+    };
+
+    join5(fut1, fut2, fut3, fut4, scene_handler).await;
+}
+///Returns rotated register and of the bit had been flipped
+fn rotate_select_bit(x: u16, a: u16, b: u16, bit_index: u16) -> (u16, bool) {
+    let bit_index = (16 - bit_index).clamp(0, 16);
+
+    // Extract the original bit
+    let original_bit = ((x >> bit_index) & 1) as u8;
+    let mut bit = original_bit;
+
+    // Invert the bit if a > b
+    if a > b {
+        bit ^= 1;
+    }
+
+    // Shift x right by 1
+    let shifted = x >> 1;
+
+    // Insert the (possibly inverted) bit into the MSB
+    let result = shifted | ((bit as u16) << 15);
+
+    // Return the new value and whether the bit was flipped
+    let flipped = bit != original_bit;
+    (result, flipped)
+}
+
+fn scale_to_12bit(input: u16, x: u8) -> u16 {
+    let x = x.clamp(1, 16);
+
+    // Shift to keep the top `x` bits
+    let top_x_bits = input >> (16 - x);
+
+    // Scale to 12-bit
+    let max_x_val = (1 << x) - 1;
+    ((top_x_bits as u32 * 4095) / max_x_val as u32) as u16
+}
+
+/// Rotate left a u32 pattern within a given bit width
+fn rotl32(value: u32, width: u8, rotation: u8) -> u32 {
+    let rotation = rotation % width;
+    ((value << rotation) | (value >> (width - rotation))) & ((1 << width) - 1)
+}
+
+/// Get the Euclidean pattern as a u32
+fn euclidean_pattern(num_steps: u8, num_beats: u8, rotation: u8, padding: u8) -> u32 {
+    let steps = num_steps.max(2);
+    let beats = num_beats.min(steps);
+    let index = ((steps - 2) as usize) * 33 + beats as usize;
+
+    let mut pattern = BJORKLUND_PATTERNS.get(index).copied().unwrap_or(0);
+
+    if rotation > 0 {
+        let rot = rotation % (steps + padding);
+        pattern = rotl32(pattern, steps + padding, rot);
+    }
+
+    pattern
+}
+
+/// Check if there's a beat at a given clock position
+fn euclidean_filter(num_steps: u8, num_beats: u8, rotation: u8, clock: u32) -> bool {
+    let pattern = euclidean_pattern(num_steps, num_beats, rotation, 0);
+    let pos = (clock % num_steps as u32) as u8;
+    (pattern & (1 << pos)) != 0
+}

--- a/faderpunk/src/apps/genseq.rs
+++ b/faderpunk/src/apps/genseq.rs
@@ -109,7 +109,7 @@ impl AppParams for Params {
 }
 
 /// Fader layout:
-///   F0 Main=pitch_att     Alt=pitch_length_saved  Third=res_saved
+///   F0 Main=pitch_att     Alt=pitch_tm_length     Third=res_saved
 ///   F1 Main=length_att    Alt=legato_att          Third=octave_shift
 ///   F2 Main=beat_density  Alt=accent_att          Third=gate_length
 ///
@@ -129,7 +129,6 @@ pub struct Storage {
     length_att: u16,
     beat_density: u16,
     // Alt layer
-    pitch_length_saved: u16,
     legato_att: u16,
     accent_att: u16,
     // Third layer
@@ -151,7 +150,6 @@ impl Default for Storage {
             pitch_att: 3000,
             length_att: 2048,
             beat_density: 2048,
-            pitch_length_saved: 2048, // ~9 steps
             legato_att: 1024,
             accent_att: 1024,
             res_saved: 2048,  // resolution[4] = 6 PPQN
@@ -214,6 +212,9 @@ pub async fn run(
     let last_note_on = app.make_global(MidiNote::from(0));
     let glob_latch_layer = app.make_global(LatchLayer::Main);
     let glob_muted = app.make_global(storage.query(|s| s.muted));
+    let third_layer_used = app.make_global(false);
+    let pitch_tm_step_glob = app.make_global(0u8);
+    let length_tm_step_glob = app.make_global(0u8);
 
     let resolution = [24u32, 16, 12, 8, 6, 4, 3, 2];
 
@@ -254,12 +255,18 @@ pub async fn run(
         let mut legato = false;
         let mut legato_register: u16 = register_pitch ^ register_length;
         let mut accent_register: u16 = register_pitch ^ register_length.rotate_right(8);
+        let mut pitch_cycle_step: u8 = 0;
+        let mut length_cycle_step: u8 = 0;
 
         loop {
             let div = div_glob.get();
             match clock.wait_for_event(ClockDivision::_1).await {
                 ClockEvent::Reset => {
                     clkn = 0;
+                    pitch_cycle_step = 0;
+                    length_cycle_step = 0;
+                    pitch_tm_step_glob.set(0);
+                    length_tm_step_glob.set(0);
                     if gate_on {
                         gate_out.set_value(0);
                         midi.send_note_off(last_note_on.get()).await;
@@ -302,6 +309,14 @@ pub async fn run(
                             let rand = die.roll().clamp(100, 3900);
                             register_pitch =
                                 rotate_select_bit(register_pitch, prob_pitch, rand, length).0;
+
+                            // Advance TM cycle step counters for Bottom LED progress display
+                            let ptm_len = length as u8;
+                            pitch_cycle_step = (pitch_cycle_step + 1) % ptm_len;
+                            pitch_tm_step_glob.set(pitch_cycle_step);
+                            let ltm_len = beat_reg_length;
+                            length_cycle_step = (length_cycle_step + 1) % ltm_len;
+                            length_tm_step_glob.set(length_cycle_step);
 
                             let register_scaled = scale_to_12bit(register_pitch, length as u8);
                             let raw_att = storage.query(|s| s.pitch_att);
@@ -449,6 +464,9 @@ pub async fn run(
         loop {
             let chan = fader.wait_for_any_change().await;
             let layer = glob_latch_layer.get();
+            if matches!(layer, LatchLayer::Third) {
+                third_layer_used.set(true);
+            }
 
             let target = match (chan, layer) {
                 (0, LatchLayer::Main) => storage.query(|s| s.pitch_att),
@@ -507,8 +525,12 @@ pub async fn run(
             let btn1 = buttons.is_button_pressed(1);
             let btn2 = buttons.is_button_pressed(2);
 
-            // Mute toggle: btn2 short press without shift
-            if btn2 && !btn2_old && !shift {
+            // Btn2 rising edge: reset Third-layer-used flag
+            if btn2 && !btn2_old {
+                third_layer_used.set(false);
+            }
+            // Mute toggle: Btn2 release, only if no Third layer fader was moved
+            if !btn2 && btn2_old && !shift && !third_layer_used.get() {
                 let muted = !glob_muted.get();
                 glob_muted.set(muted);
                 storage.modify_and_save(|s| s.muted = muted);
@@ -551,7 +573,7 @@ pub async fn run(
 
             let layer = if shift {
                 LatchLayer::Alt
-            } else if btn0 {
+            } else if btn2 {
                 LatchLayer::Third
             } else {
                 LatchLayer::Main
@@ -575,6 +597,7 @@ pub async fn run(
                 leds.unset(1, Led::Top);
                 leds.unset(2, Led::Top);
                 leds.unset(0, Led::Bottom);
+                leds.unset(1, Led::Bottom);
             }
             was_overlay = is_overlay;
 
@@ -589,11 +612,22 @@ pub async fn run(
                     } else {
                         leds.set(2, Led::Button, led_color, Brightness::Low);
                     }
+                    // Bottom LEDs: TM cycle progress (bright at step 0, dims through cycle)
+                    let pitch_step = pitch_tm_step_glob.get() as u32;
+                    let pitch_len = storage.query(|s| s.pitch_tm_length).max(1) as u32;
+                    let p0 = (255u32.saturating_sub(pitch_step * 255 / pitch_len)) as u8;
+                    leds.set(0, Led::Bottom, led_color, Brightness::Custom(p0));
+                    let len_step = length_tm_step_glob.get() as u32;
+                    let len_len = storage.query(|s| s.length_tm_length).max(1) as u32;
+                    let p1 = (255u32.saturating_sub(len_step * 255 / len_len)) as u8;
+                    leds.set(1, Led::Bottom, led_color, Brightness::Custom(p1));
                 }
                 LatchLayer::Alt => {
-                    // Button LEDs: brightness shows live count while counting
-                    leds.set(0, Led::Button, Color::White, Brightness::Custom(pitch_len_count.saturating_mul(16)));
-                    leds.set(1, Led::Button, Color::Green, Brightness::Custom(length_len_count.saturating_mul(16)));
+                    // Button LEDs: stored length by default; switch to live count once tapping starts
+                    let pitch_disp = if pitch_len_count > 0 { pitch_len_count } else { storage.query(|s| s.pitch_tm_length) };
+                    let len_disp = if length_len_count > 0 { length_len_count } else { storage.query(|s| s.length_tm_length) };
+                    leds.set(0, Led::Button, Color::White, Brightness::Custom((pitch_disp as u16 * 16).min(255) as u8));
+                    leds.set(1, Led::Button, Color::Green, Brightness::Custom((len_disp as u16 * 16).min(255) as u8));
                     if muted {
                         leds.unset(2, Led::Button);
                     } else {
@@ -622,14 +656,11 @@ pub async fn run(
                     );
                 }
                 LatchLayer::Third => {
-                    leds.set(0, Led::Button, led_color, Brightness::Low);
+                    leds.set(0, Led::Button, led_color, if btn0 { Brightness::High } else { Brightness::Low });
+                    leds.set(1, Led::Button, led_color, if btn1 { Brightness::High } else { Brightness::Low });
+                    leds.set(2, Led::Button, led_color, Brightness::High);
                     let oct_idx = (storage.query(|s| s.octave_shift) / 819).min(4) as usize;
-                    leds.set(1, Led::Button, OCT_COLORS[oct_idx], Brightness::High);
-                    if muted {
-                        leds.unset(2, Led::Button);
-                    } else {
-                        leds.set(2, Led::Button, led_color, Brightness::Low);
-                    }
+                    leds.set(1, Led::Bottom, OCT_COLORS[oct_idx], Brightness::High);
                     leds.set(
                         2,
                         Led::Top,
@@ -649,6 +680,7 @@ pub async fn run(
                     let res = storage.query(|s| s.res_saved);
                     div_glob.set(resolution[(res / 512).min(7) as usize]);
                     recall_flag.set(true);
+                    glob_muted.set(storage.query(|s| s.muted));
                 }
                 SceneEvent::SaveScene(scene) => {
                     storage.save_to_scene(scene).await;

--- a/faderpunk/src/apps/genseq.rs
+++ b/faderpunk/src/apps/genseq.rs
@@ -1,10 +1,5 @@
-// TODO :
-// Fix MIDI note off
-// Confirm the Velocity stuff
-
-use defmt::info;
 use embassy_futures::{
-    join::join5,
+    join::join4,
     select::{select, select3},
 };
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
@@ -15,10 +10,9 @@ use libfp::{
     constants::BJORKLUND_PATTERNS,
     ext::FromValue,
     latch::LatchLayer,
-    quantizer::Pitch,
-    utils::{attenuate, attenuate_bipolar},
-    AppIcon, Brightness, ClockDivision, Color, Config, Curve, MidiChannel, MidiNote, MidiOut,
-    Param, Range, Value, APP_MAX_PARAMS,
+    utils::attenuate,
+    AppIcon, Brightness, ClockDivision, Color, Config, MidiChannel, MidiNote, MidiOut, Param,
+    Range, Value, VoltPerOct, APP_MAX_PARAMS,
 };
 use midly::num::u7;
 
@@ -27,25 +21,25 @@ use crate::app::{
 };
 
 pub const CHANNELS: usize = 3;
-pub const PARAMS: usize = 5;
+pub const PARAMS: usize = 4;
 
-// TODO: How to add param for midi-cc base number that it just works as a default?
+/// LED colors for the 5 octave shift steps -2..+2 (F1 Third layer)
+const OCT_COLORS: [Color; 5] = [
+    Color::Blue,
+    Color::Cyan,
+    Color::Green,
+    Color::Yellow,
+    Color::Red,
+];
+
 pub static CONFIG: Config<PARAMS> = Config::new(
     "GenSeq",
-    "Turing machine, synched to internal clock",
+    "Generative sequencer with Turing machine registers",
     Color::Blue,
     AppIcon::SequenceSquare,
 )
-.add_param(Param::MidiChannel {
-    //is it possible to have this apear only if CC or note are selected
-    name: "Midi channel",
-})
+.add_param(Param::MidiChannel { name: "MIDI Channel" })
 .add_param(Param::MidiNote { name: "Base Note" })
-.add_param(Param::i32 {
-    name: "GATE %",
-    min: 1,
-    max: 100,
-})
 .add_param(Param::Color {
     name: "Color",
     variants: &[
@@ -64,7 +58,6 @@ pub static CONFIG: Config<PARAMS> = Config::new(
 pub struct Params {
     midi_channel: MidiChannel,
     note: MidiNote,
-    gatel: i32,
     color: Color,
     midi_out: MidiOut,
 }
@@ -74,7 +67,6 @@ impl Default for Params {
         Self {
             midi_channel: MidiChannel::default(),
             note: MidiNote::from(36),
-            gatel: 50,
             color: Color::Blue,
             midi_out: MidiOut::default(),
         }
@@ -89,9 +81,8 @@ impl AppParams for Params {
         Some(Self {
             midi_channel: MidiChannel::from_value(values[0]),
             note: MidiNote::from_value(values[1]),
-            gatel: i32::from_value(values[2]),
-            color: Color::from_value(values[3]),
-            midi_out: MidiOut::from_value(values[4]),
+            color: Color::from_value(values[2]),
+            midi_out: MidiOut::from_value(values[3]),
         })
     }
 
@@ -99,48 +90,73 @@ impl AppParams for Params {
         let mut vec = Vec::new();
         vec.push(self.midi_channel.into()).unwrap();
         vec.push(self.note.into()).unwrap();
-        vec.push(self.gatel.into()).unwrap();
         vec.push(self.color.into()).unwrap();
         vec.push(self.midi_out.into()).unwrap();
         vec
     }
 }
 
+/// Fader layout:
+///   F0 Main=pitch_att     Alt=pitch_length_saved  Third=res_saved
+///   F1 Main=length_att    Alt=legato_att          Third=octave_shift
+///   F2 Main=beat_density  Alt=accent_att          Third=gate_length
+///
+/// Buttons (no shift): hold to mutate that register
+///   Btn0=pitch  Btn1=length
+///
+/// Shift+Button counting (while shift held, each press increments; release commits):
+///   Shift+Btn0: pitch TM length (1–16) → pitch_tm_length
+///   Shift+Btn1: length TM register width (1–16) → length_tm_length
+///
+/// Outputs:
+///   Jack0=CV (quantized pitch)  Jack1=Gate  Jack2=Accent CV (4095 when accented)
 #[derive(Serialize, Deserialize)]
 pub struct Storage {
+    // Main layer
     pitch_att: u16,
     length_att: u16,
-    beat_att: u16,
+    beat_density: u16,
+    // Alt layer
     pitch_length_saved: u16,
-    beat_length_saved: u16,
-    register_pitch: u16,
-    register_rhythm_length: u16,
-    register_rhythm_beat: u16,
-    register_legato: u16,
     legato_att: u16,
+    accent_att: u16,
+    // Third layer
     res_saved: u16,
+    octave_shift: u16,
+    gate_length: u16,
+    // Turing machine state (register_pitch persists; register_length is ephemeral)
+    register_pitch: u16,
+    register_length: u16,
+    // TM register widths (1–16, set by Shift+Button counting)
+    pitch_tm_length: u8,
+    length_tm_length: u8,
+    muted: bool,
 }
 
 impl Default for Storage {
     fn default() -> Self {
         Self {
             pitch_att: 3000,
-            length_att: 2045,
-            beat_att: 2045,
-            pitch_length_saved: 8,
-            beat_length_saved: 8,
+            length_att: 2048,
+            beat_density: 2048,
+            pitch_length_saved: 2048, // ~9 steps
+            legato_att: 1024,
+            accent_att: 1024,
+            res_saved: 2048,  // resolution[4] = 6 PPQN
+            octave_shift: 1638, // 1638/819=2 → 2-2=0 octave shift
+            gate_length: 2048,  // ~50%
             register_pitch: 7632,
-            register_rhythm_length: 534,
-            register_rhythm_beat: 2342,
-            register_legato: 2821,
-            legato_att: 2048,
-            res_saved: 2048,
+            register_length: 534,
+            pitch_tm_length: 9,
+            length_tm_length: 16,
+            muted: false,
         }
     }
 }
+
 impl AppStorage for Storage {}
 
-#[embassy_executor::task(pool_size = 16/CHANNELS)]
+#[embassy_executor::task(pool_size = 16 / CHANNELS)]
 pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMutex, bool>) {
     let param_store = ParamStore::<Params>::new(app.app_id, app.layout_id, Params::default());
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
@@ -167,74 +183,65 @@ pub async fn run(
     params: &ParamStore<Params>,
     storage: &ManagedStorage<Storage>,
 ) {
-    let (led_color, midi_chan, base_note, gatel, midi_out) =
-        params.query(|p| (p.color, p.midi_channel, p.note, p.gatel, p.midi_out));
-    let range = Range::_0_10V;
+    let (led_color, midi_chan, base_note, midi_out) =
+        params.query(|p| (p.color, p.midi_channel, p.note, p.midi_out));
 
     let buttons = app.use_buttons();
     let fader = app.use_faders();
     let leds = app.use_leds();
     let mut clock = app.use_clock();
     let die = app.use_die();
-    let quantizer = app.use_quantizer(range);
-
+    let quantizer = app.use_quantizer(Range::_0_10V, VoltPerOct::Standard, false);
     let midi = app.use_midi_output(midi_out, midi_chan, false);
 
-    let prob_pitch_glob = app.make_global(0);
-    let prob_beat_glob = app.make_global(0);
-    let legato_beat_glob = app.make_global(0);
-
+    let prob_pitch_glob = app.make_global(0u16);
+    let prob_length_glob = app.make_global(0u16);
     let recall_flag = app.make_global(false);
-    let div_glob = app.make_global(4);
+    let div_glob = app.make_global(4u32);
     let midi_note = app.make_global(MidiNote::from(0));
     let last_note_on = app.make_global(MidiNote::from(0));
     let glob_latch_layer = app.make_global(LatchLayer::Main);
+    let glob_muted = app.make_global(storage.query(|s| s.muted));
 
-    let latched_glob = app.make_global(true);
-
-    let resolution = [24, 16, 12, 8, 6, 4, 3, 2];
+    let resolution = [24u32, 16, 12, 8, 6, 4, 3, 2];
 
     leds.set(0, Led::Button, led_color, Brightness::Low);
     leds.set(1, Led::Button, led_color, Brightness::Low);
-    leds.set(2, Led::Button, led_color, Brightness::Low);
+    if storage.query(|s| s.muted) {
+        leds.unset(2, Led::Button);
+    } else {
+        leds.set(2, Led::Button, led_color, Brightness::Low);
+    }
 
     let cv_out = app.make_out_jack(0, Range::_0_10V).await;
     let gate_out = app.make_out_jack(1, Range::_0_10V).await;
     let aux_out = app.make_out_jack(2, Range::_0_10V).await;
 
-    let curve = Curve::Linear;
+    let (mut register_pitch, mut register_length) =
+        storage.query(|s| (s.register_pitch, s.register_length));
 
-    let (mut register_pitch, mut register_length, mut register_beat, mut register_legato) = storage
-        .query(|s| {
-            (
-                s.register_pitch,
-                s.register_rhythm_length,
-                s.register_rhythm_beat,
-                s.register_legato,
-            )
-        });
-    let res = storage.query(|s| (s.res_saved));
+    let res = storage.query(|s| s.res_saved);
+    div_glob.set(resolution[(res / 512).min(7) as usize]);
 
-    div_glob.set(resolution[res as usize / 512]);
-
+    // Clock-driven sequencer loop
     let fut1 = async {
         let mut clkn: u32 = 0;
-        let mut att_reg: u16;
         let mut gate_on = false;
         let mut clkn_euclid: u16 = 0;
-        let mut euclid_length = 7;
-        let mut euclid_beat = 3;
-        let mut legato_beat = 5;
+        let mut beat_reg_length: u8 = storage.query(|s| s.length_tm_length).clamp(1, 16);
+        let mut euclid_length: u8 = attenuate(
+            length_register_scaled(register_length, beat_reg_length),
+            storage.query(|s| s.length_att),
+        )
+        .max(1) as u8;
+        let mut euclid_beat: u8 = (storage.query(|s| s.beat_density) as u32
+            * euclid_length as u32
+            / 4095)
+            .clamp(1, euclid_length as u32) as u8;
         let mut pending_note_off = false;
-
-        let beat_reg_length = 16;
-        let mut length = storage.query(|s| (s.pitch_length_saved)).max(1);
         let mut legato = false;
-        let mut aux_val: u16;
-
-        let mut out: Pitch;
-
-        let mut register_aux = ((register_length as u32 + register_beat as u32) / 2) as u16;
+        let mut legato_register: u16 = register_pitch ^ register_length;
+        let mut accent_register: u16 = register_pitch ^ register_length.rotate_right(8);
 
         loop {
             let div = div_glob.get();
@@ -242,139 +249,70 @@ pub async fn run(
                 ClockEvent::Reset => {
                     clkn = 0;
                     if gate_on {
+                        gate_out.set_value(0);
                         midi.send_note_off(last_note_on.get()).await;
                         gate_on = false;
                     }
-                    register_pitch = storage.query(|s| (s.register_pitch));
+                    register_pitch = storage.query(|s| s.register_pitch);
                 }
                 ClockEvent::Tick => {
                     if clkn % div == 0 {
-                        let beat_length = storage.query(|s| (s.beat_length_saved)) as u16;
-                        clkn_euclid += 1;
-                        clkn_euclid = clkn_euclid % euclid_length.max(1) as u16;
+                        clkn_euclid = (clkn_euclid + 1) % euclid_length.max(1) as u16;
 
-                        //euclidean generator
-                        if euclidean_filter(euclid_length, euclid_beat, 0, clkn_euclid as u32) {
-                            gate_out.set_value(4095);
-                            gate_on = true;
-                            leds.set(1, Led::Top, led_color, Brightness::Low);
-                            register_aux =
-                                rotate_select_bit(register_aux, 100, 0, euclid_beat as u16).0;
-                            aux_val = scale_to_12bit(register_aux, euclid_beat);
-                            aux_val = attenuate_bipolar(aux_val, 2095);
-                            aux_out.set_value(aux_val);
-                            let note = midi_note.get();
-                            if gate_on {
-                                midi.send_note_off(last_note_on.get()).await;
-                            }
-                            last_note_on.set(note);
-                            pending_note_off = false;
-                            info!("Note on = {}", u7::from(note).as_int());
-                            midi.send_note_on(note, aux_val).await;
-
-                            // // // // info!("aux_val = {}, reg = {}", aux_val, register_aux);
-                        }
-                        //legato generator
-                        if euclidean_filter(
-                            euclid_length,
-                            legato_beat,
-                            (euclid_length + 5) % euclid_length,
-                            clkn_euclid as u32,
-                        ) {
-                            legato = true;
-                            leds.set(2, Led::Top, led_color, Brightness::Low);
-                        } else {
-                            legato = false;
-                            leds.set(2, Led::Top, led_color, Brightness::Custom(0));
-                            if pending_note_off && gate_on {
-                                let note = last_note_on.get();
-                                gate_out.set_value(0);
-                                gate_on = false;
-                                pending_note_off = false;
-                                leds.set(1, Led::Top, led_color, Brightness::Custom(0));
-                                info!("Note off = {}", u7::from(note).as_int());
-                                midi.send_note_off(note).await;
-                            }
-                        }
-
-                        //rotate all turing registers
                         if clkn_euclid == 0 {
+                            // Cycle boundary: rotate TMs, recompute pattern params and pitch
                             let prob_pitch = prob_pitch_glob.get();
-                            let prob_beat = prob_beat_glob.get();
-                            let prob_legato = legato_beat_glob.get();
+                            let prob_length = prob_length_glob.get();
+
+                            beat_reg_length = storage.query(|s| s.length_tm_length).clamp(1, 16);
+
                             let rand = die.roll().clamp(100, 3900);
-                            length = (storage.query(|s| (s.pitch_length_saved))) as u16;
-
-                            register_length =
-                                rotate_select_bit(register_length, prob_beat, rand, beat_length).0;
-                            let rand = die.roll().clamp(100, 3900);
-                            register_beat =
-                                rotate_select_bit(register_beat, prob_beat, rand, beat_length).0;
-                            let rand = die.roll().clamp(100, 3900);
-                            register_legato =
-                                rotate_select_bit(register_legato, prob_legato, rand, beat_length)
-                                    .0;
-                            register_aux =
-                                ((register_length as u32 + register_beat as u32) / 2) as u16;
-                            // // // // info!("register aux = {}", register_aux);
-
-                            euclid_length = if beat_length == 1 {
-                                (storage.query(|s| (s.length_att)) as u32 * 16 / 4095).max(1) as u8
-                            } else {
-                                attenuate(
-                                    (scale_to_12bit(register_length, beat_reg_length) as u32 * 16
-                                        / 4095) as u16,
-                                    storage.query(|s| (s.length_att)),
-                                )
-                                .max(1) as u8
-                            };
-
-                            euclid_beat = if beat_length == 1 {
-                                (storage.query(|s| (s.beat_att)) as u32 * euclid_length as u32
-                                    / 4095)
-                                    .max(1) as u8
-                            } else {
-                                attenuate(
-                                    ((scale_to_12bit(register_beat, beat_reg_length)
-                                        * euclid_length as u16)
-                                        as u32
-                                        / 2048) as u16,
-                                    storage.query(|s| (s.beat_att)),
-                                )
-                                .clamp(1, euclid_length as u16)
-                                    as u8
-                            };
-
-                            legato_beat = attenuate(
-                                ((scale_to_12bit(register_legato, beat_reg_length)
-                                    * euclid_length as u16) as u32
-                                    / 2048) as u16,
-                                storage.query(|s| (s.legato_att)),
-                            )
-                            .clamp(0, euclid_length as u16)
-                                as u8;
-
-                            //pitch register
-                            register_pitch = rotate_select_bit(
-                                register_pitch,
-                                prob_pitch,
+                            register_length = rotate_select_bit(
+                                register_length,
+                                prob_length,
                                 rand,
-                                (storage.query(|s| (s.pitch_length_saved))) as u16,
+                                beat_reg_length as u16,
                             )
                             .0;
 
-                            let register_scaled = scale_to_12bit(register_pitch, length as u8);
-                            att_reg = ((register_scaled as u32
-                                * curve.at(storage.query(|s| (s.pitch_att))) as u32)
-                                / 4095) as u16;
+                            euclid_length = attenuate(
+                                length_register_scaled(register_length, beat_reg_length),
+                                storage.query(|s| s.length_att),
+                            )
+                            .max(1) as u8;
 
-                            out = quantizer.get_quantized_note(att_reg / 2).await;
-                            let base_note_u7 = u7::from(base_note).as_int() as i32;
-                            let out_note_u7 = u7::from(out.as_midi()).as_int() as i32;
-                            let note = MidiNote::from(base_note_u7 + out_note_u7 - 12);
+                            euclid_beat = (storage.query(|s| s.beat_density) as u32
+                                * euclid_length as u32
+                                / 4095)
+                                .clamp(1, euclid_length as u32) as u8;
+
+                            let length = storage.query(|s| s.pitch_tm_length).clamp(1, 16) as u16;
+                            let rand = die.roll().clamp(100, 3900);
+                            register_pitch =
+                                rotate_select_bit(register_pitch, prob_pitch, rand, length).0;
+
+                            let register_scaled = scale_to_12bit(register_pitch, length as u8);
+                            let att_reg =
+                                attenuate(register_scaled, storage.query(|s| s.pitch_att));
+                            let out = quantizer.get_quantized_note(att_reg / 2).await;
+
+                            let octave_offset =
+                                (storage.query(|s| s.octave_shift) / 819).min(4) as i32 - 2;
+                            let base_note_i = u7::from(base_note).as_int() as i32;
+                            let out_note_i = u7::from(out.as_midi()).as_int() as i32;
+                            let note = MidiNote::from(
+                                (base_note_i + out_note_i - 12 + octave_offset * 12)
+                                    .clamp(0, 127),
+                            );
                             midi_note.set(note);
 
-                            cv_out.set_value(out.as_counts(Range::_0_10V));
+                            if !glob_muted.get() {
+                                let cv_val = (out.as_counts(Range::_0_10V, VoltPerOct::Standard)
+                                    as i32
+                                    + octave_offset * 410)
+                                    .clamp(0, 4095) as u16;
+                                cv_out.set_value(cv_val);
+                            }
                             leds.set(
                                 0,
                                 Led::Top,
@@ -382,34 +320,86 @@ pub async fn run(
                                 Brightness::Custom((register_scaled / 16) as u8),
                             );
 
-                            if buttons.is_button_pressed(0) && !buttons.is_shift_pressed() {
-                                leds.set(0, Led::Bottom, Color::Red, Brightness::Low);
+                            let reg_old = storage.query(|s| s.register_pitch);
+                            if recall_flag.get() {
+                                register_pitch = reg_old;
+                                recall_flag.set(false);
+                            } else if register_pitch != reg_old {
+                                storage.modify_and_save(|s| s.register_pitch = register_pitch);
+                            }
+
+                            // Derive legato/accent registers from XOR of both TMs
+                            legato_register = register_pitch ^ register_length;
+                            accent_register = register_pitch ^ register_length.rotate_right(8);
+                        } else {
+                            // Every other step: rotate derived registers
+                            legato_register = legato_register.rotate_right(1);
+                            accent_register = accent_register.rotate_right(1);
+                        }
+
+                        let is_legato =
+                            scale_to_12bit(legato_register, 16) < storage.query(|s| s.legato_att);
+                        let is_accented = scale_to_12bit(accent_register, 16)
+                            < storage.query(|s| s.accent_att);
+
+                        let is_beat =
+                            euclidean_filter(euclid_length, euclid_beat, 0, clkn_euclid as u32);
+
+                        if is_beat && !glob_muted.get() {
+                            if gate_on {
+                                midi.send_note_off(last_note_on.get()).await;
+                            }
+                            let note = midi_note.get();
+                            last_note_on.set(note);
+                            gate_out.set_value(4095);
+                            gate_on = true;
+                            pending_note_off = false;
+                            aux_out.set_value(if is_accented { 4095 } else { 0 });
+                            midi.send_note_on(note, if is_accented { 4095 } else { 2048 })
+                                .await;
+                            leds.set(1, Led::Top, led_color, Brightness::Low);
+                        }
+
+                        legato = is_legato;
+                        if is_legato {
+                            leds.set(2, Led::Top, led_color, Brightness::Low);
+                        } else {
+                            leds.set(2, Led::Top, led_color, Brightness::Custom(0));
+                            if pending_note_off && gate_on {
+                                gate_out.set_value(0);
+                                gate_on = false;
+                                pending_note_off = false;
+                                leds.set(1, Led::Top, led_color, Brightness::Custom(0));
+                                midi.send_note_off(last_note_on.get()).await;
                             }
                         }
                     }
-                    // note off
-                    if clkn % div == (div * gatel as u32 / 100).clamp(1, div - 1) {
-                        let note = last_note_on.get();
+
+                    // Resolution flash on Ch0 Bottom while in Third layer
+                    if matches!(glob_latch_layer.get(), LatchLayer::Third) {
+                        if clkn % div == 0 {
+                            let color = if matches!(div, 2 | 4 | 8 | 16) {
+                                Color::Orange
+                            } else {
+                                Color::Blue
+                            };
+                            leds.set(0, Led::Bottom, color, Brightness::High);
+                        } else if clkn % div == (div / 2).max(1) {
+                            leds.unset(0, Led::Bottom);
+                        }
+                    }
+
+                    // Gate off
+                    let gate_pct =
+                        (storage.query(|s| s.gate_length) as u32 * 100 / 4095).clamp(1, 99);
+                    if clkn % div == (div * gate_pct / 100).clamp(1, div - 1) {
                         if gate_on && !legato {
                             gate_out.set_value(0);
                             gate_on = false;
                             leds.set(1, Led::Top, led_color, Brightness::Custom(0));
-                            info!("Note off = {}", u7::from(note).as_int());
-                            midi.send_note_off(note).await;
+                            midi.send_note_off(last_note_on.get()).await;
                         } else if gate_on && legato {
                             pending_note_off = true;
-                        }
-                    }
-
-                    if (clkn / div) % length.max(1) as u32 == 0 {
-                        let reg_old = storage.query(|s| (s.register_pitch));
-                        if recall_flag.get() {
-                            register_pitch = reg_old;
-                            recall_flag.set(false);
-                        }
-
-                        if register_pitch != reg_old {
-                            storage.modify_and_save(|s| s.register_pitch = register_pitch);
                         }
                     }
 
@@ -420,6 +410,7 @@ pub async fn run(
         }
     };
 
+    // Fader handler
     let fut2 = async {
         let mut latch = [
             app.make_latch(fader.get_value_at(0)),
@@ -429,171 +420,194 @@ pub async fn run(
 
         loop {
             let chan = fader.wait_for_any_change().await;
-            if chan == 0 {
-                let latch_layer = glob_latch_layer.get();
+            let layer = glob_latch_layer.get();
 
-                let target_value = match latch_layer {
-                    LatchLayer::Main => storage.query(|s| s.pitch_att),
-                    LatchLayer::Alt => storage.query(|s| s.pitch_length_saved),
-                    LatchLayer::Third => storage.query(|s| s.res_saved),
-                };
-
-                if let Some(new_value) =
-                    latch[chan].update(fader.get_value_at(chan), latch_layer, target_value)
-                {
-                    match latch_layer {
-                        LatchLayer::Main => {
-                            storage.modify_and_save(|s| s.pitch_att = new_value);
-                        }
-                        LatchLayer::Alt => {
-                            // storage.modify_and_save(|s| s.pitch_length_saved = new_value)
-                        }
-                        LatchLayer::Third => {
-                            div_glob.set(resolution[new_value as usize / 512]);
-                            let note = last_note_on.get();
-                            midi.send_note_off(note).await;
-                            storage.modify_and_save(|s| s.res_saved = new_value);
-                        }
-                    }
+            let target = match (chan, layer) {
+                (0, LatchLayer::Main) => storage.query(|s| s.pitch_att),
+                (0, LatchLayer::Alt) => {
+                    (storage.query(|s| s.pitch_tm_length).saturating_sub(1) as u32 * 4095 / 15)
+                        as u16
                 }
-            }
-            if chan == 1 {
-                let latch_layer = glob_latch_layer.get();
+                (0, LatchLayer::Third) => storage.query(|s| s.res_saved),
+                (1, LatchLayer::Main) => storage.query(|s| s.length_att),
+                (1, LatchLayer::Alt) => storage.query(|s| s.legato_att),
+                (1, LatchLayer::Third) => storage.query(|s| s.octave_shift),
+                (2, LatchLayer::Main) => storage.query(|s| s.beat_density),
+                (2, LatchLayer::Alt) => storage.query(|s| s.accent_att),
+                (2, LatchLayer::Third) => storage.query(|s| s.gate_length),
+                _ => 0,
+            };
 
-                let target_value = match latch_layer {
-                    LatchLayer::Alt => storage.query(|s| s.length_att),
-                    LatchLayer::Main => storage.query(|s| s.beat_att),
-                    LatchLayer::Third => storage.query(|s| s.res_saved),
-                };
-
-                if let Some(new_value) =
-                    latch[chan].update(fader.get_value_at(chan), latch_layer, target_value)
-                {
-                    match latch_layer {
-                        LatchLayer::Alt => storage.modify_and_save(|s| s.length_att = new_value),
-                        LatchLayer::Main => storage.modify_and_save(|s| s.beat_att = new_value),
-                        LatchLayer::Third => {}
+            if let Some(v) = latch[chan].update(fader.get_value_at(chan), layer, target) {
+                match (chan, layer) {
+                    (0, LatchLayer::Main) => storage.modify_and_save(|s| s.pitch_att = v),
+                    (0, LatchLayer::Alt) => storage.modify_and_save(|s| {
+                        s.pitch_tm_length = (v as u32 * 15 / 4095 + 1).min(16) as u8;
+                    }),
+                    (0, LatchLayer::Third) => {
+                        div_glob.set(resolution[(v / 512).min(7) as usize]);
+                        midi.send_note_off(last_note_on.get()).await;
+                        storage.modify_and_save(|s| s.res_saved = v);
                     }
-                }
-            }
-            if chan == 2 {
-                let latch_layer = glob_latch_layer.get();
-
-                let target_value = match latch_layer {
-                    LatchLayer::Main => storage.query(|s| s.legato_att),
-                    LatchLayer::Alt => 0,
-                    LatchLayer::Third => 0,
-                };
-
-                if let Some(new_value) =
-                    latch[chan].update(fader.get_value_at(chan), latch_layer, target_value)
-                {
-                    match latch_layer {
-                        LatchLayer::Main => storage.modify_and_save(|s| s.legato_att = new_value),
-                        LatchLayer::Alt => {}
-                        LatchLayer::Third => {}
-                    }
+                    (1, LatchLayer::Main) => storage.modify_and_save(|s| s.length_att = v),
+                    (1, LatchLayer::Alt) => storage.modify_and_save(|s| s.legato_att = v),
+                    (1, LatchLayer::Third) => storage.modify_and_save(|s| s.octave_shift = v),
+                    (2, LatchLayer::Main) => storage.modify_and_save(|s| s.beat_density = v),
+                    (2, LatchLayer::Alt) => storage.modify_and_save(|s| s.accent_att = v),
+                    (2, LatchLayer::Third) => storage.modify_and_save(|s| s.gate_length = v),
+                    _ => {}
                 }
             }
         }
     };
 
-    let rec_flag = app.make_global(false);
-    let pitch_length_rec = app.make_global(0);
-    let beat_length_rec = app.make_global(0);
-
+    // Layer management, mutation, TM length counting, mute, and LED feedback
     let fut3 = async {
-        loop {
-            let (chan, shift) = buttons.wait_for_any_down().await;
-            if chan == 0 {
-                let mut length = pitch_length_rec.get();
-                if shift && rec_flag.get() {
-                    length += 1;
-                    pitch_length_rec.set(length.min(16));
-                }
-            }
-            if chan == 1 {
-                let mut length = beat_length_rec.get();
-                if shift && rec_flag.get() {
-                    length += 1;
-                    beat_length_rec.set(length.min(16));
-                }
-            }
-        }
-    };
-
-    let fut4 = async {
         let mut shift_old = false;
-        let mut button_old = false;
+        let mut btn0_old = false;
+        let mut btn1_old = false;
+        let mut btn2_old = false;
+        let mut pitch_len_count: u8 = 0;
+        let mut length_len_count: u8 = 0;
+        let mut was_overlay = false;
+
         loop {
             app.delay_millis(1).await;
 
-            let latch_active_layer = if buttons.is_shift_pressed() && !buttons.is_button_pressed(0)
-            {
+            let shift = buttons.is_shift_pressed();
+            let btn0 = buttons.is_button_pressed(0);
+            let btn1 = buttons.is_button_pressed(1);
+            let btn2 = buttons.is_button_pressed(2);
+
+            // Mute toggle: btn2 short press without shift
+            if btn2 && !btn2_old && !shift {
+                let muted = !glob_muted.get();
+                glob_muted.set(muted);
+                storage.modify_and_save(|s| s.muted = muted);
+            }
+            btn2_old = btn2;
+
+            // TM length counting: Shift + Btn0/Btn1 presses (edge-triggered)
+            let was_shift = shift_old;
+            shift_old = shift;
+
+            // Reset at the start of a new Shift session, before counting
+            if shift && !was_shift {
+                pitch_len_count = 0;
+                length_len_count = 0;
+            }
+
+            // Count presses (safe now — reset already fired this tick if needed)
+            if shift {
+                if btn0 && !btn0_old {
+                    pitch_len_count = pitch_len_count.saturating_add(1).min(16);
+                }
+                if btn1 && !btn1_old {
+                    length_len_count = length_len_count.saturating_add(1).min(16);
+                }
+            }
+            btn0_old = btn0;
+            btn1_old = btn1;
+
+            // Commit on Shift release
+            if !shift && was_shift {
+                if pitch_len_count >= 1 {
+                    storage.modify_and_save(|s| s.pitch_tm_length = pitch_len_count);
+                }
+                if length_len_count >= 1 {
+                    storage.modify_and_save(|s| s.length_tm_length = length_len_count);
+                }
+                pitch_len_count = 0;
+                length_len_count = 0;
+            }
+
+            let layer = if shift {
                 LatchLayer::Alt
-            } else if !buttons.is_shift_pressed() && buttons.is_button_pressed(0) {
+            } else if btn0 {
                 LatchLayer::Third
             } else {
                 LatchLayer::Main
             };
-            glob_latch_layer.set(latch_active_layer);
+            glob_latch_layer.set(layer);
 
-            if buttons.is_shift_pressed() {
-                if !shift_old {
-                    // latched_glob.set(false);
-                    shift_old = true;
-                    rec_flag.set(true);
-                    pitch_length_rec.set(0);
-                    beat_length_rec.set(0);
-                }
-                leds.set(
-                    0,
-                    Led::Top,
-                    Color::Red,
-                    Brightness::Custom((storage.query(|s| (s.pitch_att)) / 16) as u8),
-                );
+            if !shift {
+                prob_pitch_glob.set(if btn0 { 2048 } else { 0 });
+                prob_length_glob.set(if btn1 { 2048 } else { 0 });
+            } else {
+                prob_pitch_glob.set(0);
+                prob_length_glob.set(0);
             }
 
-            if shift_old {
-                if !buttons.is_shift_pressed() && shift_old {
-                    // latched_glob.set(false);
-                    shift_old = false;
-                    rec_flag.set(false);
+            let muted = glob_muted.get();
+            let is_overlay = !matches!(layer, LatchLayer::Main);
 
-                    if pitch_length_rec.get() >= 1 {
-                        storage.modify_and_save(|s| s.pitch_length_saved = pitch_length_rec.get());
-                    }
-                    if beat_length_rec.get() >= 1 {
-                        storage.modify_and_save(|s| s.beat_length_saved = beat_length_rec.get());
-                    }
-                }
-            } else {
-                if buttons.is_button_pressed(0) {
-                    //button going down
-                    if !button_old {
-                        // latched_glob.set(false);
-                        button_old = true;
-                    }
-                    prob_pitch_glob.set(2048);
-                } else {
-                    prob_pitch_glob.set(0);
-                }
+            // Returning to Main: clear overlay LEDs so fut1 takes over cleanly
+            if was_overlay && !is_overlay {
+                leds.unset(0, Led::Top);
+                leds.unset(1, Led::Top);
+                leds.unset(2, Led::Top);
+                leds.unset(0, Led::Bottom);
+            }
+            was_overlay = is_overlay;
 
-                if buttons.is_button_pressed(1) {
-                    prob_beat_glob.set(2048);
-                } else {
-                    prob_beat_glob.set(0);
+            match layer {
+                LatchLayer::Main => {
+                    // Btn0/Btn1: brighter when held (mutating)
+                    leds.set(0, Led::Button, led_color, if btn0 { Brightness::High } else { Brightness::Low });
+                    leds.set(1, Led::Button, led_color, if btn1 { Brightness::High } else { Brightness::Low });
+                    // Btn2: mute indicator — dim when active, off when muted
+                    if muted {
+                        leds.unset(2, Led::Button);
+                    } else {
+                        leds.set(2, Led::Button, led_color, Brightness::Low);
+                    }
                 }
-
-                if buttons.is_button_pressed(2) {
-                    legato_beat_glob.set(2048);
-                } else {
-                    legato_beat_glob.set(0);
+                LatchLayer::Alt => {
+                    // Button LEDs: brightness shows live count while counting
+                    leds.set(0, Led::Button, Color::White, Brightness::Custom(pitch_len_count.saturating_mul(16)));
+                    leds.set(1, Led::Button, Color::Green, Brightness::Custom(length_len_count.saturating_mul(16)));
+                    if muted {
+                        leds.unset(2, Led::Button);
+                    } else {
+                        leds.set(2, Led::Button, led_color, Brightness::Low);
+                    }
+                    // Top LEDs: fader values (brightness = current setting)
+                    leds.set(
+                        0,
+                        Led::Top,
+                        Color::White,
+                        Brightness::Custom(
+                            (storage.query(|s| s.pitch_tm_length) as u8 * 16).saturating_sub(1),
+                        ),
+                    );
+                    leds.set(
+                        1,
+                        Led::Top,
+                        Color::Cyan,
+                        Brightness::Custom((storage.query(|s| s.legato_att) / 16) as u8),
+                    );
+                    leds.set(
+                        2,
+                        Led::Top,
+                        Color::Yellow,
+                        Brightness::Custom((storage.query(|s| s.accent_att) / 16) as u8),
+                    );
                 }
-                if !buttons.is_button_pressed(0) && button_old {
-                    // latched_glob.set(false);
-                    button_old = false;
-                    leds.unset(0, Led::Bottom);
+                LatchLayer::Third => {
+                    leds.set(0, Led::Button, led_color, Brightness::Low);
+                    let oct_idx = (storage.query(|s| s.octave_shift) / 819).min(4) as usize;
+                    leds.set(1, Led::Button, OCT_COLORS[oct_idx], Brightness::High);
+                    if muted {
+                        leds.unset(2, Led::Button);
+                    } else {
+                        leds.set(2, Led::Button, led_color, Brightness::Low);
+                    }
+                    leds.set(
+                        2,
+                        Led::Top,
+                        Color::White,
+                        Brightness::Custom((storage.query(|s| s.gate_length) / 16) as u8),
+                    );
                 }
             }
         }
@@ -604,16 +618,10 @@ pub async fn run(
             match app.wait_for_scene_event().await {
                 SceneEvent::LoadScene(scene) => {
                     storage.load_from_scene(scene).await;
-                    let res = storage.query(|s| (s.res_saved));
-
+                    let res = storage.query(|s| s.res_saved);
+                    div_glob.set(resolution[(res / 512).min(7) as usize]);
                     recall_flag.set(true);
-
-                    div_glob.set(resolution[res as usize / 512]);
-
-                    //Add recall routine
-                    latched_glob.set(false);
                 }
-
                 SceneEvent::SaveScene(scene) => {
                     storage.save_to_scene(scene).await;
                 }
@@ -621,68 +629,63 @@ pub async fn run(
         }
     };
 
-    join5(fut1, fut2, fut3, fut4, scene_handler).await;
+    join4(fut1, fut2, fut3, scene_handler).await;
 }
-///Returns rotated register and of the bit had been flipped
+
+/// Rotate shift register right by 1; conditionally flip the MSB based on probability.
+/// Returns (new_register, was_bit_flipped).
 fn rotate_select_bit(x: u16, a: u16, b: u16, bit_index: u16) -> (u16, bool) {
     let bit_index = (16 - bit_index).clamp(0, 16);
-
-    // Extract the original bit
     let original_bit = ((x >> bit_index) & 1) as u8;
     let mut bit = original_bit;
-
-    // Invert the bit if a > b
     if a > b {
         bit ^= 1;
     }
-
-    // Shift x right by 1
-    let shifted = x >> 1;
-
-    // Insert the (possibly inverted) bit into the MSB
-    let result = shifted | ((bit as u16) << 15);
-
-    // Return the new value and whether the bit was flipped
-    let flipped = bit != original_bit;
-    (result, flipped)
+    let result = (x >> 1) | ((bit as u16) << 15);
+    (result, bit != original_bit)
 }
 
+/// Scale the length register to the 0–16 range used for euclid_length.
+/// When bit_length == 1, bypasses the register and returns 16 (full scale) so
+/// length_att becomes a direct euclidean length control.
+fn length_register_scaled(register: u16, bit_length: u8) -> u16 {
+    if bit_length == 1 {
+        16
+    } else {
+        (scale_to_12bit(register, bit_length) as u32 * 16 / 4095) as u16
+    }
+}
+
+/// Extract the top `x` bits of `input` and scale linearly to 12-bit (0–4095).
 fn scale_to_12bit(input: u16, x: u8) -> u16 {
     let x = x.clamp(1, 16);
-
-    // Shift to keep the top `x` bits
     let top_x_bits = input >> (16 - x);
-
-    // Scale to 12-bit
-    let max_x_val = (1 << x) - 1;
-    ((top_x_bits as u32 * 4095) / max_x_val as u32) as u16
+    let max_x_val = (1u32 << x) - 1;
+    ((top_x_bits as u32 * 4095) / max_x_val) as u16
 }
 
-/// Rotate left a u32 pattern within a given bit width
+/// Rotate a pattern of `width` bits left by `rotation` steps.
 fn rotl32(value: u32, width: u8, rotation: u8) -> u32 {
     let rotation = rotation % width;
     ((value << rotation) | (value >> (width - rotation))) & ((1 << width) - 1)
 }
 
-/// Get the Euclidean pattern as a u32
+/// Look up the Bjorklund (Euclidean) pattern for the given step/beat counts.
 fn euclidean_pattern(num_steps: u8, num_beats: u8, rotation: u8, padding: u8) -> u32 {
     let steps = num_steps.max(2);
     let beats = num_beats.min(steps);
     let index = ((steps - 2) as usize) * 33 + beats as usize;
-
     let mut pattern = BJORKLUND_PATTERNS.get(index).copied().unwrap_or(0);
-
     if rotation > 0 {
         let rot = rotation % (steps + padding);
         pattern = rotl32(pattern, steps + padding, rot);
     }
-
     pattern
 }
 
-/// Check if there's a beat at a given clock position
+/// Return true if there is a beat at `clock` position in the Euclidean pattern.
 fn euclidean_filter(num_steps: u8, num_beats: u8, rotation: u8, clock: u32) -> bool {
     let pattern = euclidean_pattern(num_steps, num_beats, rotation, 0);
-    let pos = (clock % num_steps as u32) as u8;
+    let pos = (clock % num_steps.max(1) as u32) as u8;
     (pattern & (1 << pos)) != 0
 }

--- a/faderpunk/src/apps/genseq.rs
+++ b/faderpunk/src/apps/genseq.rs
@@ -7,10 +7,9 @@ use heapless::Vec;
 use serde::{Deserialize, Serialize};
 
 use libfp::{
-    constants::BJORKLUND_PATTERNS,
     ext::FromValue,
     latch::LatchLayer,
-    utils::attenuate,
+    utils::{attenuate, euclidean_at, rotate_select_bit, scale_to_12bit},
     AppIcon, Brightness, ClockDivision, Color, Config, MidiChannel, MidiNote, MidiOut, Param,
     Range, Value, VoltPerOct, APP_MAX_PARAMS,
 };
@@ -343,7 +342,7 @@ pub async fn run(
                             < storage.query(|s| s.accent_att);
 
                         let is_beat =
-                            euclidean_filter(euclid_length, euclid_beat, 0, clkn_euclid as u32);
+                            euclidean_at(euclid_length, euclid_beat, 0, clkn_euclid as u32);
 
                         if is_beat && !glob_muted.get() {
                             if gate_on {
@@ -632,19 +631,6 @@ pub async fn run(
     join4(fut1, fut2, fut3, scene_handler).await;
 }
 
-/// Rotate shift register right by 1; conditionally flip the MSB based on probability.
-/// Returns (new_register, was_bit_flipped).
-fn rotate_select_bit(x: u16, a: u16, b: u16, bit_index: u16) -> (u16, bool) {
-    let bit_index = (16 - bit_index).clamp(0, 16);
-    let original_bit = ((x >> bit_index) & 1) as u8;
-    let mut bit = original_bit;
-    if a > b {
-        bit ^= 1;
-    }
-    let result = (x >> 1) | ((bit as u16) << 15);
-    (result, bit != original_bit)
-}
-
 /// Scale the length register to the 0–16 range used for euclid_length.
 /// When bit_length == 1, bypasses the register and returns 16 (full scale) so
 /// length_att becomes a direct euclidean length control.
@@ -654,38 +640,4 @@ fn length_register_scaled(register: u16, bit_length: u8) -> u16 {
     } else {
         (scale_to_12bit(register, bit_length) as u32 * 16 / 4095) as u16
     }
-}
-
-/// Extract the top `x` bits of `input` and scale linearly to 12-bit (0–4095).
-fn scale_to_12bit(input: u16, x: u8) -> u16 {
-    let x = x.clamp(1, 16);
-    let top_x_bits = input >> (16 - x);
-    let max_x_val = (1u32 << x) - 1;
-    ((top_x_bits as u32 * 4095) / max_x_val) as u16
-}
-
-/// Rotate a pattern of `width` bits left by `rotation` steps.
-fn rotl32(value: u32, width: u8, rotation: u8) -> u32 {
-    let rotation = rotation % width;
-    ((value << rotation) | (value >> (width - rotation))) & ((1 << width) - 1)
-}
-
-/// Look up the Bjorklund (Euclidean) pattern for the given step/beat counts.
-fn euclidean_pattern(num_steps: u8, num_beats: u8, rotation: u8, padding: u8) -> u32 {
-    let steps = num_steps.max(2);
-    let beats = num_beats.min(steps);
-    let index = ((steps - 2) as usize) * 33 + beats as usize;
-    let mut pattern = BJORKLUND_PATTERNS.get(index).copied().unwrap_or(0);
-    if rotation > 0 {
-        let rot = rotation % (steps + padding);
-        pattern = rotl32(pattern, steps + padding, rot);
-    }
-    pattern
-}
-
-/// Return true if there is a beat at `clock` position in the Euclidean pattern.
-fn euclidean_filter(num_steps: u8, num_beats: u8, rotation: u8, clock: u32) -> bool {
-    let pattern = euclidean_pattern(num_steps, num_beats, rotation, 0);
-    let pos = (clock % num_steps.max(1) as u32) as u8;
-    (pattern & (1 << pos)) != 0
 }

--- a/faderpunk/src/apps/genseq.rs
+++ b/faderpunk/src/apps/genseq.rs
@@ -11,8 +11,8 @@ use libfp::{
     latch::LatchLayer,
     quantizer::Pitch,
     utils::{attenuate, euclidean_at, rotate_select_bit, scale_to_12bit},
-    AppIcon, Brightness, ClockDivision, Color, Config, MidiChannel, MidiNote, MidiOut, Param,
-    Range, Value, VoltPerOct, APP_MAX_PARAMS,
+    AppIcon, Brightness, ClockDivision, Color, Config, Curve, MidiChannel, MidiNote, MidiOut,
+    Param, Range, Value, VoltPerOct, APP_MAX_PARAMS,
 };
 use midly::num::u7;
 
@@ -35,10 +35,12 @@ const OCT_COLORS: [Color; 5] = [
 pub static CONFIG: Config<PARAMS> = Config::new(
     "GenSeq",
     "Generative sequencer with Turing machine registers",
-    Color::Blue,
-    AppIcon::SequenceSquare,
+    Color::Yellow,
+    AppIcon::Sequence,
 )
-.add_param(Param::MidiChannel { name: "MIDI Channel" })
+.add_param(Param::MidiChannel {
+    name: "MIDI Channel",
+})
 .add_param(Param::MidiNote { name: "Base Note" })
 .add_param(Param::Color {
     name: "Color",
@@ -72,7 +74,7 @@ impl Default for Params {
     fn default() -> Self {
         Self {
             midi_channel: MidiChannel::default(),
-            note: MidiNote::from(36),
+            note: MidiNote::from(12),
             color: Color::Blue,
             midi_out: MidiOut::default(),
             vpo: VoltPerOct::Standard,
@@ -135,7 +137,7 @@ pub struct Storage {
     res_saved: u16,
     octave_shift: u16,
     gate_length: u16,
-    // Turing machine state (register_pitch persists; register_length is ephemeral)
+    // Turing machine state
     register_pitch: u16,
     register_length: u16,
     // TM register widths (1–16, set by Shift+Button counting)
@@ -152,7 +154,7 @@ impl Default for Storage {
             beat_density: 2048,
             legato_att: 1024,
             accent_att: 1024,
-            res_saved: 2048,  // resolution[4] = 6 PPQN
+            res_saved: 2048,    // resolution[4] = 6 PPQN
             octave_shift: 1638, // 1638/819=2 → 2-2=0 octave shift
             gate_length: 2048,  // ~50%
             register_pitch: 7632,
@@ -215,6 +217,8 @@ pub async fn run(
     let third_layer_used = app.make_global(false);
     let pitch_tm_step_glob = app.make_global(0u8);
     let length_tm_step_glob = app.make_global(0u8);
+    let euclid_step_glob = app.make_global(0u16);
+    let euclid_len_glob = app.make_global(1u8);
 
     let resolution = [24u32, 16, 12, 8, 6, 4, 3, 2];
 
@@ -247,8 +251,7 @@ pub async fn run(
             storage.query(|s| s.length_att),
         )
         .max(1) as u8;
-        let mut euclid_beat: u8 = (storage.query(|s| s.beat_density) as u32
-            * euclid_length as u32
+        let mut euclid_beat: u8 = (storage.query(|s| s.beat_density) as u32 * euclid_length as u32
             / 4095)
             .clamp(1, euclid_length as u32) as u8;
         let mut pending_note_off = false;
@@ -263,10 +266,12 @@ pub async fn run(
             match clock.wait_for_event(ClockDivision::_1).await {
                 ClockEvent::Reset => {
                     clkn = 0;
+                    clkn_euclid = 0;
                     pitch_cycle_step = 0;
                     length_cycle_step = 0;
                     pitch_tm_step_glob.set(0);
                     length_tm_step_glob.set(0);
+                    euclid_step_glob.set(0);
                     if gate_on {
                         gate_out.set_value(0);
                         midi.send_note_off(last_note_on.get()).await;
@@ -277,6 +282,7 @@ pub async fn run(
                 ClockEvent::Tick => {
                     if clkn.is_multiple_of(div) {
                         clkn_euclid = (clkn_euclid + 1) % euclid_length.max(1) as u16;
+                        euclid_step_glob.set(clkn_euclid);
 
                         if clkn_euclid == 0 {
                             // Cycle boundary: rotate TMs, recompute pattern params and pitch
@@ -299,11 +305,13 @@ pub async fn run(
                                 storage.query(|s| s.length_att),
                             )
                             .max(1) as u8;
+                            euclid_len_glob.set(euclid_length);
 
                             euclid_beat = (storage.query(|s| s.beat_density) as u32
                                 * euclid_length as u32
                                 / 4095)
-                                .clamp(1, euclid_length as u32) as u8;
+                                .clamp(1, euclid_length as u32)
+                                as u8;
 
                             let length = storage.query(|s| s.pitch_tm_length).clamp(1, 16) as u16;
                             let rand = die.roll().clamp(100, 3900);
@@ -320,17 +328,16 @@ pub async fn run(
 
                             let register_scaled = scale_to_12bit(register_pitch, length as u8);
                             let raw_att = storage.query(|s| s.pitch_att);
-                            let curved_att = (raw_att as u32 * 4095).isqrt() as u16;
-                            let att_reg = attenuate(register_scaled, curved_att);
+                            let att_reg =
+                                attenuate(register_scaled, Curve::Logarithmic.at(raw_att));
                             let octave_offset =
                                 (storage.query(|s| s.octave_shift) / 819).min(4) as i32 - 2;
 
                             // When shifting down, raise the quantizer input floor so the
                             // bottom of the pitch range maps to C0 rather than clipping
                             // negative DAC values to 0V.
-                            let input_floor =
-                                ((-octave_offset).max(0) as u16)
-                                    .saturating_mul(vpo.counts_per_oct() as u16);
+                            let input_floor = ((-octave_offset).max(0) as u16)
+                                .saturating_mul(vpo.counts_per_oct() as u16);
                             let quantizer_input =
                                 (att_reg as u32 / 2 + input_floor as u32).min(4095) as u16;
                             let out = quantizer.get_quantized_note(quantizer_input).await;
@@ -344,17 +351,13 @@ pub async fn run(
                             };
 
                             let base_note_i = u7::from(base_note).as_int() as i32;
-                            let shifted_midi_val =
-                                u7::from(shifted.as_midi()).as_int() as i32;
-                            let note = MidiNote::from(
-                                (base_note_i + shifted_midi_val - 12).clamp(0, 127),
-                            );
+                            let shifted_midi_val = u7::from(shifted.as_midi()).as_int() as i32;
+                            let note =
+                                MidiNote::from((base_note_i + shifted_midi_val - 12).clamp(0, 127));
                             midi_note.set(note);
 
                             if !glob_muted.get() {
-                                cv_out.set_value(
-                                    shifted.as_counts(Range::_0_10V, vpo),
-                                );
+                                cv_out.set_value(shifted.as_counts(Range::_0_10V, vpo));
                             }
                             leds.set(
                                 0,
@@ -364,11 +367,25 @@ pub async fn run(
                             );
 
                             let reg_old = storage.query(|s| s.register_pitch);
+                            let reg_len_old = storage.query(|s| s.register_length);
                             if recall_flag.get() {
                                 register_pitch = reg_old;
+                                register_length = reg_len_old;
+                                euclid_length = attenuate(
+                                    length_register_scaled(register_length, beat_reg_length),
+                                    storage.query(|s| s.length_att),
+                                )
+                                .max(1) as u8;
+                                euclid_len_glob.set(euclid_length);
                                 recall_flag.set(false);
-                            } else if register_pitch != reg_old {
-                                storage.modify_and_save(|s| s.register_pitch = register_pitch);
+                            } else {
+                                if register_pitch != reg_old {
+                                    storage.modify_and_save(|s| s.register_pitch = register_pitch);
+                                }
+                                if register_length != reg_len_old {
+                                    storage
+                                        .modify_and_save(|s| s.register_length = register_length);
+                                }
                             }
 
                             // Derive legato/accent registers from XOR of both TMs
@@ -383,7 +400,7 @@ pub async fn run(
                         let is_legato =
                             scale_to_12bit(legato_register, 16) < storage.query(|s| s.legato_att);
                         let is_accented = scale_to_12bit(accent_register, 16)
-                            < storage.query(|s| s.accent_att);
+                            < Curve::Exponential.at(storage.query(|s| s.accent_att));
 
                         let is_beat =
                             euclidean_at(euclid_length, euclid_beat, 0, clkn_euclid as u32);
@@ -598,14 +615,33 @@ pub async fn run(
                 leds.unset(2, Led::Top);
                 leds.unset(0, Led::Bottom);
                 leds.unset(1, Led::Bottom);
+                leds.unset(2, Led::Bottom);
             }
             was_overlay = is_overlay;
 
             match layer {
                 LatchLayer::Main => {
                     // Btn0/Btn1: brighter when held (mutating)
-                    leds.set(0, Led::Button, led_color, if btn0 { Brightness::High } else { Brightness::Low });
-                    leds.set(1, Led::Button, led_color, if btn1 { Brightness::High } else { Brightness::Low });
+                    leds.set(
+                        0,
+                        Led::Button,
+                        led_color,
+                        if btn0 {
+                            Brightness::High
+                        } else {
+                            Brightness::Low
+                        },
+                    );
+                    leds.set(
+                        1,
+                        Led::Button,
+                        led_color,
+                        if btn1 {
+                            Brightness::High
+                        } else {
+                            Brightness::Low
+                        },
+                    );
                     // Btn2: mute indicator — dim when active, off when muted
                     if muted {
                         leds.unset(2, Led::Button);
@@ -621,13 +657,35 @@ pub async fn run(
                     let len_len = storage.query(|s| s.length_tm_length).max(1) as u32;
                     let p1 = (255u32.saturating_sub(len_step * 255 / len_len)) as u8;
                     leds.set(1, Led::Bottom, led_color, Brightness::Custom(p1));
+                    let e_step = euclid_step_glob.get() as u32;
+                    let e_len = euclid_len_glob.get().max(1) as u32;
+                    let p2 = (255u32.saturating_sub(e_step * 255 / e_len)) as u8;
+                    leds.set(2, Led::Bottom, led_color, Brightness::Custom(p2));
                 }
                 LatchLayer::Alt => {
                     // Button LEDs: stored length by default; switch to live count once tapping starts
-                    let pitch_disp = if pitch_len_count > 0 { pitch_len_count } else { storage.query(|s| s.pitch_tm_length) };
-                    let len_disp = if length_len_count > 0 { length_len_count } else { storage.query(|s| s.length_tm_length) };
-                    leds.set(0, Led::Button, Color::White, Brightness::Custom((pitch_disp as u16 * 16).min(255) as u8));
-                    leds.set(1, Led::Button, Color::Green, Brightness::Custom((len_disp as u16 * 16).min(255) as u8));
+                    let pitch_disp = if pitch_len_count > 0 {
+                        pitch_len_count
+                    } else {
+                        storage.query(|s| s.pitch_tm_length)
+                    };
+                    let len_disp = if length_len_count > 0 {
+                        length_len_count
+                    } else {
+                        storage.query(|s| s.length_tm_length)
+                    };
+                    leds.set(
+                        0,
+                        Led::Button,
+                        Color::White,
+                        Brightness::Custom((pitch_disp as u16 * 16).min(255) as u8),
+                    );
+                    leds.set(
+                        1,
+                        Led::Button,
+                        Color::Green,
+                        Brightness::Custom((len_disp as u16 * 16).min(255) as u8),
+                    );
                     if muted {
                         leds.unset(2, Led::Button);
                     } else {
@@ -656,8 +714,26 @@ pub async fn run(
                     );
                 }
                 LatchLayer::Third => {
-                    leds.set(0, Led::Button, led_color, if btn0 { Brightness::High } else { Brightness::Low });
-                    leds.set(1, Led::Button, led_color, if btn1 { Brightness::High } else { Brightness::Low });
+                    leds.set(
+                        0,
+                        Led::Button,
+                        led_color,
+                        if btn0 {
+                            Brightness::High
+                        } else {
+                            Brightness::Low
+                        },
+                    );
+                    leds.set(
+                        1,
+                        Led::Button,
+                        led_color,
+                        if btn1 {
+                            Brightness::High
+                        } else {
+                            Brightness::Low
+                        },
+                    );
                     leds.set(2, Led::Button, led_color, Brightness::High);
                     let oct_idx = (storage.query(|s| s.octave_shift) / 819).min(4) as usize;
                     leds.set(1, Led::Bottom, OCT_COLORS[oct_idx], Brightness::High);

--- a/faderpunk/src/apps/genseq.rs
+++ b/faderpunk/src/apps/genseq.rs
@@ -21,7 +21,7 @@ use crate::app::{
 };
 
 pub const CHANNELS: usize = 3;
-pub const PARAMS: usize = 4;
+pub const PARAMS: usize = 6;
 
 /// LED colors for the 5 octave shift steps -2..+2 (F1 Third layer)
 const OCT_COLORS: [Color; 5] = [
@@ -53,13 +53,19 @@ pub static CONFIG: Config<PARAMS> = Config::new(
         Color::Yellow,
     ],
 })
-.add_param(Param::MidiOut);
+.add_param(Param::MidiOut)
+.add_param(Param::VoltPerOct)
+.add_param(Param::bool {
+    name: "Bypass quantizer",
+});
 
 pub struct Params {
     midi_channel: MidiChannel,
     note: MidiNote,
     color: Color,
     midi_out: MidiOut,
+    vpo: VoltPerOct,
+    bypass: bool,
 }
 
 impl Default for Params {
@@ -69,6 +75,8 @@ impl Default for Params {
             note: MidiNote::from(36),
             color: Color::Blue,
             midi_out: MidiOut::default(),
+            vpo: VoltPerOct::Standard,
+            bypass: false,
         }
     }
 }
@@ -83,6 +91,8 @@ impl AppParams for Params {
             note: MidiNote::from_value(values[1]),
             color: Color::from_value(values[2]),
             midi_out: MidiOut::from_value(values[3]),
+            vpo: VoltPerOct::from_value(values[4]),
+            bypass: bool::from_value(values[5]),
         })
     }
 
@@ -92,6 +102,8 @@ impl AppParams for Params {
         vec.push(self.note.into()).unwrap();
         vec.push(self.color.into()).unwrap();
         vec.push(self.midi_out.into()).unwrap();
+        vec.push(self.vpo.into()).unwrap();
+        vec.push(self.bypass.into()).unwrap();
         vec
     }
 }
@@ -183,15 +195,15 @@ pub async fn run(
     params: &ParamStore<Params>,
     storage: &ManagedStorage<Storage>,
 ) {
-    let (led_color, midi_chan, base_note, midi_out) =
-        params.query(|p| (p.color, p.midi_channel, p.note, p.midi_out));
+    let (led_color, midi_chan, base_note, midi_out, vpo, bypass) =
+        params.query(|p| (p.color, p.midi_channel, p.note, p.midi_out, p.vpo, p.bypass));
 
     let buttons = app.use_buttons();
     let fader = app.use_faders();
     let leds = app.use_leds();
     let mut clock = app.use_clock();
     let die = app.use_die();
-    let quantizer = app.use_quantizer(Range::_0_10V, VoltPerOct::Standard, false);
+    let quantizer = app.use_quantizer(Range::_0_10V, vpo, bypass);
     let midi = app.use_midi_output(midi_out, midi_chan, false);
 
     let prob_pitch_glob = app.make_global(0u16);
@@ -301,11 +313,9 @@ pub async fn run(
                             // When shifting down, raise the quantizer input floor so the
                             // bottom of the pitch range maps to C0 rather than clipping
                             // negative DAC values to 0V.
-                            let input_floor: u16 = match (-octave_offset).max(0) {
-                                1 => 410, // C1 in 0–10 V counts
-                                2 => 819, // C2 in 0–10 V counts
-                                _ => 0,
-                            };
+                            let input_floor =
+                                ((-octave_offset).max(0) as u16)
+                                    .saturating_mul(vpo.counts_per_oct() as u16);
                             let quantizer_input =
                                 (att_reg as u32 / 2 + input_floor as u32).min(4095) as u16;
                             let out = quantizer.get_quantized_note(quantizer_input).await;
@@ -328,7 +338,7 @@ pub async fn run(
 
                             if !glob_muted.get() {
                                 cv_out.set_value(
-                                    shifted.as_counts(Range::_0_10V, VoltPerOct::Standard),
+                                    shifted.as_counts(Range::_0_10V, vpo),
                                 );
                             }
                             leds.set(

--- a/faderpunk/src/apps/genseq.rs
+++ b/faderpunk/src/apps/genseq.rs
@@ -291,8 +291,9 @@ pub async fn run(
                                 rotate_select_bit(register_pitch, prob_pitch, rand, length).0;
 
                             let register_scaled = scale_to_12bit(register_pitch, length as u8);
-                            let att_reg =
-                                attenuate(register_scaled, storage.query(|s| s.pitch_att));
+                            let raw_att = storage.query(|s| s.pitch_att);
+                            let curved_att = (raw_att as u32 * 4095).isqrt() as u16;
+                            let att_reg = attenuate(register_scaled, curved_att);
                             let out = quantizer.get_quantized_note(att_reg / 2).await;
 
                             let octave_offset =

--- a/faderpunk/src/apps/genseq.rs
+++ b/faderpunk/src/apps/genseq.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use libfp::{
     ext::FromValue,
     latch::LatchLayer,
+    quantizer::Pitch,
     utils::{attenuate, euclidean_at, rotate_select_bit, scale_to_12bit},
     AppIcon, Brightness, ClockDivision, Color, Config, MidiChannel, MidiNote, MidiOut, Param,
     Range, Value, VoltPerOct, APP_MAX_PARAMS,
@@ -294,24 +295,41 @@ pub async fn run(
                             let raw_att = storage.query(|s| s.pitch_att);
                             let curved_att = (raw_att as u32 * 4095).isqrt() as u16;
                             let att_reg = attenuate(register_scaled, curved_att);
-                            let out = quantizer.get_quantized_note(att_reg / 2).await;
-
                             let octave_offset =
                                 (storage.query(|s| s.octave_shift) / 819).min(4) as i32 - 2;
+
+                            // When shifting down, raise the quantizer input floor so the
+                            // bottom of the pitch range maps to C0 rather than clipping
+                            // negative DAC values to 0V.
+                            let input_floor: u16 = match (-octave_offset).max(0) {
+                                1 => 410, // C1 in 0–10 V counts
+                                2 => 819, // C2 in 0–10 V counts
+                                _ => 0,
+                            };
+                            let quantizer_input =
+                                (att_reg as u32 / 2 + input_floor as u32).min(4095) as u16;
+                            let out = quantizer.get_quantized_note(quantizer_input).await;
+
+                            // Apply the octave shift in pitch space to avoid the ±1 count
+                            // rounding error from the integer counts_per_oct approximation.
+                            let shifted = Pitch {
+                                octave: (out.octave as i32 + octave_offset) as i8,
+                                note: out.note,
+                                raw: None,
+                            };
+
                             let base_note_i = u7::from(base_note).as_int() as i32;
-                            let out_note_i = u7::from(out.as_midi()).as_int() as i32;
+                            let shifted_midi_val =
+                                u7::from(shifted.as_midi()).as_int() as i32;
                             let note = MidiNote::from(
-                                (base_note_i + out_note_i - 12 + octave_offset * 12)
-                                    .clamp(0, 127),
+                                (base_note_i + shifted_midi_val - 12).clamp(0, 127),
                             );
                             midi_note.set(note);
 
                             if !glob_muted.get() {
-                                let cv_val = (out.as_counts(Range::_0_10V, VoltPerOct::Standard)
-                                    as i32
-                                    + octave_offset * 410)
-                                    .clamp(0, 4095) as u16;
-                                cv_out.set_value(cv_val);
+                                cv_out.set_value(
+                                    shifted.as_counts(Range::_0_10V, VoltPerOct::Standard),
+                                );
                             }
                             leds.set(
                                 0,

--- a/faderpunk/src/apps/mod.rs
+++ b/faderpunk/src/apps/mod.rs
@@ -24,4 +24,5 @@ register_apps!(
     23 => fp_grids,
     24 => tb3po,
     25 => automator,
+    26 => genseq,
 );

--- a/faderpunk/src/apps/turing.rs
+++ b/faderpunk/src/apps/turing.rs
@@ -11,9 +11,11 @@ use heapless::Vec;
 use serde::{Deserialize, Serialize};
 
 use libfp::{
-    ext::FromValue, latch::LatchLayer, AppIcon, Brightness, ClockDivision, Color, Config, Curve,
-    MidiCc, MidiChannel, MidiMode, MidiNote, MidiOut, Param, Range, Value, VoltPerOct,
-    APP_MAX_PARAMS,
+    ext::FromValue,
+    latch::LatchLayer,
+    utils::{rotate_select_bit, scale_to_12bit},
+    AppIcon, Brightness, ClockDivision, Color, Config, Curve, MidiCc, MidiChannel, MidiMode,
+    MidiNote, MidiOut, Param, Range, Value, VoltPerOct, APP_MAX_PARAMS,
 };
 
 use crate::app::{
@@ -558,36 +560,3 @@ pub async fn run(
     join(join5(fut1, fut2, fut3, fut4, scene_handler), fut_long_press).await;
 }
 
-fn rotate_select_bit(x: u16, a: u16, b: u16, bit_index: u16) -> (u16, bool, bool) {
-    let bit_index = (16 - bit_index).clamp(0, 16);
-
-    // Extract the original bit
-    let original_bit = ((x >> bit_index) & 1) as u8;
-    let mut bit = original_bit;
-
-    // Invert the bit if a > b
-    if a > b {
-        bit ^= 1;
-    }
-
-    // Shift x right by 1
-    let shifted = x >> 1;
-
-    // Insert the (possibly inverted) bit into the MSB
-    let result = shifted | ((bit as u16) << 15);
-
-    // Return the new value, whether the bit was flipped, and the output bit
-    let flipped = bit != original_bit;
-    (result, flipped, bit != 0)
-}
-
-fn scale_to_12bit(input: u16, x: u8) -> u16 {
-    let x = x.clamp(1, 16);
-
-    // Shift to keep the top `x` bits
-    let top_x_bits = input >> (16 - x);
-
-    // Scale to 12-bit
-    let max_x_val = (1 << x) - 1;
-    ((top_x_bits as u32 * 4095) / max_x_val as u32) as u16
-}

--- a/libfp/src/utils.rs
+++ b/libfp/src/utils.rs
@@ -214,6 +214,31 @@ pub fn euclidean_at(num_steps: u8, num_beats: u8, rotation: u8, clock: u32) -> b
     (pattern & (1 << pos)) != 0
 }
 
+/// Scale the top `x` bits of a 16-bit shift register (`x` in 1..=16) to a 12-bit value
+/// (`0..=4095`). Used by the Turing-machine apps to turn register state into a CV/level.
+pub fn scale_to_12bit(input: u16, x: u8) -> u16 {
+    let x = x.clamp(1, 16);
+    let top_x_bits = input >> (16 - x);
+    let max_x_val = (1u32 << x) - 1;
+    ((top_x_bits as u32 * 4095) / max_x_val) as u16
+}
+
+/// Turing-machine shift-register step. Rotates `x` right by one bit, re-injecting the
+/// looped bit at the MSB. The looped bit is read from the bottom of the active
+/// `length`-bit window (`length` in 1..=16) so the pattern repeats with period `length`;
+/// when `a > b` the bit is inverted (the probabilistic mutation).
+/// Returns `(new_register, was_flipped, output_bit)`.
+pub fn rotate_select_bit(x: u16, a: u16, b: u16, length: u16) -> (u16, bool, bool) {
+    let bit_index = (16 - length).clamp(0, 16);
+    let original_bit = ((x >> bit_index) & 1) as u8;
+    let mut bit = original_bit;
+    if a > b {
+        bit ^= 1;
+    }
+    let result = (x >> 1) | ((bit as u16) << 15);
+    (result, bit != original_bit, bit != 0)
+}
+
 /// RC-filter coefficient for an exponential approach with the given `tau` (in ticks).
 /// `tau <= 0` returns 1.0 (instant). Apply each tick: `current += (target - current) * coeff`.
 pub fn rc_coeff(tau: f32) -> f32 {
@@ -271,6 +296,42 @@ pub fn interp_loop_sample(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn scale_to_12bit_full_window() {
+        assert_eq!(scale_to_12bit(0, 16), 0);
+        assert_eq!(scale_to_12bit(0xFFFF, 16), 4095);
+        assert_eq!(scale_to_12bit(0x8000, 1), 4095);
+        assert_eq!(scale_to_12bit(0, 1), 0);
+    }
+
+    #[test]
+    fn rotate_select_bit_no_flip_loops_with_period_length() {
+        // With a > b == false, the register must repeat exactly every `length` steps:
+        // the looped bit is the bottom of the top-`length` window.
+        for length in 1..=16u16 {
+            let start = 0xACE5u16;
+            let mut reg = start;
+            for _ in 0..length {
+                (reg, _, _) = rotate_select_bit(reg, 0, 1, length);
+            }
+            let mask = if length == 16 {
+                0xFFFF
+            } else {
+                ((1u32 << length) - 1) as u16
+            } << (16 - length);
+            assert_eq!(reg & mask, start & mask, "length {length} did not loop");
+        }
+    }
+
+    #[test]
+    fn rotate_select_bit_flips_when_a_gt_b() {
+        let (_, flipped, _) = rotate_select_bit(0x0000, 1, 0, 16);
+        assert!(flipped);
+        let (result, _, out_bit) = rotate_select_bit(0x0000, 1, 0, 16);
+        assert_eq!(result, 0x8000);
+        assert!(out_bit);
+    }
 
     #[test]
     fn interp_midpoint() {


### PR DESCRIPTION
## Summary

- Adds **GenSeq** (app slot 26), a generative melodic sequencer built around two Turing machine shift registers
- Pitch register → quantized pitch CV; length register → Euclidean pattern length; beat density fader → gate density
- Legato and accent derived deterministically from XOR of both registers (no 3rd TM), rotating every euclidean step with threshold-based detection
- Mute on Button 3 (gate stops, CV holds); bypass mode when length register width = 1 (Fader 2 directly controls phrase length)
- Shift+Button counting to set TM register widths (1–16) for both pitch and length registers
- Full manual entry in ManualTab.tsx and GenSeq added to the mute list in Apps.tsx

## Key design decisions

- Legato/accent use `pitch XOR length` and `pitch XOR length.rotate_right(8)` — same two seeds produce identical slide/accent patterns, fully deterministic
- Length register width = 1 bypasses generative variation on phrase length, turning Fader 2 into a direct length control
- Resolution LED feedback matches other apps: Ch 1 Bottom flashes orange (straight) / blue (triplet) while Button 1 is held

## Shared-util refactor + clkturing bugfix

Factored the Turing/Euclidean helpers GenSeq was carrying locally into `libfp::utils` and deduplicated the other Turing apps against them:

- Added `scale_to_12bit` and `rotate_select_bit` to `libfp::utils` (the latter unified on the correct `16 - length` window, returning `(new_register, was_flipped, output_bit)`); added unit tests, incl. one asserting the period-`length` loop invariant.
- GenSeq now uses `libfp::utils::{euclidean_at, scale_to_12bit, rotate_select_bit}` and drops its local `rotl32`/`euclidean_pattern`/`euclidean_filter`/`scale_to_12bit`/`rotate_select_bit`.
- `turing` and `clkturing` drop their duplicate copies and use the shared ones. Net −110 lines.
- **Bugfix (clkturing):** its local `rotate_select_bit` read the feedback bit at `15 - length` (one bit below the value window) instead of `16 - length`. Switching to the shared function corrects this, so its register now loops cleanly with period `length`, matching `turing`/`genseq`. **This changes clkturing's generated sequences** — behavioral fix, verify on hardware.

### Test plan (changed apps)

clkturing (Turing+) — behavior changed, check most carefully:
- [ ] Sequences loop cleanly with the expected period at each register length (1–16)
- [ ] Length control still spans 1–16 as before; mute, gate threshold mode, and quantized output unaffected

turing — behavior should be unchanged:
- [ ] Register loop, gate output (uses the looped output bit), and length control behave exactly as before the refactor

genseq — behavior should be unchanged:
- [ ] Pitch/length registers, Euclidean gate density, and bypass mode (length width = 1) behave exactly as before

## Test plan

- [ ] Verify pitch CV tracks the system quantizer scale and root
- [ ] Confirm gate fires at the correct euclidean density (Fader 3)
- [ ] Confirm phrase length evolves with Fader 2 and locks when Button 2 is released
- [ ] Test mute: gate closes, CV holds, Button 3 LED turns off
- [ ] Test bypass mode: Shift+Button 2 → 1 press → commit; Fader 2 directly controls phrase length
- [ ] Test Shift+Button counting for both registers up to 16; verify LED brightens with count
- [ ] Test scene recall: melody re-enters at next phrase boundary
- [ ] Verify resolution flash on Ch 1 Bottom while Button 1 held (orange = straight, blue = triplet)
