### PR TITLE
fix(faderpunk): fix MIDI CC guard so CC 127 is reachable in LFO, LFO+, rnd, rnd+

### DIFF
--- a/faderpunk/src/apps/lfo.rs
+++ b/faderpunk/src/apps/lfo.rs
@@ -4,12 +4,13 @@ use embassy_futures::{
 };
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use heapless::Vec;
+use midly::num::u7;
 use serde::{Deserialize, Serialize};
 
 use libfp::{
     ext::FromValue,
     latch::LatchLayer,
-    utils::{attenuate, attenuate_bipolar, split_unsigned_value},
+    utils::{attenuate, attenuate_bipolar, scale_bits_12_7, split_unsigned_value},
     AppIcon, Brightness, ClockDivision, Color, Config, Curve, MidiCc, MidiChannel, MidiOut, Param,
     Range, Value, Waveform, APP_MAX_PARAMS,
 };
@@ -161,7 +162,7 @@ pub async fn run(
     leds.set(0, Led::Button, color, Brightness::Mid);
 
     let mut count = 0;
-    let mut last_out = 0;
+    let mut last_cc = u7::new(0);
 
     let update_speed = async || {
         glob_lfo_speed.set((curve.at(storage.query(|s| s.layer_speed)) as f32) * 0.015 + 0.0682);
@@ -212,10 +213,11 @@ pub async fn run(
 
             output.set_value(val);
             if midi_out.is_some() {
-                if val as u32 * 127 / 4095 != last_out as u32 * 127 / 4095 {
+                let cc = scale_bits_12_7(val);
+                if cc != last_cc {
                     midi.send_cc(midi_cc, val).await;
+                    last_cc = cc;
                 }
-                last_out = val;
             }
 
             let led = if range == Range::_Neg5_5V {

--- a/faderpunk/src/apps/lfo.rs
+++ b/faderpunk/src/apps/lfo.rs
@@ -212,7 +212,7 @@ pub async fn run(
 
             output.set_value(val);
             if midi_out.is_some() {
-                if last_out / 32 != val / 32 {
+                if val as u32 * 127 / 4095 != last_out as u32 * 127 / 4095 {
                     midi.send_cc(midi_cc, val).await;
                 }
                 last_out = val;

--- a/faderpunk/src/apps/lfo_plus.rs
+++ b/faderpunk/src/apps/lfo_plus.rs
@@ -4,12 +4,13 @@ use embassy_futures::{
 };
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use heapless::Vec;
+use midly::num::u7;
 use serde::{Deserialize, Serialize};
 
 use libfp::{
     ext::FromValue,
     latch::LatchLayer,
-    utils::{attenuate, attenuate_bipolar, split_unsigned_value},
+    utils::{attenuate, attenuate_bipolar, scale_bits_12_7, split_unsigned_value},
     AppIcon, Brightness, ClockDivision, Color, Config, Curve, MidiCc, MidiChannel, MidiOut, Param,
     Range, Value, Waveform, APP_MAX_PARAMS,
 };
@@ -203,7 +204,7 @@ pub async fn run(
     glob_div.set(resolution[(speed as usize / 500).clamp(0, 8)]);
     let mut count = 0;
 
-    let mut last_out = 0;
+    let mut last_cc = u7::new(0);
 
     if storage.query(|s| s.in_mute) {
         leds.unset(0, Led::Button);
@@ -295,10 +296,11 @@ pub async fn run(
 
             output.set_value(val);
             if midi_out.is_some() {
-                if val as u32 * 127 / 4095 != last_out as u32 * 127 / 4095 {
+                let cc = scale_bits_12_7(val);
+                if cc != last_cc {
                     midi.send_cc(midi_cc, val).await;
+                    last_cc = cc;
                 }
-                last_out = val;
             }
 
             let led = if range.is_bipolar() {

--- a/faderpunk/src/apps/lfo_plus.rs
+++ b/faderpunk/src/apps/lfo_plus.rs
@@ -295,7 +295,7 @@ pub async fn run(
 
             output.set_value(val);
             if midi_out.is_some() {
-                if last_out / 32 != val / 32 {
+                if val as u32 * 127 / 4095 != last_out as u32 * 127 / 4095 {
                     midi.send_cc(midi_cc, val).await;
                 }
                 last_out = val;

--- a/faderpunk/src/apps/rnd.rs
+++ b/faderpunk/src/apps/rnd.rs
@@ -8,6 +8,7 @@ use embassy_futures::{
 };
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use heapless::Vec;
+use midly::num::u7;
 use serde::{Deserialize, Serialize};
 
 use crate::app::{
@@ -17,7 +18,7 @@ use crate::app::{
 use libfp::{
     ext::FromValue,
     latch::LatchLayer,
-    utils::{attenuate, attenuate_bipolar, slew_2, split_unsigned_value},
+    utils::{attenuate, attenuate_bipolar, scale_bits_12_7, slew_2, split_unsigned_value},
     AppIcon, Brightness, ClockDivision, Color, Config, Curve, MidiCc, MidiChannel, MidiOut, Param,
     Range, Value, APP_MAX_PARAMS,
 };
@@ -317,7 +318,7 @@ pub async fn run(
 
     let timed_loop = async {
         let mut out: u16 = 0;
-        let mut last_out: u16 = 0;
+        let mut last_cc = u7::new(0);
         let mut count: u32 = 0;
         loop {
             app.delay_millis(1).await;
@@ -354,10 +355,11 @@ pub async fn run(
 
             output.set_value(out);
 
-            if out as u32 * 127 / 4095 != last_out as u32 * 127 / 4095 {
+            let cc = scale_bits_12_7(out);
+            if cc != last_cc {
                 midi.send_cc(midi_cc, out).await;
+                last_cc = cc;
             }
-            last_out = out;
 
             if latch_active_layer == LatchLayer::Main {
                 let color = glob_button_color.get();
@@ -370,7 +372,7 @@ pub async fn run(
                         0,
                         Led::Top,
                         color,
-                        Brightness::Custom((last_out / 16) as u8),
+                        Brightness::Custom((out / 16) as u8),
                     );
                 }
             }

--- a/faderpunk/src/apps/rnd.rs
+++ b/faderpunk/src/apps/rnd.rs
@@ -354,7 +354,7 @@ pub async fn run(
 
             output.set_value(out);
 
-            if last_out / 32 != out / 32 {
+            if out as u32 * 127 / 4095 != last_out as u32 * 127 / 4095 {
                 midi.send_cc(midi_cc, out).await;
             }
             last_out = out;

--- a/faderpunk/src/apps/rnd_plus.rs
+++ b/faderpunk/src/apps/rnd_plus.rs
@@ -460,7 +460,7 @@ pub async fn run(
 
             output.set_value(out);
 
-            if last_out / 32 != out / 32 {
+            if out as u32 * 127 / 4095 != last_out as u32 * 127 / 4095 {
                 midi.send_cc(midi_cc, out).await;
             }
             last_out = out;

--- a/faderpunk/src/apps/rnd_plus.rs
+++ b/faderpunk/src/apps/rnd_plus.rs
@@ -4,6 +4,7 @@ use embassy_futures::{
 };
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use heapless::Vec;
+use midly::num::u7;
 use serde::{Deserialize, Serialize};
 
 use crate::app::{
@@ -13,7 +14,7 @@ use crate::app::{
 use libfp::{
     ext::FromValue,
     latch::LatchLayer,
-    utils::{attenuate, attenuate_bipolar, slew_2, split_unsigned_value},
+    utils::{attenuate, attenuate_bipolar, scale_bits_12_7, slew_2, split_unsigned_value},
     AppIcon, Brightness, ClockDivision, Color, Config, Curve, MidiCc, MidiChannel, MidiOut, Param,
     Range, Value, APP_MAX_PARAMS,
 };
@@ -387,7 +388,7 @@ pub async fn run(
 
     let timed_loop = async {
         let mut out: u16 = 0;
-        let mut last_out: u16 = 0;
+        let mut last_cc = u7::new(0);
         let mut count: u32 = 0;
         let mut oldinputval = 0;
         loop {
@@ -460,10 +461,11 @@ pub async fn run(
 
             output.set_value(out);
 
-            if out as u32 * 127 / 4095 != last_out as u32 * 127 / 4095 {
+            let cc = scale_bits_12_7(out);
+            if cc != last_cc {
                 midi.send_cc(midi_cc, out).await;
+                last_cc = cc;
             }
-            last_out = out;
 
             if latch_active_layer == LatchLayer::Main {
                 if storage.query(|s| s.in_mute) {
@@ -483,7 +485,7 @@ pub async fn run(
                         1,
                         Led::Top,
                         rnd_color,
-                        Brightness::Custom((last_out / 16) as u8),
+                        Brightness::Custom((out / 16) as u8),
                     );
                 }
             }


### PR DESCRIPTION
Closes #510

## Summary

- The MIDI CC send guard `last_out / 32 != val / 32` divides the 12-bit range into 128 uniform buckets of 32. Bucket 127 spans vals 4064–4095, but `scale_bits_12_7` only produces CC 127 for val = 4095 exactly.
- When val first enters bucket 127 (e.g. val = 4064), CC 126 is sent and the guard never fires again within the bucket — CC 127 is unreachable.
- Fixed by replacing the guard with a direct comparison of the actual CC value: `val as u32 * 127 / 4095 != last_out as u32 * 127 / 4095`. This fires exactly when the MIDI CC output changes, including the transition to 127.

Affected apps: LFO, LFO+, Random CC/CV, Random+.

## Test plan

- [ ] `cargo clippy -p faderpunk --target thumbv8m.main-none-eabihf -- -D warnings` — clean
- [ ] `cargo fmt -- --check` — clean
- [ ] Hardware: set LFO to unipolar, full attenuation, monitor MIDI CC output — should reach 127 at peak
- [ ] Hardware: same test for rnd at full speed and full attenuation

🤖 Generated with [Claude Code](https://claude.com/claude-code)