### PR TITLE
feat(faderpunk): add Range param to Quantizer, Slew Limiter, and Offset+Attenuverter

### DIFF
--- a/configurator/src/components/ManualTab.tsx
+++ b/configurator/src/components/ManualTab.tsx
@@ -537,13 +537,13 @@ const apps: ManualAppData[] = [
     description: "Offset and attenuverter module",
     color: "Rose",
     icon: "attenuate",
-    params: ["Color"],
+    params: ["Color", "Range"],
     storage: ["Attenuation", "Offset", "Offset toggle", "Attenuation toggle"],
-    text: "This app provides offset and attenuverter functionality. The input and output range is ±5V, and the attenuverter has a maximum gain of 2x. Color can be set in the configurator. Jack 1 is the input, Jack 2 is the output. Main functions include Fader 1 for offset and Fader 2 for attenuvertion. Button 1 toggles the offset on or off, Button 2 toggles the attenuvertion on or off. When both of these are off the app acts as a simple pass through.",
+    text: "This app provides offset and attenuverter functionality. The input and output range is configurable as either ±5V (default) or 0–10V via the Range parameter, and the attenuverter has a maximum gain of 2x. Color can be set in the configurator. Jack 1 is the input, Jack 2 is the output. Main functions include Fader 1 for offset and Fader 2 for attenuvertion. Button 1 toggles the offset on or off, Button 2 toggles the attenuvertion on or off. When both of these are off the app acts as a simple pass through.",
     channels: [
       {
         jackTitle: "Input",
-        jackDescription: "Accepts ±5V signals",
+        jackDescription: "Accepts ±5V or 0–10V signals (set by Range)",
         faderTitle: "Offset",
         faderDescription: "Applies a DC offset to the input signal",
         fnTitle: "Kill Offset",
@@ -553,7 +553,7 @@ const apps: ManualAppData[] = [
       },
       {
         jackTitle: "Output",
-        jackDescription: "Outputs ±5V signals",
+        jackDescription: "Outputs ±5V or 0–10V signals (set by Range)",
         faderTitle: "Attenuverter",
         faderDescription: "Scales and inverts the input signal (max gain 2x)",
         fnTitle: "Kill Attenuverter",
@@ -570,13 +570,13 @@ const apps: ManualAppData[] = [
     description: "Slows CV changes with offset and attenuverter",
     color: "Green",
     icon: "soft-random",
-    params: ["Color"],
+    params: ["Color", "Range"],
     storage: ["Attack", "Attenuvertion", "Offset"],
-    text: "This app combines a slew limiter with offset and attenuverter functions. Input and output range is ±5V. Jack 1 is the input, Jack 2 is the output. Color can be set in the configurator. Main functions include Fader 1 for attack and Fader 2 for decay. Shift + Fader 1 sets offset, Shift + Fader 2 sets attenuvertion. Button 1 kills the offset, Button 2 sets the attenuvertion.",
+    text: "This app combines a slew limiter with offset and attenuverter functions. Input and output range is configurable as either ±5V (default) or 0–10V via the Range parameter. Jack 1 is the input, Jack 2 is the output. Color can be set in the configurator. Main functions include Fader 1 for attack and Fader 2 for decay. Shift + Fader 1 sets offset, Shift + Fader 2 sets attenuvertion. Button 1 kills the offset, Button 2 sets the attenuvertion.",
     channels: [
       {
         jackTitle: "Input",
-        jackDescription: "Accepts ±5V signals",
+        jackDescription: "Accepts ±5V or 0–10V signals (set by Range)",
         faderTitle: "Attack",
         faderDescription: "Sets the attack time of the slew limiter",
         faderPlusShiftTitle: "Offset",
@@ -588,7 +588,7 @@ const apps: ManualAppData[] = [
       },
       {
         jackTitle: "Output",
-        jackDescription: "Outputs ±5V signals",
+        jackDescription: "Outputs ±5V or 0–10V signals (set by Range)",
         faderTitle: "Decay",
         faderDescription: "Sets the decay time of the slew limiter",
         faderPlusShiftTitle: "Attenuverter",
@@ -647,13 +647,13 @@ const apps: ManualAppData[] = [
     description: "Quantize CV passing through",
     color: "Blue",
     icon: "quantize",
-    params: ["Color"],
+    params: ["Color", "Range"],
     storage: ["Octave shift", "Semitone shift", "Offset toggles"],
-    text: "This app is a simple quantizer that processes CV signals within a ±5V range. Jack 1 is the input, Jack 2 is the output. The quantizer applies pitch quantization to the incoming CV. Fader 1 performs semitone shifts (0–12 semitones), and Fader 2 performs octave shifts (±5 octaves). These shifts are applied before quantization. Button 1 toggles semitone shift, and Button 2 toggles octave shift.",
+    text: "This app is a simple quantizer that processes CV signals. The input and output range is configurable as either ±5V (default) or 0–10V via the Range parameter. Jack 1 is the input, Jack 2 is the output. The quantizer applies pitch quantization to the incoming CV. Fader 1 performs semitone shifts (0–12 semitones), and Fader 2 performs octave shifts (±5 octaves). These shifts are applied before quantization. Button 1 toggles semitone shift, and Button 2 toggles octave shift.",
     channels: [
       {
         jackTitle: "Input",
-        jackDescription: "Accepts ±5V CV signals",
+        jackDescription: "Accepts ±5V or 0–10V CV signals (set by Range)",
         faderTitle: "Semitone Shift",
         faderDescription: "Shifts the CV by 0–12 semitones before quantization",
         fnTitle: "Toggle Semitone Shift",
@@ -663,7 +663,8 @@ const apps: ManualAppData[] = [
       },
       {
         jackTitle: "Output",
-        jackDescription: "Outputs quantized ±5V CV signals",
+        jackDescription:
+          "Outputs quantized ±5V or 0–10V CV signals (set by Range)",
         faderTitle: "Octave Shift",
         faderDescription: "Shifts the CV by ±5 octaves before quantization",
         fnTitle: "Toggle Octave Shift",

--- a/faderpunk/src/apps/offset_att.rs
+++ b/faderpunk/src/apps/offset_att.rs
@@ -16,7 +16,7 @@ use libfp::{
 use crate::app::{App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
 
 pub const CHANNELS: usize = 2;
-pub const PARAMS: usize = 1;
+pub const PARAMS: usize = 2;
 
 pub static CONFIG: Config<PARAMS> = Config::new(
     "Offset+Attenuverter",
@@ -36,10 +36,15 @@ pub static CONFIG: Config<PARAMS> = Config::new(
         Color::Violet,
         Color::Yellow,
     ],
+})
+.add_param(Param::Range {
+    name: "Range",
+    variants: &[Range::_0_10V, Range::_Neg5_5V],
 });
 
 pub struct Params {
     color: Color,
+    range: Range,
 }
 
 impl AppParams for Params {
@@ -49,12 +54,14 @@ impl AppParams for Params {
         }
         Some(Self {
             color: Color::from_value(values[0]),
+            range: Range::from_value(values[1]),
         })
     }
 
     fn to_values(&self) -> Vec<Value, APP_MAX_PARAMS> {
         let mut vec = Vec::new();
         vec.push(self.color.into()).unwrap();
+        vec.push(self.range.into()).unwrap();
         vec
     }
 }
@@ -82,6 +89,7 @@ impl AppStorage for Storage {}
 pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMutex, bool>) {
     let param_store = ParamStore::<Params>::new(app.app_id, app.layout_id, Params {
         color: Color::Rose,
+        range: Range::_Neg5_5V,
     });
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
 
@@ -111,10 +119,10 @@ pub async fn run(
     let faders = app.use_faders();
     let leds = app.use_leds();
 
-    let led_color = params.query(|p| p.color);
+    let (led_color, range) = params.query(|p| (p.color, p.range));
 
-    let input = app.make_in_jack(0, Range::_Neg5_5V).await;
-    let output = app.make_out_jack(1, Range::_Neg5_5V).await;
+    let input = app.make_in_jack(0, range).await;
+    let output = app.make_out_jack(1, range).await;
 
     for n in 0..=1 {
         if storage.query(|s| s.offset_att_toggle[n]) {

--- a/faderpunk/src/apps/quantizer.rs
+++ b/faderpunk/src/apps/quantizer.rs
@@ -15,7 +15,7 @@ use libfp::{Config, Param, Range, Value};
 use crate::app::{App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
 
 pub const CHANNELS: usize = 2;
-pub const PARAMS: usize = 1;
+pub const PARAMS: usize = 2;
 
 pub static CONFIG: Config<PARAMS> = Config::new(
     "Quantizer",
@@ -35,10 +35,15 @@ pub static CONFIG: Config<PARAMS> = Config::new(
         Color::Violet,
         Color::Yellow,
     ],
+})
+.add_param(Param::Range {
+    name: "Range",
+    variants: &[Range::_0_10V, Range::_Neg5_5V],
 });
 
 pub struct Params {
     color: Color,
+    range: Range,
 }
 
 impl AppParams for Params {
@@ -48,12 +53,14 @@ impl AppParams for Params {
         }
         Some(Self {
             color: Color::from_value(values[0]),
+            range: Range::from_value(values[1]),
         })
     }
 
     fn to_values(&self) -> Vec<Value, APP_MAX_PARAMS> {
         let mut vec = Vec::new();
         vec.push(self.color.into()).unwrap();
+        vec.push(self.range.into()).unwrap();
         vec
     }
 }
@@ -81,6 +88,7 @@ impl AppStorage for Storage {}
 pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMutex, bool>) {
     let param_store = ParamStore::<Params>::new(app.app_id, app.layout_id, Params {
         color: Color::Blue,
+        range: Range::_Neg5_5V,
     });
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
 
@@ -106,14 +114,13 @@ pub async fn run(
     params: &ParamStore<Params>,
     storage: &ManagedStorage<Storage>,
 ) {
-    let led_color = params.query(|p| p.color);
+    let (led_color, range) = params.query(|p| (p.color, p.range));
     let buttons = app.use_buttons();
     let faders = app.use_faders();
     let leds = app.use_leds();
     leds.set(0, Led::Button, led_color, Brightness::Mid);
     leds.set(1, Led::Button, led_color, Brightness::Mid);
 
-    let range = Range::_Neg5_5V;
     let quantizer = app.use_quantizer(range);
     let _input = app.make_in_jack(0, range).await;
     let output = app.make_out_jack(1, range).await;

--- a/faderpunk/src/apps/slew.rs
+++ b/faderpunk/src/apps/slew.rs
@@ -16,7 +16,7 @@ use libfp::{
 use crate::app::{App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
 
 pub const CHANNELS: usize = 2;
-pub const PARAMS: usize = 1;
+pub const PARAMS: usize = 2;
 
 const BUTTON_BRIGHTNESS: Brightness = Brightness::Mid;
 
@@ -38,10 +38,15 @@ pub static CONFIG: Config<PARAMS> = Config::new(
         Color::Violet,
         Color::Yellow,
     ],
+})
+.add_param(Param::Range {
+    name: "Range",
+    variants: &[Range::_0_10V, Range::_Neg5_5V],
 });
 
 pub struct Params {
     color: Color,
+    range: Range,
 }
 
 impl AppParams for Params {
@@ -51,12 +56,14 @@ impl AppParams for Params {
         }
         Some(Self {
             color: Color::from_value(values[0]),
+            range: Range::from_value(values[1]),
         })
     }
 
     fn to_values(&self) -> Vec<Value, APP_MAX_PARAMS> {
         let mut vec = Vec::new();
         vec.push(self.color.into()).unwrap();
+        vec.push(self.range.into()).unwrap();
         vec
     }
 }
@@ -84,6 +91,7 @@ impl AppStorage for Storage {}
 pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMutex, bool>) {
     let param_store = ParamStore::<Params>::new(app.app_id, app.layout_id, Params {
         color: Color::Green,
+        range: Range::_Neg5_5V,
     });
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
     param_store.load().await;
@@ -108,13 +116,13 @@ pub async fn run(
     params: &ParamStore<Params>,
     storage: &ManagedStorage<Storage>,
 ) {
-    let led_color = params.query(|p| p.color);
+    let (led_color, range) = params.query(|p| (p.color, p.range));
 
     let buttons = app.use_buttons();
     let faders = app.use_faders();
     let leds = app.use_leds();
-    let input = app.make_in_jack(0, Range::_Neg5_5V).await;
-    let output = app.make_out_jack(1, Range::_Neg5_5V).await;
+    let input = app.make_in_jack(0, range).await;
+    let output = app.make_out_jack(1, range).await;
 
     let glob_latch_layer = app.make_global(LatchLayer::Main);
 


### PR DESCRIPTION
Closes #514

## Summary

- Quantizer, Slew Limiter, and Offset+Attenuverter were the only CV apps without a user-selectable range — all three were hardcoded to `_Neg5_5V`
- Adds `Param::Range [_0_10V, _Neg5_5V]` to each, so the hardware ADC/DAC calibration matches the connected signal range
- Default remains `_Neg5_5V` (existing behaviour on first boot after upgrade)

## Test plan

- [ ] `cargo clippy -p faderpunk --target thumbv8m.main-none-eabihf -- -D warnings` — clean
- [ ] `cargo fmt -- --check` — clean
- [ ] Hardware: set Quantizer to `_0_10V`, feed a 0–10V CV source — pitch tracking should be correct
- [ ] Hardware: set Slew to `_0_10V`, verify slew behaviour on a unipolar signal
- [ ] Hardware: set Offset+Attenuverter to `_0_10V`, verify attenuation/offset work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)