### PR TITLE
feat(seq8): sequencer improvements — slide, probability, direction

### DIFF
--- a/configurator/src/components/ManualTab.tsx
+++ b/configurator/src/components/ManualTab.tsx
@@ -181,22 +181,33 @@ const apps: ManualAppData[] = [
       "MIDI Channel 2",
       "MIDI Channel 3",
       "MIDI Channel 4",
+      "MIDI Out",
+      "Track 2: velocity lane",
+      "Track 4: velocity lane",
+      "Transpose MIDI In",
+      "Track 1: transpose CH",
+      "Track 2: transpose CH",
+      "Track 3: transpose CH",
+      "Track 4: transpose CH",
     ],
     storage: [
       "Sequences (Gate/CV)",
       "Legato",
       "Sequence lengths",
-      "Sequence resolution",
       "Gate lengths",
-      "Ranges",
       "Octaves",
+      "Ranges",
+      "Sequence resolutions",
+      "Directions",
+      "Probabilities",
+      "Slide times",
     ],
-    text: "4x16 step sequencer app featuring four independent sequencers, each represented by a distinct color. Each sequencer has two pages, and you can navigate between them using Shift + Buttons. The CV/Gate outputs are paired per sequencer: jacks 1&2 for sequencer 1, 3&4 for sequencer 2, and so on. MIDI channels for each sequencer can be set individually in the parameters. Faders are used to set note values, buttons define the gate pattern, and long button presses enable legato. Shift modifies settings for the selected sequencer: Shift + Fader 1 sets step length, Fader 2 sets gate length, Fader 3 selects octave, Fader 4 defines the sequence range (1–5 octaves), and Fader 5 sets the sequence resolution (32ndT, 32nd, 16thT, 16th, 8thT, 8th, 4thT, 4th). In Shift mode, resolution type is color-coded on sequence LEDs: orange for triplet divisions and blue for straight divisions. Buttons are used to select pages, with two pages available per sequencer. The output of each sequencer is quantized to the scale set in the global quantizer.",
+    text: "4x16 step sequencer app featuring four independent sequencers, each represented by a distinct color. Each sequencer has two pages, navigated with **Shift + Buttons**. CV/Gate outputs are paired per sequencer: jacks 1&2 for sequencer 1, 3&4 for sequencer 2, 5&6 for sequencer 3, and 7&8 for sequencer 4. Faders set note values, buttons define the gate pattern, and **long button presses** enable legato between steps. CV output is quantized to the scale set in the global quantizer.\n\n#### Shift mode\n\nWith Shift held, all 8 faders control settings for the currently selected sequencer:\n\n- **Fader 1** — step length (1–16 steps)\n- **Fader 2** — gate length\n- **Fader 3** — octave offset (0–5 octaves)\n- **Fader 4** — sequence range (1–5 octaves)\n- **Fader 5** — clock resolution (32ndT, 32nd, 16thT, 16th, 8thT, 8th, 4thT, 4th)\n- **Fader 6** — direction (Forward / Backward / Ping-Pong / Random)\n- **Fader 7** — trigger probability (5%–100%)\n- **Fader 8** — 303-style slide time (0 = instant)\n\nTop LEDs show sequence length. Resolution LED color: **orange** = triplet division, **blue** = straight division.\n\n#### MIDI transposition\n\nEach track can be live-transposed via incoming MIDI. Assign a dedicated transpose MIDI channel per track in the parameters. Receiving a NoteOn on that channel shifts the track's output relative to **C4** — middle C = no change, notes above/below transpose up/down by semitones. Transposition applies to both CV and MIDI output.\n\n#### Velocity lane mode (tracks 2 and 4)\n\nWhen enabled, a track acts as a velocity lane for its paired primary track (track 2 → track 1, track 4 → track 3):\n\n- **Fader** — controls the MIDI velocity sent to the paired track, not a note value\n- **CV output** — unquantized voltage proportional to fader position (0–10V)\n- **Gate button** — controls whether velocity advances on that step (on) or holds the previous value (off)\n- MIDI notes are suppressed on the velocity lane track itself",
     channels: [
       {
         jackTitle: "CV Output",
-        jackDescription: "Quantized output",
-        faderTitle: "Note",
+        jackDescription: "Quantized note output",
+        faderTitle: "Note / Velocity",
         faderDescription: "Sets the note at this step",
         faderPlusShiftTitle: "Sequence length",
         faderPlusShiftDescription:
@@ -212,8 +223,8 @@ const apps: ManualAppData[] = [
       },
       {
         jackTitle: "Gate Output",
-        jackDescription: "Quantized output",
-        faderTitle: "Note",
+        jackDescription: "Gate output",
+        faderTitle: "Note / Velocity",
         faderDescription: "Sets the note at this step",
         faderPlusShiftTitle: "Gate length",
         fnTitle: "Gate/Legato",
@@ -227,11 +238,13 @@ const apps: ManualAppData[] = [
       },
       {
         jackTitle: "CV Output",
-        jackDescription: "Quantized output",
-        faderTitle: "Note",
-        faderDescription: "Sets the note at this step",
+        jackDescription:
+          "Quantized note output, or unquantized velocity CV when velocity lane is enabled",
+        faderTitle: "Note / Velocity",
+        faderDescription:
+          "Sets the note at this step, or velocity level when velocity lane is enabled",
         faderPlusShiftTitle: "Octave",
-        faderPlusShiftDescription: "offset the whole sequence by 0-5 Octaves",
+        faderPlusShiftDescription: "Offset the whole sequence by 0–5 octaves",
         fnTitle: "Gate/Legato",
         fnDescription:
           "Short press sets a gate or rest, long press sets a legato",
@@ -243,11 +256,12 @@ const apps: ManualAppData[] = [
       },
       {
         jackTitle: "Gate Output",
-        jackDescription: "Quantized output",
-        faderTitle: "Note",
-        faderDescription: "Sets the note at this step",
+        jackDescription: "Gate output",
+        faderTitle: "Note / Velocity",
+        faderDescription:
+          "Sets the note at this step, or velocity level when velocity lane is enabled",
         faderPlusShiftTitle: "Sequence Range",
-        faderPlusShiftDescription: "set sequence range (1-5 octave)",
+        faderPlusShiftDescription: "Set sequence range (1–5 octaves)",
         fnTitle: "Gate/Legato",
         fnDescription:
           "Short press sets a gate or rest, long press sets a legato",
@@ -259,12 +273,12 @@ const apps: ManualAppData[] = [
       },
       {
         jackTitle: "CV Output",
-        jackDescription: "Quantized output",
-        faderTitle: "Note",
+        jackDescription: "Quantized note output",
+        faderTitle: "Note / Velocity",
         faderDescription: "Sets the note at this step",
-        faderPlusShiftTitle: "Sequence speed",
+        faderPlusShiftTitle: "Sequence resolution",
         faderPlusShiftDescription:
-          "Set sequence resolution  32ndT, 32nd, 16thT, 16th, 8thT, 8th, 4thT, 4th",
+          "Set sequence resolution: 32ndT, 32nd, 16thT, 16th, 8thT, 8th, 4thT, 4th",
         fnTitle: "Gate/Legato",
         fnDescription:
           "Short press sets a gate or rest, long press sets a legato",
@@ -276,10 +290,12 @@ const apps: ManualAppData[] = [
       },
       {
         jackTitle: "Gate Output",
-        jackDescription: "Quantized output",
-        faderTitle: "Note",
+        jackDescription: "Gate output",
+        faderTitle: "Note / Velocity",
         faderDescription: "Sets the note at this step",
-
+        faderPlusShiftTitle: "Direction",
+        faderPlusShiftDescription:
+          "Set sequence direction: Forward, Backward, Ping-Pong, or Random",
         fnTitle: "Gate/Legato",
         fnDescription:
           "Short press sets a gate or rest, long press sets a legato",
@@ -291,9 +307,14 @@ const apps: ManualAppData[] = [
       },
       {
         jackTitle: "CV Output",
-        jackDescription: "Quantized output",
-        faderTitle: "Note",
-        faderDescription: "Sets the note at this step",
+        jackDescription:
+          "Quantized note output, or unquantized velocity CV when velocity lane is enabled",
+        faderTitle: "Note / Velocity",
+        faderDescription:
+          "Sets the note at this step, or velocity level when velocity lane is enabled",
+        faderPlusShiftTitle: "Probability",
+        faderPlusShiftDescription:
+          "Set trigger probability for this sequencer (5%–100%)",
         fnTitle: "Gate/Legato",
         fnDescription:
           "Short press sets a gate or rest, long press sets a legato",
@@ -305,9 +326,13 @@ const apps: ManualAppData[] = [
       },
       {
         jackTitle: "Gate Output",
-        jackDescription: "Quantized output",
-        faderTitle: "Note",
-        faderDescription: "Sets the note at this step",
+        jackDescription: "Gate output",
+        faderTitle: "Note / Velocity",
+        faderDescription:
+          "Sets the note at this step, or velocity level when velocity lane is enabled",
+        faderPlusShiftTitle: "Slide time",
+        faderPlusShiftDescription:
+          "Set 303-style portamento slide time (0 = instant)",
         fnTitle: "Gate/Legato",
         fnDescription:
           "Short press sets a gate or rest, long press sets a legato",

--- a/faderpunk/src/apps/midi2cv.rs
+++ b/faderpunk/src/apps/midi2cv.rs
@@ -5,14 +5,15 @@ use embassy_futures::{
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use heapless::Vec;
 
-use libm::expf;
 use midly::{num::u7, MidiMessage};
 use serde::{Deserialize, Serialize};
 
 use libfp::{
     ext::FromValue,
     latch::LatchLayer,
-    utils::{bits_7_16, clickless, scale_bits_14_12, scale_bits_7_12},
+    utils::{
+        apply_slide, bits_7_16, clickless, fader_to_slide_coeff, scale_bits_14_12, scale_bits_7_12,
+    },
     AppIcon, Brightness, Color, Config, Curve, MidiCc, MidiChannel, MidiIn, MidiNote, Param, Range,
     Value, APP_MAX_PARAMS,
 };
@@ -162,26 +163,6 @@ pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMut
     select(app_loop, app.exit_handler(exit_signal)).await;
 }
 
-/// RC filter glide calculation.
-/// Returns the coefficient for exponential approach based on glide time.
-/// At glide=0, returns 1.0 (instant). At glide=100, returns a small value for slow glide.
-fn calc_glide_coeff(glide: i32) -> f32 {
-    if glide == 0 {
-        1.0
-    } else {
-        // RC time constant: larger glide value = slower approach
-        // With 1ms tick rate, we need coefficients that give ~150ms settling
-        // coeff = 1 - e^(-1/tau) where tau is in ticks
-        let tau = 1.0 + (glide as f32 * 0.5);
-        1.0 - expf(-1.0 / tau)
-    }
-}
-
-/// Apply RC filter glide: moves current toward target exponentially
-fn apply_glide(current: f32, target: f32, coeff: f32) -> f32 {
-    current + (target - current) * coeff
-}
-
 pub async fn run(
     app: &App<CHANNELS>,
     params: &ParamStore<Params>,
@@ -208,9 +189,7 @@ pub async fn run(
     let offset_glob = app.make_global(0);
     let pitch_glob = app.make_global(0);
     let glide_active_glob = app.make_global(false);
-    let glide_coeff_glob = app.make_global(calc_glide_coeff(
-        storage.query(|s| s.alt_layer_val) as i32 * 100 / 4095,
-    ));
+    let glide_coeff_glob = app.make_global(fader_to_slide_coeff(storage.query(|s| s.alt_layer_val)));
     let buttons = app.use_buttons();
     let fader = app.use_faders();
     let leds = app.use_leds();
@@ -316,7 +295,7 @@ pub async fn run(
                     let glide_coeff = glide_coeff_glob.get();
 
                     if glide_active_glob.get() {
-                        glide_current = apply_glide(glide_current, pitch_target, glide_coeff);
+                        glide_current = apply_slide(glide_current, pitch_target, glide_coeff);
                     } else {
                         glide_current = pitch_target;
                     }
@@ -404,8 +383,7 @@ pub async fn run(
                     LatchLayer::Alt => {
                         storage.modify_and_save(|s| s.alt_layer_val = new_value);
                         if mode == 1 {
-                            let glide = new_value as i32 * 100 / 4095;
-                            glide_coeff_glob.set(calc_glide_coeff(glide));
+                            glide_coeff_glob.set(fader_to_slide_coeff(new_value));
                         }
                     }
                     LatchLayer::Third => {}

--- a/faderpunk/src/apps/seq8.rs
+++ b/faderpunk/src/apps/seq8.rs
@@ -343,6 +343,9 @@ pub async fn run(
     // Was the just-played step a legato step? Drives whether to slide into the next.
     let mut prev_step_legato = [false; 4];
     let mut gatelength1 = gatelength_glob.get();
+    // Persistent velocity from velocity-lane tracks. Held across ticks so primary
+    // tracks 1/3 keep the last value when paired lane 2/4 doesn't fire or rests.
+    let mut vel_source = [4095u16; 4];
 
     // Initialize latches for all 8 faders
     let mut latches: [libfp::latch::AnalogLatch; 8] =
@@ -629,10 +632,11 @@ pub async fn run(
                     let seq = seq_glob.get();
                     let direction = direction_glob.get();
                     let probability = probability_glob.get();
-                    // Reversed so velocity lane tracks (2, 4) run before their
-                    // paired primary tracks (1, 3) — vel_source is ready when needed.
+                    // Reversed so velocity lane tracks (2, 4) update vel_source
+                    // before their paired primary tracks (1, 3) consume it within
+                    // the same tick. vel_source itself is persistent — when a lane
+                    // track doesn't tick or rests, the last value carries over.
                     let transpo = transpo_glob.get();
-                    let mut vel_source = [4095u16; 4];
                     for n in (0..4).rev() {
                         if clockn.is_multiple_of(clockres[n]) {
                             let step = clockn / clockres[n];

--- a/faderpunk/src/apps/seq8.rs
+++ b/faderpunk/src/apps/seq8.rs
@@ -1,7 +1,8 @@
 use embassy_futures::{
     join::{join4, join5},
-    select::{select, select3},
+    select::{select, select3, select4, Either4},
 };
+use midly::MidiMessage;
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use heapless::Vec;
 use libm::expf;
@@ -9,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use libfp::{
     ext::FromValue, latch::LatchLayer, AppIcon, Brightness, ClockDivision, Color, Config,
-    MidiChannel, MidiNote, MidiOut, Param, Range, Value, APP_MAX_PARAMS,
+    MidiChannel, MidiIn, MidiNote, MidiOut, Param, Range, Value, APP_MAX_PARAMS,
 };
 
 use crate::app::{
@@ -18,7 +19,7 @@ use crate::app::{
 };
 
 pub const CHANNELS: usize = 8;
-pub const PARAMS: usize = 7;
+pub const PARAMS: usize = 12;
 
 pub static CONFIG: Config<PARAMS> = Config::new(
     "Sequencer",
@@ -40,8 +41,12 @@ pub static CONFIG: Config<PARAMS> = Config::new(
 })
 .add_param(Param::MidiOut)
 .add_param(Param::bool { name: "Track 2: velocity lane" })
-.add_param(Param::bool { name: "Track 4: velocity lane" });
-// TODO: add per-track MIDI transposition param (semitone offset applied to outgoing notes)
+.add_param(Param::bool { name: "Track 4: velocity lane" })
+.add_param(Param::MidiIn)
+.add_param(Param::MidiChannel { name: "Track 1: transpose CH" })
+.add_param(Param::MidiChannel { name: "Track 2: transpose CH" })
+.add_param(Param::MidiChannel { name: "Track 3: transpose CH" })
+.add_param(Param::MidiChannel { name: "Track 4: transpose CH" });
 
 pub struct Params {
     midi_channel1: MidiChannel,
@@ -51,6 +56,11 @@ pub struct Params {
     midi_out: MidiOut,
     vel_lane_2: bool,
     vel_lane_4: bool,
+    transpose_midi_in: MidiIn,
+    transpose_ch1: MidiChannel,
+    transpose_ch2: MidiChannel,
+    transpose_ch3: MidiChannel,
+    transpose_ch4: MidiChannel,
 }
 
 impl AppParams for Params {
@@ -66,6 +76,11 @@ impl AppParams for Params {
             midi_out: MidiOut::from_value(values[4]),
             vel_lane_2: bool::from_value(values[5]),
             vel_lane_4: bool::from_value(values[6]),
+            transpose_midi_in: MidiIn::from_value(values[7]),
+            transpose_ch1: MidiChannel::from_value(values[8]),
+            transpose_ch2: MidiChannel::from_value(values[9]),
+            transpose_ch3: MidiChannel::from_value(values[10]),
+            transpose_ch4: MidiChannel::from_value(values[11]),
         })
     }
 
@@ -78,6 +93,11 @@ impl AppParams for Params {
         vec.push(self.midi_out.into()).unwrap();
         vec.push(self.vel_lane_2.into()).unwrap();
         vec.push(self.vel_lane_4.into()).unwrap();
+        vec.push(self.transpose_midi_in.into()).unwrap();
+        vec.push(self.transpose_ch1.into()).unwrap();
+        vec.push(self.transpose_ch2.into()).unwrap();
+        vec.push(self.transpose_ch3.into()).unwrap();
+        vec.push(self.transpose_ch4.into()).unwrap();
         vec
     }
 }
@@ -212,6 +232,11 @@ pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMut
             midi_out: MidiOut::default(),
             vel_lane_2: false,
             vel_lane_4: false,
+            transpose_midi_in: MidiIn::default(),
+            transpose_ch1: MidiChannel::from(1),
+            transpose_ch2: MidiChannel::from(2),
+            transpose_ch3: MidiChannel::from(3),
+            transpose_ch4: MidiChannel::from(4),
         },
     );
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
@@ -239,18 +264,35 @@ pub async fn run(
     storage: &ManagedStorage<Storage>,
 ) {
     let range = Range::_0_10V;
-    let (midi_out, midi_chan1, midi_chan2, midi_chan3, midi_chan4, vel_lane_2, vel_lane_4) =
-        params.query(|p| {
-            (
-                p.midi_out,
-                p.midi_channel1,
-                p.midi_channel2,
-                p.midi_channel3,
-                p.midi_channel4,
-                p.vel_lane_2,
-                p.vel_lane_4,
-            )
-        });
+    let (
+        midi_out,
+        midi_chan1,
+        midi_chan2,
+        midi_chan3,
+        midi_chan4,
+        vel_lane_2,
+        vel_lane_4,
+        transpose_midi_in,
+        transpose_ch1,
+        transpose_ch2,
+        transpose_ch3,
+        transpose_ch4,
+    ) = params.query(|p| {
+        (
+            p.midi_out,
+            p.midi_channel1,
+            p.midi_channel2,
+            p.midi_channel3,
+            p.midi_channel4,
+            p.vel_lane_2,
+            p.vel_lane_4,
+            p.transpose_midi_in,
+            p.transpose_ch1,
+            p.transpose_ch2,
+            p.transpose_ch3,
+            p.transpose_ch4,
+        )
+    });
     let vel_lane = [false, vel_lane_2, false, vel_lane_4];
 
     let buttons = app.use_buttons();
@@ -303,6 +345,8 @@ pub async fn run(
     // Actual playing position per track (post direction). LED display reads this
     // so the highlighted step matches the audible step regardless of direction.
     let playing_pos_glob: Global<[usize; 4]> = app.make_global([0; 4]);
+    // Per-track semitone offset set by incoming MIDI (0 = no transpose).
+    let transpo_glob: Global<[i8; 4]> = app.make_global([0i8; 4]);
 
     let resolution = [24usize, 16, 12, 8, 6, 4, 3, 2];
 
@@ -599,6 +643,7 @@ pub async fn run(
                     let probability = probability_glob.get();
                     // Reversed so velocity lane tracks (2, 4) run before their
                     // paired primary tracks (1, 3) — vel_source is ready when needed.
+                    let transpo = transpo_glob.get();
                     let mut vel_source = [4095u16; 4];
                     for n in (0..4).rev() {
                         if clockn.is_multiple_of(clockres[n]) {
@@ -639,7 +684,8 @@ pub async fn run(
                                                 + (storage.query(|s| s.oct_fader[n]) / 1000) * 410,
                                         )
                                         .await;
-                                    lastnote[n] = out.as_midi();
+                                    let mut base = out.as_midi();
+                                    lastnote[n] = base.transpose(transpo[n]);
                                     let velocity = if n == 0 && vel_lane_2 {
                                         vel_source[1]
                                     } else if n == 2 && vel_lane_4 {
@@ -652,7 +698,9 @@ pub async fn run(
                                     // Hand the target CV to slide_handler; slide only if
                                     // the previously played step had legato enabled.
                                     let mut targets = target_cv_glob.get();
-                                    targets[n] = out.as_counts(range);
+                                    targets[n] = (out.as_counts(range) as i32
+                                        + transpo[n] as i32 * 410 / 12)
+                                        .clamp(0, 4095) as u16;
                                     target_cv_glob.set(targets);
                                     let mut slid = sliding_glob.get();
                                     slid[n] = prev_step_legato[n];
@@ -755,19 +803,62 @@ pub async fn run(
         }
     };
 
-    join4(
+    let midi_handler = async {
+        let mut mi1 = app.use_midi_input(transpose_midi_in, transpose_ch1);
+        let mut mi2 = app.use_midi_input(transpose_midi_in, transpose_ch2);
+        let mut mi3 = app.use_midi_input(transpose_midi_in, transpose_ch3);
+        let mut mi4 = app.use_midi_input(transpose_midi_in, transpose_ch4);
+        loop {
+            let (track, key) = match select4(
+                mi1.wait_for_message(),
+                mi2.wait_for_message(),
+                mi3.wait_for_message(),
+                mi4.wait_for_message(),
+            )
+            .await
+            {
+                Either4::First(MidiMessage::NoteOn { key, vel }) if vel > 0 => (0usize, key),
+                Either4::Second(MidiMessage::NoteOn { key, vel }) if vel > 0 => (1usize, key),
+                Either4::Third(MidiMessage::NoteOn { key, vel }) if vel > 0 => (2usize, key),
+                Either4::Fourth(MidiMessage::NoteOn { key, vel }) if vel > 0 => (3usize, key),
+                _ => continue,
+            };
+            let mut t = transpo_glob.get();
+            t[track] = key.as_int() as i8 - 60;
+            transpo_glob.set(t);
+        }
+    };
+
+    if transpose_midi_in.is_none() {
+        join4(
+            join5(
+                shift_handler,
+                fader_handler,
+                button_handler,
+                led_handler,
+                clock_handler,
+            ),
+            button_long_press_handler,
+            scene_handler,
+            slide_handler,
+        )
+        .await;
+    } else {
         join5(
-            shift_handler,
-            fader_handler,
-            button_handler,
-            led_handler,
-            clock_handler,
-        ),
-        button_long_press_handler,
-        scene_handler,
-        slide_handler,
-    )
-    .await;
+            join5(
+                shift_handler,
+                fader_handler,
+                button_handler,
+                led_handler,
+                clock_handler,
+            ),
+            button_long_press_handler,
+            scene_handler,
+            slide_handler,
+            midi_handler,
+        )
+        .await;
+    }
 }
 
 fn get_alt_target(chan: usize, seq_idx: usize, storage: &ManagedStorage<Storage>) -> u16 {

--- a/faderpunk/src/apps/seq8.rs
+++ b/faderpunk/src/apps/seq8.rs
@@ -103,15 +103,38 @@ impl Default for Storage {
 
 impl AppStorage for Storage {}
 
+/// Derives runtime parameters from stored fader values.
+fn derive_runtime_params(
+    length_faders: [u16; 4],
+    gate_faders: [u16; 4],
+    res_faders: [u16; 4],
+    resolution: &[usize; 8],
+) -> ([u8; 4], [usize; 4], [u8; 4]) {
+    let mut seq_length = [0u8; 4];
+    let mut clockres = [0usize; 4];
+    let mut gatel = [0u8; 4];
+    for n in 0..4 {
+        seq_length[n] = (length_faders[n] / 256 + 1) as u8;
+        clockres[n] = resolution[(res_faders[n] / 512) as usize];
+        gatel[n] = (clockres[n] * (gate_faders[n] as usize) / 4096) as u8;
+        gatel[n] = gatel[n].clamp(1, clockres[n] as u8 - 1);
+    }
+    (seq_length, clockres, gatel)
+}
+
 #[embassy_executor::task(pool_size = 16/CHANNELS)]
 pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMutex, bool>) {
-    let param_store = ParamStore::<Params>::new(app.app_id, app.layout_id, Params {
-        midi_channel1: MidiChannel::from(1),
-        midi_channel2: MidiChannel::from(2),
-        midi_channel3: MidiChannel::from(3),
-        midi_channel4: MidiChannel::from(4),
-        midi_out: MidiOut::default(),
-    });
+    let param_store = ParamStore::<Params>::new(
+        app.app_id,
+        app.layout_id,
+        Params {
+            midi_channel1: MidiChannel::from(1),
+            midi_channel2: MidiChannel::from(2),
+            midi_channel3: MidiChannel::from(3),
+            midi_channel4: MidiChannel::from(4),
+            midi_out: MidiOut::default(),
+        },
+    );
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
 
     param_store.load().await;
@@ -176,7 +199,6 @@ pub async fn run(
     let quantizer = app.use_quantizer(range);
 
     let page_glob: Global<usize> = app.make_global(0);
-    let led_flag_glob: Global<bool> = app.make_global(true);
     let latch_layer_glob: Global<LatchLayer> = app.make_global(LatchLayer::Main);
     let seq_glob: Global<[u16; 64]> = app.make_global([0; 64]);
     let gateseq_glob: Global<[bool; 64]> = app.make_global([true; 64]);
@@ -184,10 +206,9 @@ pub async fn run(
 
     let seq_length_glob: Global<[u8; 4]> = app.make_global([16; 4]);
     let gatelength_glob: Global<[u8; 4]> = app.make_global([128; 4]);
+    let clockres_glob = app.make_global([6usize; 4]);
 
-    let clockres_glob = app.make_global([6, 6, 6, 6]);
-
-    let resolution = [24, 16, 12, 8, 6, 4, 3, 2];
+    let resolution = [24usize, 16, 12, 8, 6, 4, 3, 2];
 
     let mut lastnote = [MidiNote::default(); 4];
     let mut gatelength1 = gatelength_glob.get();
@@ -222,23 +243,15 @@ pub async fn run(
     gateseq_glob.set(gateseq_saved.get());
     legatoseq_glob.set(legato_seq_saved.get());
 
-    // Derive runtime parameters from fader values
-    let mut seq_length_saved = [0u8; 4];
-    let mut clockres = [0usize; 4];
-    let mut gatel = [0u8; 4];
-    for n in 0..4 {
-        seq_length_saved[n] = (length_faders[n] / 256 + 1) as u8;
-        clockres[n] = resolution[(res_faders[n] / 512) as usize];
-        gatel[n] = (clockres[n] * (gate_faders[n] as usize) / 4096) as u8;
-        gatel[n] = gatel[n].clamp(1, clockres[n] as u8 - 1);
-    }
-    seq_length_glob.set(seq_length_saved);
-    clockres_glob.set(clockres);
-    gatelength_glob.set(gatel);
+    let (seq_length_init, clockres_init, gatel_init) =
+        derive_runtime_params(length_faders, gate_faders, res_faders, &resolution);
+    seq_length_glob.set(seq_length_init);
+    clockres_glob.set(clockres_init);
+    gatelength_glob.set(gatel_init);
 
     let shift_handler = async {
         loop {
-            app.delay_millis(1).await;
+            app.delay_millis(16).await;
             let layer = if buttons.is_shift_pressed() {
                 LatchLayer::Alt
             } else {
@@ -255,7 +268,6 @@ pub async fn run(
             let seq_idx = page / 2;
             let latch_layer = latch_layer_glob.get();
 
-            // Determine target value based on layer and fader
             let target_value = match latch_layer {
                 LatchLayer::Main => {
                     let seq = seq_glob.get();
@@ -270,7 +282,6 @@ pub async fn run(
             {
                 match latch_layer {
                     LatchLayer::Main => {
-                        // Update step value
                         let mut seq = seq_glob.get();
                         seq[chan + (page * 8)] = new_value;
                         seq_glob.set(seq);
@@ -297,33 +308,28 @@ pub async fn run(
                     LatchLayer::Third => {}
                 }
             }
-            led_flag_glob.set(true);
         }
     };
 
     let button_handler = async {
         loop {
             let (chan, is_shift_pressed) = buttons.wait_for_any_down().await;
-            let mut gateseq = gateseq_glob.get();
-            let mut legato_seq = legatoseq_glob.get();
-
-            // let mut gateseq = gateseq_glob.get_array();
             let page = page_glob.get();
-            if !is_shift_pressed {
-                gateseq[chan + (page * 8)] = !gateseq[chan + (page * 8)];
-                gateseq_glob.set(gateseq);
 
+            if !is_shift_pressed {
+                let mut gateseq = gateseq_glob.get();
+                let mut legato_seq = legatoseq_glob.get();
+
+                gateseq[chan + (page * 8)] = !gateseq[chan + (page * 8)];
                 legato_seq[chan + (page * 8)] = false;
+
+                gateseq_glob.set(gateseq);
                 legatoseq_glob.set(legato_seq);
 
                 storage.modify_and_save(|s| {
                     s.gateseq.set(gateseq);
                     s.legato_seq.set(legato_seq);
                 });
-
-                // gateseq_glob.set_array(gateseq);
-                // gateseq_glob.save();
-                led_flag_glob.set(true);
             } else {
                 page_glob.set(chan);
             }
@@ -333,54 +339,56 @@ pub async fn run(
     let button_long_press_handler = async {
         loop {
             let (chan, is_shift_pressed) = buttons.wait_for_any_long_press().await;
-
             let page = page_glob.get();
 
             if !is_shift_pressed {
                 let mut legato_seq = legatoseq_glob.get();
-                legato_seq[chan + (page * 8)] = !legato_seq[chan + (page * 8)];
-                legatoseq_glob.set(legato_seq);
-
                 let mut gateseq = gateseq_glob.get();
+
+                legato_seq[chan + (page * 8)] = !legato_seq[chan + (page * 8)];
                 gateseq[chan + (page * 8)] = true;
+
+                legatoseq_glob.set(legato_seq);
                 gateseq_glob.set(gateseq);
 
-                storage.modify_and_save(|s| s.gateseq.set(gateseq));
-                storage.modify_and_save(|s| s.legato_seq.set(legato_seq));
-
-                // gateseq_glob.set_array(gateseq);
-                // gateseq_glob.save();
+                storage.modify_and_save(|s| {
+                    s.gateseq.set(gateseq);
+                    s.legato_seq.set(legato_seq);
+                });
             }
         }
     };
 
     let led_handler = async {
+        let intensities = [
+            Brightness::Low,
+            Brightness::Mid,
+            Brightness::High,
+            Brightness::High,
+        ];
+        let colors = [Color::Yellow, Color::Pink, Color::Cyan, Color::White];
+
         loop {
-            let intensities = [
-                Brightness::Low,
-                Brightness::Mid,
-                Brightness::High,
-                Brightness::High,
-            ];
-            let colors = [Color::Yellow, Color::Pink, Color::Cyan, Color::White];
             app.delay_millis(16).await;
             let clockres = clockres_glob.get();
             let clockn = ticks() as usize;
+            let page = page_glob.get();
 
             if buttons.is_shift_pressed() {
                 let seq_length = seq_length_glob.get();
+                let track = page / 2;
+                let current_step = (clockn / clockres[track] % seq_length[track] as usize) as u8;
 
-                let page = page_glob.get();
-                let mut bright = Brightness::Mid;
-                for n in 0..=7 {
-                    if n == page {
-                        bright = intensities[3];
+                for n in 0..8 {
+                    let bright = if n == page {
+                        intensities[3]
                     } else {
-                        bright = intensities[1];
-                    }
+                        intensities[1]
+                    };
                     led.set(n, Led::Button, colors[n / 2], bright);
                 }
                 for n in 0..=15 {
+                    let mut bright = Brightness::Off;
                     if n < seq_length[page / 2] {
                         bright = Brightness::Mid;
                     }
@@ -390,46 +398,20 @@ pub async fn run(
                     if n >= seq_length[page / 2] {
                         bright = Brightness::Off;
                     }
-
-                    let led_color = if matches!(clockres[page / 2], 2 | 4 | 8 | 16) {
-                        Color::Orange
-                    } else {
-                        Color::Blue
-                    };
                     if n < 8 {
-                        led.set(n as usize, Led::Top, led_color, bright)
+                        led.set(n as usize, Led::Top, Color::Red, bright)
                     } else {
-                        led.set(n as usize - 8, Led::Bottom, led_color, bright)
+                        led.set(n as usize - 8, Led::Bottom, Color::Red, bright)
                     }
                 }
-            }
-
-            if !buttons.is_shift_pressed() {
-                // LED stuff
-                let page = page_glob.get();
-
+            } else {
                 let seq = seq_glob.get();
                 let gateseq = gateseq_glob.get();
-                let seq_length = seq_length_glob.get();
-
-                let mut color = colors[0];
-
-                if page / 2 == 0 {
-                    color = colors[0];
-                }
-                if page / 2 == 1 {
-                    color = colors[1];
-                }
-                if page / 2 == 2 {
-                    color = colors[2];
-                }
-                if page / 2 == 3 {
-                    color = colors[3];
-                }
-
                 let legato_seq = legatoseq_glob.get();
+                let seq_length = seq_length_glob.get();
+                let color = colors[page / 2];
 
-                for n in 0..=7 {
+                for n in 0..8 {
                     led.set(
                         n,
                         Led::Top,
@@ -437,40 +419,38 @@ pub async fn run(
                         Brightness::Custom((seq[n + (page * 8)] / 16) as u8 / 2),
                     );
 
-                    if gateseq[n + (page * 8)] {
-                        led.set(n, Led::Button, color, intensities[1]);
-                    }
-                    if !gateseq[n + (page * 8)] {
-                        led.set(n, Led::Button, color, intensities[0]);
-                    }
-                    if legato_seq[n + (page * 8)] {
-                        led.set(n, Led::Button, color, intensities[2]);
-                    }
+                    let button_bright = if legato_seq[n + (page * 8)] {
+                        intensities[2]
+                    } else if gateseq[n + (page * 8)] {
+                        intensities[1]
+                    } else {
+                        intensities[0]
+                    };
+                    led.set(n, Led::Button, color, button_bright);
 
                     let index = seq_length[page / 2] as usize - (page % 2 * 8);
-
                     if n >= index || index > 16 {
                         led.unset(n, Led::Button);
                     }
 
-                    if (clockn / clockres[n / 2] % seq_length[n / 2] as usize) % 16 - (n % 2) * 8
-                        < 8
-                    {
-                        //this needs changing
-                        led.set(n, Led::Bottom, Color::Red, Brightness::Mid)
+                    // Show which page of each track is currently playing
+                    let track = n / 2;
+                    let step = clockn / clockres[track] % seq_length[track] as usize;
+                    let active = if n % 2 == 0 { step < 8 } else { step >= 8 };
+                    if active {
+                        led.set(n, Led::Bottom, Color::Red, Brightness::Mid);
                     } else {
                         led.unset(n, Led::Bottom);
                     }
                 }
-                //runing light on buttons
-                if ((clockn / clockres[page / 2]) % seq_length[page / 2] as usize) % 16
-                    - (page % 2) * 8
-                    < 8
-                    && clockn != 0
-                {
+
+                // Highlight the current step button on the active page
+                let step_in_seq =
+                    (clockn / clockres[page / 2] % seq_length[page / 2] as usize) % 16;
+                let page_offset = (page % 2) * 8;
+                if clockn != 0 && step_in_seq >= page_offset && step_in_seq < page_offset + 8 {
                     led.set(
-                        (clockn / clockres[page / 2] % seq_length[page / 2] as usize) % 16
-                            - (page % 2) * 8,
+                        step_in_seq - page_offset,
                         Led::Button,
                         Color::Red,
                         Brightness::Mid,
@@ -479,8 +459,6 @@ pub async fn run(
 
                 led.set(page, Led::Bottom, color, Brightness::High);
             }
-
-            led_flag_glob.set(false);
         }
     };
 
@@ -492,13 +470,7 @@ pub async fn run(
             let legato_seq = legatoseq_glob.get();
 
             match clk.wait_for_event(ClockDivision::_1).await {
-                ClockEvent::Reset => {
-                    for n in 0..4 {
-                        midi[n].send_note_off(lastnote[n]).await;
-                        gate_out[n].set_low().await;
-                    }
-                }
-                ClockEvent::Stop => {
+                ClockEvent::Reset | ClockEvent::Stop => {
                     for n in 0..4 {
                         midi[n].send_note_off(lastnote[n]).await;
                         gate_out[n].set_low().await;
@@ -506,15 +478,14 @@ pub async fn run(
                 }
                 ClockEvent::Tick => {
                     let clockn = ticks() as usize;
-                    for n in 0..=3 {
+                    let seq = seq_glob.get();
+                    for n in 0..4 {
                         if clockn.is_multiple_of(clockres[n]) {
                             let clkindex =
                                 (clockn / clockres[n] % seq_length[n] as usize) + (n * 16);
 
                             midi[n].send_note_off(lastnote[n]).await;
                             if gateseq[clkindex] {
-                                let seq = seq_glob.get();
-
                                 let out = quantizer
                                     .get_quantized_note(
                                         (seq[clkindex] as u32
@@ -580,17 +551,9 @@ pub async fn run(
                     gateseq_glob.set(gateseq_saved.get());
                     legatoseq_glob.set(legato_seq_saved.get());
 
-                    // Derive runtime parameters from fader values
-                    let mut seq_length_saved = [0u8; 4];
-                    let mut clockres = [0usize; 4];
-                    let mut gatel = [0u8; 4];
-                    for n in 0..4 {
-                        seq_length_saved[n] = (length_faders[n] / 256 + 1) as u8;
-                        clockres[n] = resolution[(res_faders[n] / 512) as usize];
-                        gatel[n] = (clockres[n] * (gate_faders[n] as usize) / 4096) as u8;
-                        gatel[n] = gatel[n].clamp(1, clockres[n] as u8 - 1);
-                    }
-                    seq_length_glob.set(seq_length_saved);
+                    let (seq_length, clockres, gatel) =
+                        derive_runtime_params(length_faders, gate_faders, res_faders, &resolution);
+                    seq_length_glob.set(seq_length);
                     clockres_glob.set(clockres);
                     gatelength_glob.set(gatel);
                 }
@@ -672,7 +635,7 @@ fn apply_alt_update(chan: usize, seq_idx: usize, value: u16, ctx: &AltUpdateCont
             let mut arr = ctx.clockres_glob.get();
             arr[seq_idx] = ctx.resolution[res_index];
             ctx.clockres_glob.set(arr);
-            // Update gate length to clamp within new resolution
+            // Re-clamp gate length within new resolution
             let clockres = ctx.clockres_glob.get();
             let mut gatel = ctx.gatelength_glob.get();
             gatel[seq_idx] = gatel[seq_idx].clamp(1, clockres[seq_idx] as u8);

--- a/faderpunk/src/apps/seq8.rs
+++ b/faderpunk/src/apps/seq8.rs
@@ -40,6 +40,7 @@ pub static CONFIG: Config<PARAMS> = Config::new(
 })
 .add_param(Param::MidiOut);
 // TODO: add per-track MIDI transposition param (semitone offset applied to outgoing notes)
+// TODO: allow tracks 2/4 to act as velocity lanes for tracks 1/3 — step values control note velocity of the paired track instead of outputting their own CV/gate
 
 pub struct Params {
     midi_channel1: MidiChannel,

--- a/faderpunk/src/apps/seq8.rs
+++ b/faderpunk/src/apps/seq8.rs
@@ -5,12 +5,12 @@ use embassy_futures::{
 use midly::MidiMessage;
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use heapless::Vec;
-use libm::expf;
 use serde::{Deserialize, Serialize};
 
 use libfp::{
-    ext::FromValue, latch::LatchLayer, AppIcon, Brightness, ClockDivision, Color, Config,
-    MidiChannel, MidiIn, MidiNote, MidiOut, Param, Range, Value, APP_MAX_PARAMS,
+    ext::FromValue, latch::LatchLayer, utils::fader_to_slide_coeff, AppIcon, Brightness,
+    ClockDivision, Color, Config, MidiChannel, MidiIn, MidiNote, MidiOut, Param, Range, Value,
+    APP_MAX_PARAMS,
 };
 
 use crate::app::{
@@ -160,18 +160,6 @@ impl Default for Storage {
 /// Fader 0 → 5%, fader 4095 → 100%.
 fn probability_threshold(fader: u16) -> u16 {
     205 + ((fader as u32 * 3891) / 4095) as u16
-}
-
-/// 303-style slide coefficient. RC-filter exponential approach. Same approach as
-/// midi2cv's glide: coeff = 1 - exp(-1/tau), applied each 1ms tick.
-/// Fader 0 → 1.0 (instant). Fader 4095 → tau ~205 ticks (~600ms to settle).
-fn calc_slide_coeff(fader: u16) -> f32 {
-    if fader == 0 {
-        1.0
-    } else {
-        let tau = 1.0 + (fader as f32 * 0.05);
-        1.0 - expf(-1.0 / tau)
-    }
 }
 
 /// Maps a raw step counter to a position within `length`, respecting `direction`.
@@ -399,7 +387,7 @@ pub async fn run(
     gatelength_glob.set(gatel_init);
     direction_glob.set(direction_faders.map(Direction::from_fader));
     probability_glob.set(probability_faders.map(probability_threshold));
-    slide_coeff_glob.set(slide_faders.map(calc_slide_coeff));
+    slide_coeff_glob.set(slide_faders.map(fader_to_slide_coeff));
 
     let shift_handler = async {
         loop {
@@ -771,7 +759,7 @@ pub async fn run(
                     gatelength_glob.set(gatel);
                     direction_glob.set(direction_faders.map(Direction::from_fader));
                     probability_glob.set(probability_faders.map(probability_threshold));
-                    slide_coeff_glob.set(slide_faders.map(calc_slide_coeff));
+                    slide_coeff_glob.set(slide_faders.map(fader_to_slide_coeff));
                 }
                 SceneEvent::SaveScene(scene) => {
                     storage.save_to_scene(scene).await;
@@ -951,7 +939,7 @@ fn apply_alt_update(chan: usize, seq_idx: usize, value: u16, ctx: &AltUpdateCont
             ctx.storage
                 .modify_and_save(|s| s.slide_fader[seq_idx] = value);
             let mut arr = ctx.slide_coeff_glob.get();
-            arr[seq_idx] = calc_slide_coeff(value);
+            arr[seq_idx] = fader_to_slide_coeff(value);
             ctx.slide_coeff_glob.set(arr);
         }
         _ => {}

--- a/faderpunk/src/apps/seq8.rs
+++ b/faderpunk/src/apps/seq8.rs
@@ -97,12 +97,13 @@ pub struct Storage {
     gateseq: Arr<bool, 64>,
     legato_seq: Arr<bool, 64>,
     // Alt layer - fader-scale values (0-4095)
-    length_fader: [u16; 4],    // F0: derive seq_length = val/256+1
-    gate_fader: [u16; 4],      // F1: derive gate_length
-    oct_fader: [u16; 4],       // F2: derive oct = val/1000
-    range_fader: [u16; 4],     // F3: derive range = val/1000+1
-    res_fader: [u16; 4],       // F4: derive res_index = val/512
-    direction_fader: [u16; 4], // F5: derive Direction = val/1024
+    length_fader: [u16; 4],      // F0: derive seq_length = val/256+1
+    gate_fader: [u16; 4],        // F1: derive gate_length
+    oct_fader: [u16; 4],         // F2: derive oct = val/1000
+    range_fader: [u16; 4],       // F3: derive range = val/1000+1
+    res_fader: [u16; 4],         // F4: derive res_index = val/512
+    direction_fader: [u16; 4],   // F5: derive Direction = val/1024
+    probability_fader: [u16; 4], // F6: probability 5%..100% (linear)
 }
 
 impl Default for Storage {
@@ -112,14 +113,21 @@ impl Default for Storage {
             gateseq: Arr::new([true; 64]),
             legato_seq: Arr::new([false; 64]),
             // Default fader values - positioned to produce sensible defaults
-            length_fader: [3840; 4],   // -> length 16 (3840/256+1 = 16)
-            gate_fader: [2032; 4],     // -> gate_length 127 (127*16 = 2032)
-            oct_fader: [0; 4],         // -> oct 0
-            range_fader: [2000; 4],    // -> range 3 (2000/1000+1 = 3)
-            res_fader: [2048; 4],      // -> res_index 4 (2048/512 = 4)
-            direction_fader: [0; 4],   // -> Direction::Forward
+            length_fader: [3840; 4],      // -> length 16 (3840/256+1 = 16)
+            gate_fader: [2032; 4],        // -> gate_length 127 (127*16 = 2032)
+            oct_fader: [0; 4],            // -> oct 0
+            range_fader: [2000; 4],       // -> range 3 (2000/1000+1 = 3)
+            res_fader: [2048; 4],         // -> res_index 4 (2048/512 = 4)
+            direction_fader: [0; 4],      // -> Direction::Forward
+            probability_fader: [4095; 4], // -> 100%
         }
     }
+}
+
+/// Maps the per-track probability fader (0..=4095) to a die-roll threshold (0..=4096).
+/// Fader 0 → 5%, fader 4095 → 100%.
+fn probability_threshold(fader: u16) -> u16 {
+    205 + ((fader as u32 * 3891) / 4095) as u16
 }
 
 /// Maps a raw step counter to a position within `length`, respecting `direction`.
@@ -254,6 +262,8 @@ pub async fn run(
     let gatelength_glob: Global<[u8; 4]> = app.make_global([128; 4]);
     let clockres_glob = app.make_global([6usize; 4]);
     let direction_glob: Global<[Direction; 4]> = app.make_global([Direction::Forward; 4]);
+    // Cached die-roll thresholds (0..=4096); recomputed when F6 changes.
+    let probability_glob: Global<[u16; 4]> = app.make_global([4096; 4]);
     // Actual playing position per track (post direction). LED display reads this
     // so the highlighted step matches the audible step regardless of direction.
     let playing_pos_glob: Global<[usize; 4]> = app.make_global([0; 4]);
@@ -278,6 +288,7 @@ pub async fn run(
         _range_faders,
         res_faders,
         direction_faders,
+        probability_faders,
     ) = storage.query(|s| {
         (
             s.seq,
@@ -289,6 +300,7 @@ pub async fn run(
             s.range_fader,
             s.res_fader,
             s.direction_fader,
+            s.probability_fader,
         )
     });
 
@@ -302,6 +314,7 @@ pub async fn run(
     clockres_glob.set(clockres_init);
     gatelength_glob.set(gatel_init);
     direction_glob.set(direction_faders.map(Direction::from_fader));
+    probability_glob.set(probability_faders.map(probability_threshold));
 
     let shift_handler = async {
         loop {
@@ -356,6 +369,7 @@ pub async fn run(
                                 gatelength_glob: &gatelength_glob,
                                 clockres_glob: &clockres_glob,
                                 direction_glob: &direction_glob,
+                                probability_glob: &probability_glob,
                                 resolution: &resolution,
                             },
                         );
@@ -540,6 +554,7 @@ pub async fn run(
                     let clockn = ticks() as usize;
                     let seq = seq_glob.get();
                     let direction = direction_glob.get();
+                    let probability = probability_glob.get();
                     for n in 0..4 {
                         if clockn.is_multiple_of(clockres[n]) {
                             let step = clockn / clockres[n];
@@ -551,7 +566,8 @@ pub async fn run(
                             playing_pos_glob.set(positions);
 
                             midi[n].send_note_off(lastnote[n]).await;
-                            if gateseq[clkindex] {
+                            let fires = gateseq[clkindex] && die.roll() < probability[n];
+                            if fires {
                                 let out = quantizer
                                     .get_quantized_note(
                                         (seq[clkindex] as u32
@@ -602,6 +618,7 @@ pub async fn run(
                         gate_faders,
                         res_faders,
                         direction_faders,
+                        probability_faders,
                     ) = storage.query(|s| {
                         (
                             s.seq,
@@ -611,6 +628,7 @@ pub async fn run(
                             s.gate_fader,
                             s.res_fader,
                             s.direction_fader,
+                            s.probability_fader,
                         )
                     });
 
@@ -624,6 +642,7 @@ pub async fn run(
                     clockres_glob.set(clockres);
                     gatelength_glob.set(gatel);
                     direction_glob.set(direction_faders.map(Direction::from_fader));
+                    probability_glob.set(probability_faders.map(probability_threshold));
                 }
                 SceneEvent::SaveScene(scene) => {
                     storage.save_to_scene(scene).await;
@@ -654,7 +673,8 @@ fn get_alt_target(chan: usize, seq_idx: usize, storage: &ManagedStorage<Storage>
         3 => storage.query(|s| s.range_fader[seq_idx]),
         4 => storage.query(|s| s.res_fader[seq_idx]),
         5 => storage.query(|s| s.direction_fader[seq_idx]),
-        _ => 0, // F6-F7 have no alt function
+        6 => storage.query(|s| s.probability_fader[seq_idx]),
+        _ => 0, // F7 has no alt function
     }
 }
 
@@ -664,6 +684,7 @@ struct AltUpdateContext<'a> {
     gatelength_glob: &'a Global<[u8; 4]>,
     clockres_glob: &'a Global<[usize; 4]>,
     direction_glob: &'a Global<[Direction; 4]>,
+    probability_glob: &'a Global<[u16; 4]>,
     resolution: &'a [usize; 8],
 }
 
@@ -718,6 +739,14 @@ fn apply_alt_update(chan: usize, seq_idx: usize, value: u16, ctx: &AltUpdateCont
             let mut arr = ctx.direction_glob.get();
             arr[seq_idx] = Direction::from_fader(value);
             ctx.direction_glob.set(arr);
+        }
+        6 => {
+            // Probability
+            ctx.storage
+                .modify_and_save(|s| s.probability_fader[seq_idx] = value);
+            let mut arr = ctx.probability_glob.get();
+            arr[seq_idx] = probability_threshold(value);
+            ctx.probability_glob.set(arr);
         }
         _ => {}
     }

--- a/faderpunk/src/apps/seq8.rs
+++ b/faderpunk/src/apps/seq8.rs
@@ -18,7 +18,7 @@ use crate::app::{
 };
 
 pub const CHANNELS: usize = 8;
-pub const PARAMS: usize = 5;
+pub const PARAMS: usize = 7;
 
 pub static CONFIG: Config<PARAMS> = Config::new(
     "Sequencer",
@@ -38,9 +38,10 @@ pub static CONFIG: Config<PARAMS> = Config::new(
 .add_param(Param::MidiChannel {
     name: "MIDI Channel 4",
 })
-.add_param(Param::MidiOut);
+.add_param(Param::MidiOut)
+.add_param(Param::bool { name: "Track 2: velocity lane" })
+.add_param(Param::bool { name: "Track 4: velocity lane" });
 // TODO: add per-track MIDI transposition param (semitone offset applied to outgoing notes)
-// TODO: allow tracks 2/4 to act as velocity lanes for tracks 1/3 — step values control note velocity of the paired track instead of outputting their own CV/gate
 
 pub struct Params {
     midi_channel1: MidiChannel,
@@ -48,6 +49,8 @@ pub struct Params {
     midi_channel3: MidiChannel,
     midi_channel4: MidiChannel,
     midi_out: MidiOut,
+    vel_lane_2: bool,
+    vel_lane_4: bool,
 }
 
 impl AppParams for Params {
@@ -61,6 +64,8 @@ impl AppParams for Params {
             midi_channel3: MidiChannel::from_value(values[2]),
             midi_channel4: MidiChannel::from_value(values[3]),
             midi_out: MidiOut::from_value(values[4]),
+            vel_lane_2: bool::from_value(values[5]),
+            vel_lane_4: bool::from_value(values[6]),
         })
     }
 
@@ -71,6 +76,8 @@ impl AppParams for Params {
         vec.push(self.midi_channel3.into()).unwrap();
         vec.push(self.midi_channel4.into()).unwrap();
         vec.push(self.midi_out.into()).unwrap();
+        vec.push(self.vel_lane_2.into()).unwrap();
+        vec.push(self.vel_lane_4.into()).unwrap();
         vec
     }
 }
@@ -203,6 +210,8 @@ pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMut
             midi_channel3: MidiChannel::from(3),
             midi_channel4: MidiChannel::from(4),
             midi_out: MidiOut::default(),
+            vel_lane_2: false,
+            vel_lane_4: false,
         },
     );
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
@@ -230,15 +239,19 @@ pub async fn run(
     storage: &ManagedStorage<Storage>,
 ) {
     let range = Range::_0_10V;
-    let (midi_out, midi_chan1, midi_chan2, midi_chan3, midi_chan4) = params.query(|p| {
-        (
-            p.midi_out,
-            p.midi_channel1,
-            p.midi_channel2,
-            p.midi_channel3,
-            p.midi_channel4,
-        )
-    });
+    let (midi_out, midi_chan1, midi_chan2, midi_chan3, midi_chan4, vel_lane_2, vel_lane_4) =
+        params.query(|p| {
+            (
+                p.midi_out,
+                p.midi_channel1,
+                p.midi_channel2,
+                p.midi_channel3,
+                p.midi_channel4,
+                p.vel_lane_2,
+                p.vel_lane_4,
+            )
+        });
+    let vel_lane = [false, vel_lane_2, false, vel_lane_4];
 
     let buttons = app.use_buttons();
     let faders = app.use_faders();
@@ -584,7 +597,10 @@ pub async fn run(
                     let seq = seq_glob.get();
                     let direction = direction_glob.get();
                     let probability = probability_glob.get();
-                    for n in 0..4 {
+                    // Reversed so velocity lane tracks (2, 4) run before their
+                    // paired primary tracks (1, 3) — vel_source is ready when needed.
+                    let mut vel_source = [4095u16; 4];
+                    for n in (0..4).rev() {
                         if clockn.is_multiple_of(clockres[n]) {
                             let step = clockn / clockres[n];
                             let pos = step_position(direction[n], step, seq_length[n], die.roll());
@@ -594,32 +610,55 @@ pub async fn run(
                             positions[n] = pos;
                             playing_pos_glob.set(positions);
 
-                            midi[n].send_note_off(lastnote[n]).await;
+                            if !vel_lane[n] {
+                                midi[n].send_note_off(lastnote[n]).await;
+                            }
                             let fires = gateseq[clkindex] && die.roll() < probability[n];
                             if fires {
-                                let out = quantizer
-                                    .get_quantized_note(
-                                        (seq[clkindex] as u32
-                                            * ((storage.query(|s| s.range_fader[n]) / 1000 + 1)
-                                                as u32)
-                                            * 410
-                                            / 4095) as u16
-                                            + (storage.query(|s| s.oct_fader[n]) / 1000) * 410,
-                                    )
-                                    .await;
-                                lastnote[n] = out.as_midi();
-
-                                midi[n].send_note_on(lastnote[n], 4095).await;
-                                gatelength1 = gatelength_glob.get();
-                                // Hand the target CV to slide_handler; slide only if
-                                // the previously played step had legato enabled.
-                                let mut targets = target_cv_glob.get();
-                                targets[n] = out.as_counts(range);
-                                target_cv_glob.set(targets);
-                                let mut slid = sliding_glob.get();
-                                slid[n] = prev_step_legato[n];
-                                sliding_glob.set(slid);
-                                gate_out[n].set_high().await;
+                                if vel_lane[n] {
+                                    // Velocity lane: skip quantizer, use raw step value.
+                                    // Gate fires; MIDI is suppressed.
+                                    let raw = seq[clkindex];
+                                    vel_source[n] = raw.max(1);
+                                    let mut targets = target_cv_glob.get();
+                                    targets[n] = raw;
+                                    target_cv_glob.set(targets);
+                                    gatelength1 = gatelength_glob.get();
+                                    let mut slid = sliding_glob.get();
+                                    slid[n] = prev_step_legato[n];
+                                    sliding_glob.set(slid);
+                                    gate_out[n].set_high().await;
+                                } else {
+                                    let out = quantizer
+                                        .get_quantized_note(
+                                            (seq[clkindex] as u32
+                                                * ((storage.query(|s| s.range_fader[n]) / 1000 + 1)
+                                                    as u32)
+                                                * 410
+                                                / 4095) as u16
+                                                + (storage.query(|s| s.oct_fader[n]) / 1000) * 410,
+                                        )
+                                        .await;
+                                    lastnote[n] = out.as_midi();
+                                    let velocity = if n == 0 && vel_lane_2 {
+                                        vel_source[1]
+                                    } else if n == 2 && vel_lane_4 {
+                                        vel_source[3]
+                                    } else {
+                                        4095
+                                    };
+                                    midi[n].send_note_on(lastnote[n], velocity).await;
+                                    gatelength1 = gatelength_glob.get();
+                                    // Hand the target CV to slide_handler; slide only if
+                                    // the previously played step had legato enabled.
+                                    let mut targets = target_cv_glob.get();
+                                    targets[n] = out.as_counts(range);
+                                    target_cv_glob.set(targets);
+                                    let mut slid = sliding_glob.get();
+                                    slid[n] = prev_step_legato[n];
+                                    sliding_glob.set(slid);
+                                    gate_out[n].set_high().await;
+                                }
                             } else {
                                 gate_out[n].set_low().await;
                             }
@@ -631,7 +670,9 @@ pub async fn run(
                             let clkindex = last_step_index[n];
                             if gateseq[clkindex] && !legato_seq[clkindex] {
                                 gate_out[n].set_low().await;
-                                midi[n].send_note_off(lastnote[n]).await;
+                                if !vel_lane[n] {
+                                    midi[n].send_note_off(lastnote[n]).await;
+                                }
                             }
                         }
                     }

--- a/faderpunk/src/apps/seq8.rs
+++ b/faderpunk/src/apps/seq8.rs
@@ -39,6 +39,7 @@ pub static CONFIG: Config<PARAMS> = Config::new(
     name: "MIDI Channel 4",
 })
 .add_param(Param::MidiOut);
+// TODO: add per-track MIDI transposition param (semitone offset applied to outgoing notes)
 
 pub struct Params {
     midi_channel1: MidiChannel,

--- a/faderpunk/src/apps/seq8.rs
+++ b/faderpunk/src/apps/seq8.rs
@@ -72,17 +72,37 @@ impl AppParams for Params {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Direction {
+    Forward,
+    Backward,
+    PingPong,
+    Random,
+}
+
+impl Direction {
+    fn from_fader(value: u16) -> Self {
+        match value / 1024 {
+            0 => Direction::Forward,
+            1 => Direction::Backward,
+            2 => Direction::PingPong,
+            _ => Direction::Random,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct Storage {
     seq: Arr<u16, 64>,
     gateseq: Arr<bool, 64>,
     legato_seq: Arr<bool, 64>,
     // Alt layer - fader-scale values (0-4095)
-    length_fader: [u16; 4], // F0: derive seq_length = val/256+1
-    gate_fader: [u16; 4],   // F1: derive gate_length
-    oct_fader: [u16; 4],    // F2: derive oct = val/1000
-    range_fader: [u16; 4],  // F3: derive range = val/1000+1
-    res_fader: [u16; 4],    // F4: derive res_index = val/512
+    length_fader: [u16; 4],    // F0: derive seq_length = val/256+1
+    gate_fader: [u16; 4],      // F1: derive gate_length
+    oct_fader: [u16; 4],       // F2: derive oct = val/1000
+    range_fader: [u16; 4],     // F3: derive range = val/1000+1
+    res_fader: [u16; 4],       // F4: derive res_index = val/512
+    direction_fader: [u16; 4], // F5: derive Direction = val/1024
 }
 
 impl Default for Storage {
@@ -92,12 +112,37 @@ impl Default for Storage {
             gateseq: Arr::new([true; 64]),
             legato_seq: Arr::new([false; 64]),
             // Default fader values - positioned to produce sensible defaults
-            length_fader: [3840; 4], // -> length 16 (3840/256+1 = 16)
-            gate_fader: [2032; 4],   // -> gate_length 127 (127*16 = 2032)
-            oct_fader: [0; 4],       // -> oct 0
-            range_fader: [2000; 4],  // -> range 3 (2000/1000+1 = 3)
-            res_fader: [2048; 4],    // -> res_index 4 (2048/512 = 4)
+            length_fader: [3840; 4],   // -> length 16 (3840/256+1 = 16)
+            gate_fader: [2032; 4],     // -> gate_length 127 (127*16 = 2032)
+            oct_fader: [0; 4],         // -> oct 0
+            range_fader: [2000; 4],    // -> range 3 (2000/1000+1 = 3)
+            res_fader: [2048; 4],      // -> res_index 4 (2048/512 = 4)
+            direction_fader: [0; 4],   // -> Direction::Forward
         }
+    }
+}
+
+/// Maps a raw step counter to a position within `length`, respecting `direction`.
+fn step_position(direction: Direction, step: usize, length: u8, die_roll: u16) -> usize {
+    let l = length as usize;
+    if l == 0 {
+        return 0;
+    }
+    match direction {
+        Direction::Forward => step % l,
+        Direction::Backward => (l - 1) - (step % l),
+        Direction::PingPong => {
+            // Endpoints are repeated. For L=3: 0,1,2,2,1,0,0,1,2,2,1,0,...
+            // Period = 2*L; first half ascends, second half descends.
+            let period = 2 * l;
+            let phase = step % period;
+            if phase < l {
+                phase
+            } else {
+                period - 1 - phase
+            }
+        }
+        Direction::Random => (die_roll as usize) % l,
     }
 }
 
@@ -173,6 +218,7 @@ pub async fn run(
     let buttons = app.use_buttons();
     let faders = app.use_faders();
     let mut clk = app.use_clock();
+    let die = app.use_die();
     let ticks = clk.get_ticker();
     let led = app.use_leds();
 
@@ -207,10 +253,15 @@ pub async fn run(
     let seq_length_glob: Global<[u8; 4]> = app.make_global([16; 4]);
     let gatelength_glob: Global<[u8; 4]> = app.make_global([128; 4]);
     let clockres_glob = app.make_global([6usize; 4]);
+    let direction_glob: Global<[Direction; 4]> = app.make_global([Direction::Forward; 4]);
+    // Actual playing position per track (post direction). LED display reads this
+    // so the highlighted step matches the audible step regardless of direction.
+    let playing_pos_glob: Global<[usize; 4]> = app.make_global([0; 4]);
 
     let resolution = [24usize, 16, 12, 8, 6, 4, 3, 2];
 
     let mut lastnote = [MidiNote::default(); 4];
+    let mut last_step_index = [0usize; 4];
     let mut gatelength1 = gatelength_glob.get();
 
     // Initialize latches for all 8 faders
@@ -226,6 +277,7 @@ pub async fn run(
         _oct_faders,
         _range_faders,
         res_faders,
+        direction_faders,
     ) = storage.query(|s| {
         (
             s.seq,
@@ -236,6 +288,7 @@ pub async fn run(
             s.oct_fader,
             s.range_fader,
             s.res_fader,
+            s.direction_fader,
         )
     });
 
@@ -248,6 +301,7 @@ pub async fn run(
     seq_length_glob.set(seq_length_init);
     clockres_glob.set(clockres_init);
     gatelength_glob.set(gatel_init);
+    direction_glob.set(direction_faders.map(Direction::from_fader));
 
     let shift_handler = async {
         loop {
@@ -301,6 +355,7 @@ pub async fn run(
                                 seq_length_glob: &seq_length_glob,
                                 gatelength_glob: &gatelength_glob,
                                 clockres_glob: &clockres_glob,
+                                direction_glob: &direction_glob,
                                 resolution: &resolution,
                             },
                         );
@@ -376,8 +431,8 @@ pub async fn run(
 
             if buttons.is_shift_pressed() {
                 let seq_length = seq_length_glob.get();
-                let track = page / 2;
-                let current_step = (clockn / clockres[track] % seq_length[track] as usize) as u8;
+                let playing_pos = playing_pos_glob.get();
+                let current_step = playing_pos[page / 2] as u8;
 
                 for n in 0..8 {
                     let bright = if n == page {
@@ -387,21 +442,26 @@ pub async fn run(
                     };
                     led.set(n, Led::Button, colors[n / 2], bright);
                 }
+                let led_color = if matches!(clockres[page / 2], 2 | 4 | 8 | 16) {
+                    Color::Orange
+                } else {
+                    Color::Blue
+                };
                 for n in 0..=15 {
                     let mut bright = Brightness::Off;
                     if n < seq_length[page / 2] {
                         bright = Brightness::Mid;
                     }
-                    if n == (clockn / clockres[page / 2]) as u8 % seq_length[page / 2] {
+                    if n == current_step {
                         bright = Brightness::High;
                     }
                     if n >= seq_length[page / 2] {
                         bright = Brightness::Off;
                     }
                     if n < 8 {
-                        led.set(n as usize, Led::Top, Color::Red, bright)
+                        led.set(n as usize, Led::Top, led_color, bright)
                     } else {
-                        led.set(n as usize - 8, Led::Bottom, Color::Red, bright)
+                        led.set(n as usize - 8, Led::Bottom, led_color, bright)
                     }
                 }
             } else {
@@ -409,6 +469,7 @@ pub async fn run(
                 let gateseq = gateseq_glob.get();
                 let legato_seq = legatoseq_glob.get();
                 let seq_length = seq_length_glob.get();
+                let playing_pos = playing_pos_glob.get();
                 let color = colors[page / 2];
 
                 for n in 0..8 {
@@ -435,7 +496,7 @@ pub async fn run(
 
                     // Show which page of each track is currently playing
                     let track = n / 2;
-                    let step = clockn / clockres[track] % seq_length[track] as usize;
+                    let step = playing_pos[track];
                     let active = if n % 2 == 0 { step < 8 } else { step >= 8 };
                     if active {
                         led.set(n, Led::Bottom, Color::Red, Brightness::Mid);
@@ -445,8 +506,7 @@ pub async fn run(
                 }
 
                 // Highlight the current step button on the active page
-                let step_in_seq =
-                    (clockn / clockres[page / 2] % seq_length[page / 2] as usize) % 16;
+                let step_in_seq = playing_pos[page / 2];
                 let page_offset = (page % 2) * 8;
                 if clockn != 0 && step_in_seq >= page_offset && step_in_seq < page_offset + 8 {
                     led.set(
@@ -479,10 +539,16 @@ pub async fn run(
                 ClockEvent::Tick => {
                     let clockn = ticks() as usize;
                     let seq = seq_glob.get();
+                    let direction = direction_glob.get();
                     for n in 0..4 {
                         if clockn.is_multiple_of(clockres[n]) {
-                            let clkindex =
-                                (clockn / clockres[n] % seq_length[n] as usize) + (n * 16);
+                            let step = clockn / clockres[n];
+                            let pos = step_position(direction[n], step, seq_length[n], die.roll());
+                            let clkindex = pos + (n * 16);
+                            last_step_index[n] = clkindex;
+                            let mut positions = playing_pos_glob.get();
+                            positions[n] = pos;
+                            playing_pos_glob.set(positions);
 
                             midi[n].send_note_off(lastnote[n]).await;
                             if gateseq[clkindex] {
@@ -509,8 +575,7 @@ pub async fn run(
                         if clockn >= gatelength1[n] as usize
                             && (clockn - gatelength1[n] as usize).is_multiple_of(clockres[n])
                         {
-                            let clkindex =
-                                (((clockn - 1) / clockres[n]) % seq_length[n] as usize) + (n * 16);
+                            let clkindex = last_step_index[n];
                             if gateseq[clkindex] && !legato_seq[clkindex] {
                                 gate_out[n].set_low().await;
                                 midi[n].send_note_off(lastnote[n]).await;
@@ -536,6 +601,7 @@ pub async fn run(
                         length_faders,
                         gate_faders,
                         res_faders,
+                        direction_faders,
                     ) = storage.query(|s| {
                         (
                             s.seq,
@@ -544,6 +610,7 @@ pub async fn run(
                             s.length_fader,
                             s.gate_fader,
                             s.res_fader,
+                            s.direction_fader,
                         )
                     });
 
@@ -556,6 +623,7 @@ pub async fn run(
                     seq_length_glob.set(seq_length);
                     clockres_glob.set(clockres);
                     gatelength_glob.set(gatel);
+                    direction_glob.set(direction_faders.map(Direction::from_fader));
                 }
                 SceneEvent::SaveScene(scene) => {
                     storage.save_to_scene(scene).await;
@@ -585,7 +653,8 @@ fn get_alt_target(chan: usize, seq_idx: usize, storage: &ManagedStorage<Storage>
         2 => storage.query(|s| s.oct_fader[seq_idx]),
         3 => storage.query(|s| s.range_fader[seq_idx]),
         4 => storage.query(|s| s.res_fader[seq_idx]),
-        _ => 0, // F5-F7 have no alt function
+        5 => storage.query(|s| s.direction_fader[seq_idx]),
+        _ => 0, // F6-F7 have no alt function
     }
 }
 
@@ -594,6 +663,7 @@ struct AltUpdateContext<'a> {
     seq_length_glob: &'a Global<[u8; 4]>,
     gatelength_glob: &'a Global<[u8; 4]>,
     clockres_glob: &'a Global<[usize; 4]>,
+    direction_glob: &'a Global<[Direction; 4]>,
     resolution: &'a [usize; 8],
 }
 
@@ -640,6 +710,14 @@ fn apply_alt_update(chan: usize, seq_idx: usize, value: u16, ctx: &AltUpdateCont
             let mut gatel = ctx.gatelength_glob.get();
             gatel[seq_idx] = gatel[seq_idx].clamp(1, clockres[seq_idx] as u8);
             ctx.gatelength_glob.set(gatel);
+        }
+        5 => {
+            // Direction
+            ctx.storage
+                .modify_and_save(|s| s.direction_fader[seq_idx] = value);
+            let mut arr = ctx.direction_glob.get();
+            arr[seq_idx] = Direction::from_fader(value);
+            ctx.direction_glob.set(arr);
         }
         _ => {}
     }

--- a/faderpunk/src/apps/seq8.rs
+++ b/faderpunk/src/apps/seq8.rs
@@ -1,9 +1,10 @@
 use embassy_futures::{
-    join::{join3, join5},
+    join::{join4, join5},
     select::{select, select3},
 };
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use heapless::Vec;
+use libm::expf;
 use serde::{Deserialize, Serialize};
 
 use libfp::{
@@ -104,6 +105,7 @@ pub struct Storage {
     res_fader: [u16; 4],         // F4: derive res_index = val/512
     direction_fader: [u16; 4],   // F5: derive Direction = val/1024
     probability_fader: [u16; 4], // F6: probability 5%..100% (linear)
+    slide_fader: [u16; 4],       // F7: 303-style slide time (0 = instant)
 }
 
 impl Default for Storage {
@@ -120,6 +122,7 @@ impl Default for Storage {
             res_fader: [2048; 4],         // -> res_index 4 (2048/512 = 4)
             direction_fader: [0; 4],      // -> Direction::Forward
             probability_fader: [4095; 4], // -> 100%
+            slide_fader: [0; 4],          // -> instant (no slide)
         }
     }
 }
@@ -128,6 +131,18 @@ impl Default for Storage {
 /// Fader 0 → 5%, fader 4095 → 100%.
 fn probability_threshold(fader: u16) -> u16 {
     205 + ((fader as u32 * 3891) / 4095) as u16
+}
+
+/// 303-style slide coefficient. RC-filter exponential approach. Same approach as
+/// midi2cv's glide: coeff = 1 - exp(-1/tau), applied each 1ms tick.
+/// Fader 0 → 1.0 (instant). Fader 4095 → tau ~205 ticks (~600ms to settle).
+fn calc_slide_coeff(fader: u16) -> f32 {
+    if fader == 0 {
+        1.0
+    } else {
+        let tau = 1.0 + (fader as f32 * 0.05);
+        1.0 - expf(-1.0 / tau)
+    }
 }
 
 /// Maps a raw step counter to a position within `length`, respecting `direction`.
@@ -264,6 +279,12 @@ pub async fn run(
     let direction_glob: Global<[Direction; 4]> = app.make_global([Direction::Forward; 4]);
     // Cached die-roll thresholds (0..=4096); recomputed when F6 changes.
     let probability_glob: Global<[u16; 4]> = app.make_global([4096; 4]);
+    // Per-tick exponential coefficient for the slide (1.0 = instant).
+    let slide_coeff_glob: Global<[f32; 4]> = app.make_global([1.0; 4]);
+    // CV target set by clock_handler at note-on; slide_handler interpolates toward it.
+    let target_cv_glob: Global<[u16; 4]> = app.make_global([0; 4]);
+    // Set true at note-on when the previously played step had legato enabled.
+    let sliding_glob: Global<[bool; 4]> = app.make_global([false; 4]);
     // Actual playing position per track (post direction). LED display reads this
     // so the highlighted step matches the audible step regardless of direction.
     let playing_pos_glob: Global<[usize; 4]> = app.make_global([0; 4]);
@@ -272,6 +293,8 @@ pub async fn run(
 
     let mut lastnote = [MidiNote::default(); 4];
     let mut last_step_index = [0usize; 4];
+    // Was the just-played step a legato step? Drives whether to slide into the next.
+    let mut prev_step_legato = [false; 4];
     let mut gatelength1 = gatelength_glob.get();
 
     // Initialize latches for all 8 faders
@@ -289,6 +312,7 @@ pub async fn run(
         res_faders,
         direction_faders,
         probability_faders,
+        slide_faders,
     ) = storage.query(|s| {
         (
             s.seq,
@@ -301,6 +325,7 @@ pub async fn run(
             s.res_fader,
             s.direction_fader,
             s.probability_fader,
+            s.slide_fader,
         )
     });
 
@@ -315,6 +340,7 @@ pub async fn run(
     gatelength_glob.set(gatel_init);
     direction_glob.set(direction_faders.map(Direction::from_fader));
     probability_glob.set(probability_faders.map(probability_threshold));
+    slide_coeff_glob.set(slide_faders.map(calc_slide_coeff));
 
     let shift_handler = async {
         loop {
@@ -370,6 +396,7 @@ pub async fn run(
                                 clockres_glob: &clockres_glob,
                                 direction_glob: &direction_glob,
                                 probability_glob: &probability_glob,
+                                slide_coeff_glob: &slide_coeff_glob,
                                 resolution: &resolution,
                             },
                         );
@@ -582,11 +609,19 @@ pub async fn run(
 
                                 midi[n].send_note_on(lastnote[n], 4095).await;
                                 gatelength1 = gatelength_glob.get();
-                                cv_out[n].set_value(out.as_counts(range));
+                                // Hand the target CV to slide_handler; slide only if
+                                // the previously played step had legato enabled.
+                                let mut targets = target_cv_glob.get();
+                                targets[n] = out.as_counts(range);
+                                target_cv_glob.set(targets);
+                                let mut slid = sliding_glob.get();
+                                slid[n] = prev_step_legato[n];
+                                sliding_glob.set(slid);
                                 gate_out[n].set_high().await;
                             } else {
                                 gate_out[n].set_low().await;
                             }
+                            prev_step_legato[n] = legato_seq[clkindex];
                         }
                         if clockn >= gatelength1[n] as usize
                             && (clockn - gatelength1[n] as usize).is_multiple_of(clockres[n])
@@ -619,6 +654,7 @@ pub async fn run(
                         res_faders,
                         direction_faders,
                         probability_faders,
+                        slide_faders,
                     ) = storage.query(|s| {
                         (
                             s.seq,
@@ -629,6 +665,7 @@ pub async fn run(
                             s.res_fader,
                             s.direction_fader,
                             s.probability_fader,
+                            s.slide_fader,
                         )
                     });
 
@@ -643,6 +680,7 @@ pub async fn run(
                     gatelength_glob.set(gatel);
                     direction_glob.set(direction_faders.map(Direction::from_fader));
                     probability_glob.set(probability_faders.map(probability_threshold));
+                    slide_coeff_glob.set(slide_faders.map(calc_slide_coeff));
                 }
                 SceneEvent::SaveScene(scene) => {
                     storage.save_to_scene(scene).await;
@@ -651,7 +689,30 @@ pub async fn run(
         }
     };
 
-    join3(
+    // CV slide handler — runs at 1ms and exponentially interpolates each
+    // track's CV from its current value toward target_cv_glob[n] using
+    // slide_coeff_glob[n]. Only slides when sliding_glob[n] is true (set
+    // by clock_handler when the previously played step had legato).
+    let slide_handler = async {
+        let mut current: [f32; 4] = [0.0; 4];
+        loop {
+            app.delay_millis(1).await;
+            let target = target_cv_glob.get();
+            let sliding = sliding_glob.get();
+            let coeff = slide_coeff_glob.get();
+            for n in 0..4 {
+                let target_f = target[n] as f32;
+                if sliding[n] && coeff[n] < 1.0 {
+                    current[n] += (target_f - current[n]) * coeff[n];
+                } else {
+                    current[n] = target_f;
+                }
+                cv_out[n].set_value(current[n] as u16);
+            }
+        }
+    };
+
+    join4(
         join5(
             shift_handler,
             fader_handler,
@@ -661,6 +722,7 @@ pub async fn run(
         ),
         button_long_press_handler,
         scene_handler,
+        slide_handler,
     )
     .await;
 }
@@ -674,7 +736,8 @@ fn get_alt_target(chan: usize, seq_idx: usize, storage: &ManagedStorage<Storage>
         4 => storage.query(|s| s.res_fader[seq_idx]),
         5 => storage.query(|s| s.direction_fader[seq_idx]),
         6 => storage.query(|s| s.probability_fader[seq_idx]),
-        _ => 0, // F7 has no alt function
+        7 => storage.query(|s| s.slide_fader[seq_idx]),
+        _ => 0,
     }
 }
 
@@ -685,6 +748,7 @@ struct AltUpdateContext<'a> {
     clockres_glob: &'a Global<[usize; 4]>,
     direction_glob: &'a Global<[Direction; 4]>,
     probability_glob: &'a Global<[u16; 4]>,
+    slide_coeff_glob: &'a Global<[f32; 4]>,
     resolution: &'a [usize; 8],
 }
 
@@ -747,6 +811,14 @@ fn apply_alt_update(chan: usize, seq_idx: usize, value: u16, ctx: &AltUpdateCont
             let mut arr = ctx.probability_glob.get();
             arr[seq_idx] = probability_threshold(value);
             ctx.probability_glob.set(arr);
+        }
+        7 => {
+            // Slide time
+            ctx.storage
+                .modify_and_save(|s| s.slide_fader[seq_idx] = value);
+            let mut arr = ctx.slide_coeff_glob.get();
+            arr[seq_idx] = calc_slide_coeff(value);
+            ctx.slide_coeff_glob.set(arr);
         }
         _ => {}
     }

--- a/libfp/src/utils.rs
+++ b/libfp/src/utils.rs
@@ -1,4 +1,5 @@
 use embassy_time::Duration;
+use libm::expf;
 use midly::num::u7;
 
 use crate::Curve;
@@ -211,6 +212,31 @@ pub fn euclidean_at(num_steps: u8, num_beats: u8, rotation: u8, clock: u32) -> b
     let pattern = euclidean_pattern(num_steps, num_beats, rotation, 0);
     let pos = (clock % num_steps as u32) as u8;
     (pattern & (1 << pos)) != 0
+}
+
+/// RC-filter coefficient for an exponential approach with the given `tau` (in ticks).
+/// `tau <= 0` returns 1.0 (instant). Apply each tick: `current += (target - current) * coeff`.
+pub fn rc_coeff(tau: f32) -> f32 {
+    if tau <= 0.0 {
+        1.0
+    } else {
+        1.0 - expf(-1.0 / tau)
+    }
+}
+
+/// Maps a 12-bit fader (0..=4095) to a slide/glide coefficient using an RC approach.
+/// Fader 0 → instant (1.0). Fader 4095 → tau ~205 ticks (~600ms at 1ms tick).
+pub fn fader_to_slide_coeff(fader: u16) -> f32 {
+    if fader == 0 {
+        1.0
+    } else {
+        rc_coeff(1.0 + fader as f32 * 0.05)
+    }
+}
+
+/// Exponential approach step: moves `current` toward `target` by `coeff`.
+pub fn apply_slide(current: f32, target: f32, coeff: f32) -> f32 {
+    current + (target - current) * coeff
 }
 
 /// Very short slew meant to avoid clicks


### PR DESCRIPTION
## Summary

- **Refactor/cleanup**: general optimization pass on seq8 (code hygiene, readability)
- **Per-track direction**: each track can run forward, backward, ping-pong, or random — controlled via alt-layer fader
- **Per-track trigger probability**: probabilistic step triggering, controlled via alt-layer fader (F6)
- **Per-track 303-style slide**: portamento/slide flag per step, controlled via alt-layer fader (F7)
- **Per-track MIDI transposition** - incoming midi note transpose the sequence
- **Paired velocity lane mode** — tracks 2/4 act as velocity lanes for tracks 1/3 (step values control note velocity of the paired track instead of their own CV/gate)