### PR TITLE
feat: add 1.2V/Oct (Buchla) mode to quantizer and pitch apps

### DIFF
--- a/configurator/src/components/input/AppParam.tsx
+++ b/configurator/src/components/input/AppParam.tsx
@@ -21,6 +21,7 @@ import { ParamMidiMode } from "./ParamMidiMode.tsx";
 import { ParamMidiNote } from "./ParamMidiNote.tsx";
 import { ParamMidiNrpn } from "./ParamMidiNrpn.tsx";
 import { ParamMidiOut } from "./ParamMidiOut.tsx";
+import { ParamVoltPerOct } from "./ParamVoltPerOct.tsx";
 
 interface Props {
   defaultValue:
@@ -197,6 +198,15 @@ export const AppParam = ({
       return (
         <ParamMidiNrpn
           defaultValue={defaultValue as boolean}
+          paramIndex={paramIndex}
+          register={register}
+        />
+      );
+    }
+    case "VoltPerOct": {
+      return (
+        <ParamVoltPerOct
+          defaultValue={defaultValue as string}
           paramIndex={paramIndex}
           register={register}
         />

--- a/configurator/src/components/input/ParamVoltPerOct.tsx
+++ b/configurator/src/components/input/ParamVoltPerOct.tsx
@@ -1,0 +1,39 @@
+import { useMemo } from "react";
+import { type UseFormRegister, type FieldValues } from "react-hook-form";
+import { Select, SelectItem } from "@heroui/select";
+
+import { selectProps } from "./defaultProps";
+
+interface Props {
+  defaultValue: string;
+  paramIndex: number;
+  register: UseFormRegister<FieldValues>;
+}
+
+type Item = { key: string; value: string };
+
+const ITEMS: Item[] = [
+  { key: "Standard", value: "1V/Oct (Eurorack)" },
+  { key: "Buchla", value: "1.2V/Oct (Buchla)" },
+];
+
+export const ParamVoltPerOct = ({
+  defaultValue,
+  paramIndex,
+  register,
+}: Props) => {
+  const items = useMemo(() => ITEMS, []);
+
+  return (
+    <Select
+      defaultSelectedKeys={[defaultValue]}
+      {...register(`param-VoltPerOct-${paramIndex}`)}
+      {...selectProps}
+      label="V/Oct Standard"
+      items={items}
+      placeholder="V/Oct Standard"
+    >
+      {(item: Item) => <SelectItem>{item.value}</SelectItem>}
+    </Select>
+  );
+};

--- a/configurator/src/utils/utils.ts
+++ b/configurator/src/utils/utils.ts
@@ -5,6 +5,7 @@ import {
   type Note,
   type Range,
   type Value,
+  type VoltPerOct,
   type Waveform,
 } from "@atov/fp-config";
 
@@ -85,6 +86,9 @@ export const getDefaultValue = (val: Value) => {
     case "MidiNrpn": {
       return val.value;
     }
+    case "VoltPerOct": {
+      return val.value.tag;
+    }
   }
 };
 
@@ -139,6 +143,8 @@ const getParamValue = (
       return { tag: "MidiMode", value: { tag: value as MidiModeTag } };
     case "MidiNrpn":
       return { tag: "MidiNrpn", value: value as boolean };
+    case "VoltPerOct":
+      return { tag: "VoltPerOct", value: { tag: value as VoltPerOct["tag"] } };
     default:
       return undefined;
   }

--- a/configurator/src/utils/validators.ts
+++ b/configurator/src/utils/validators.ts
@@ -130,6 +130,17 @@ export const getParamSchema = (param: Param) => {
           value: { tag: "Note" },
         });
     }
+    case "VoltPerOct": {
+      return z
+        .object({
+          tag: z.literal("VoltPerOct"),
+          value: z.object({ tag: z.enum(["Standard", "Buchla"]) }),
+        })
+        .catch({
+          tag: "VoltPerOct",
+          value: { tag: "Standard" },
+        });
+    }
     default: {
       return z.never();
     }

--- a/faderpunk/src/app.rs
+++ b/faderpunk/src/app.rs
@@ -16,7 +16,7 @@ use libfp::{
     quantizer::{Pitch, QuantizerState},
     utils::{scale_bits_12_7, scale_bits_14_12},
     Brightness, ClockDivision, Color, Key, MidiCc, MidiChannel, MidiIn, MidiNote, MidiOut, Note,
-    Range, TakeoverMode,
+    Range, TakeoverMode, VoltPerOct,
 };
 
 use crate::{
@@ -616,13 +616,15 @@ impl Die {
 
 pub struct Quantizer {
     range: Range,
+    vpo: VoltPerOct,
     state: RefCell<QuantizerState>,
 }
 
 impl Quantizer {
-    pub fn new(range: Range) -> Self {
+    pub fn new(range: Range, vpo: VoltPerOct) -> Self {
         Self {
             range,
+            vpo,
             state: RefCell::new(QuantizerState::default()),
         }
     }
@@ -631,7 +633,7 @@ impl Quantizer {
         let value = value.clamp(0, 4095);
         let quantizer = QUANTIZER.get().lock().await;
         let mut state = self.state.borrow_mut();
-        quantizer.get_quantized_note(&mut state, value, self.range)
+        quantizer.get_quantized_note(&mut state, value, self.range, self.vpo)
     }
     /// Get Quantizer scale
     #[allow(dead_code)]
@@ -776,8 +778,8 @@ impl<const N: usize> App<N> {
         Clock::new()
     }
 
-    pub fn use_quantizer(&self, range: Range) -> Quantizer {
-        Quantizer::new(range)
+    pub fn use_quantizer(&self, range: Range, vpo: VoltPerOct) -> Quantizer {
+        Quantizer::new(range, vpo)
     }
 
     pub fn use_midi_input(&self, midi_in: MidiIn, midi_channel: MidiChannel) -> MidiInput {

--- a/faderpunk/src/apps/clkturing.rs
+++ b/faderpunk/src/apps/clkturing.rs
@@ -11,13 +11,13 @@ use serde::{Deserialize, Serialize};
 
 use libfp::{
     ext::FromValue, latch::LatchLayer, AppIcon, Brightness, Color, Config, Curve, MidiCc,
-    MidiChannel, MidiMode, MidiNote, MidiOut, Param, Range, Value, APP_MAX_PARAMS,
+    MidiChannel, MidiMode, MidiNote, MidiOut, Param, Range, Value, VoltPerOct, APP_MAX_PARAMS,
 };
 
 use crate::app::{App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
 
 pub const CHANNELS: usize = 2;
-pub const PARAMS: usize = 8;
+pub const PARAMS: usize = 9;
 
 pub static CONFIG: Config<PARAMS> = Config::new(
     "Turing+",
@@ -49,7 +49,8 @@ pub static CONFIG: Config<PARAMS> = Config::new(
 })
 .add_param(Param::MidiNote { name: "Base note" })
 .add_param(Param::MidiNrpn)
-.add_param(Param::MidiOut);
+.add_param(Param::MidiOut)
+.add_param(Param::VoltPerOct);
 
 pub struct Params {
     midi_channel: MidiChannel,
@@ -60,6 +61,7 @@ pub struct Params {
     color: Color,
     range: Range,
     nrpn: bool,
+    vpo: VoltPerOct,
 }
 
 impl AppParams for Params {
@@ -76,6 +78,7 @@ impl AppParams for Params {
             midi_note: MidiNote::from_value(values[5]),
             nrpn: bool::from_value(values[6]),
             midi_out: MidiOut::from_value(values[7]),
+            vpo: VoltPerOct::from_value(values[8]),
         })
     }
 
@@ -89,6 +92,7 @@ impl AppParams for Params {
         vec.push(self.midi_note.into()).unwrap();
         vec.push(Value::MidiNrpn(self.nrpn)).unwrap();
         vec.push(self.midi_out.into()).unwrap();
+        vec.push(self.vpo.into()).unwrap();
         vec
     }
 }
@@ -122,6 +126,7 @@ pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMut
         color: Color::Pink,
         range: Range::_0_5V,
             nrpn: false,
+            vpo: VoltPerOct::Standard,
     });
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
 
@@ -147,7 +152,7 @@ pub async fn run(
     params: &ParamStore<Params>,
     storage: &ManagedStorage<Storage>,
 ) {
-    let (midi_mode, midi_cc, base_note, midi_out, midi_chan, led_color, range, nrpn) =
+    let (midi_mode, midi_cc, base_note, midi_out, midi_chan, led_color, range, nrpn, vpo) =
         params.query(|p| {
             (
                 p.midi_mode,
@@ -158,6 +163,7 @@ pub async fn run(
                 p.color,
                 p.range,
                 p.nrpn,
+                p.vpo,
             )
         });
 
@@ -178,7 +184,7 @@ pub async fn run(
     let recall_flag = app.make_global(false);
     let midi_note = app.make_global(MidiNote::from(0));
 
-    let quantizer = app.use_quantizer(range);
+    let quantizer = app.use_quantizer(range, vpo);
 
     leds.set(0, Led::Button, led_color, Brightness::Mid);
     leds.set(1, Led::Button, led_color, Brightness::Mid);
@@ -219,7 +225,7 @@ pub async fn run(
 
                 let out = quantizer.get_quantized_note(att_reg).await;
 
-                output.set_value(out.as_counts(range));
+                output.set_value(out.as_counts(range, vpo));
                 leds.set(
                     0,
                     Led::Top,

--- a/faderpunk/src/apps/cv2midinote.rs
+++ b/faderpunk/src/apps/cv2midinote.rs
@@ -10,12 +10,12 @@ use libfp::{
 };
 use serde::{Deserialize, Serialize};
 
-use libfp::{ext::FromValue, Config, Param, Range, Value};
+use libfp::{ext::FromValue, Config, Param, Range, Value, VoltPerOct};
 
 use crate::app::{App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
 
 pub const CHANNELS: usize = 2;
-pub const PARAMS: usize = 5;
+pub const PARAMS: usize = 6;
 
 const BUTTON_BRIGHTNESS: Brightness = Brightness::Mid;
 
@@ -50,7 +50,8 @@ pub static CONFIG: Config<PARAMS> = Config::new(
         Color::Yellow,
     ],
 })
-.add_param(Param::MidiOut);
+.add_param(Param::MidiOut)
+.add_param(Param::VoltPerOct);
 
 pub struct Params {
     range: Range,
@@ -58,6 +59,7 @@ pub struct Params {
     midi_out: MidiOut,
     delay: i32,
     color: Color,
+    vpo: VoltPerOct,
 }
 
 impl AppParams for Params {
@@ -71,6 +73,7 @@ impl AppParams for Params {
             delay: i32::from_value(values[2]),
             color: Color::from_value(values[3]),
             midi_out: MidiOut::from_value(values[4]),
+            vpo: VoltPerOct::from_value(values[5]),
         })
     }
 
@@ -81,6 +84,7 @@ impl AppParams for Params {
         vec.push(self.delay.into()).unwrap();
         vec.push(self.color.into()).unwrap();
         vec.push(self.midi_out.into()).unwrap();
+        vec.push(self.vpo.into()).unwrap();
         vec
     }
 }
@@ -112,6 +116,7 @@ pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMut
         midi_out: MidiOut::default(),
         delay: 0,
         color: Color::Orange,
+        vpo: VoltPerOct::Standard,
     });
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
 
@@ -141,8 +146,8 @@ pub async fn run(
     let faders = app.use_faders();
     let leds = app.use_leds();
 
-    let (range, midi_out, midi_channel, delay, led_color) =
-        params.query(|p| (p.range, p.midi_out, p.midi_channel, p.delay, p.color));
+    let (range, midi_out, midi_channel, delay, led_color, vpo) =
+        params.query(|p| (p.range, p.midi_out, p.midi_channel, p.delay, p.color, p.vpo));
 
     let midi = app.use_midi_output(midi_out, midi_channel, false);
 
@@ -159,7 +164,7 @@ pub async fn run(
         leds.set(0, Led::Button, led_color, BUTTON_BRIGHTNESS);
     }
     let input = app.make_in_jack(0, range).await;
-    let quantizer = app.use_quantizer(range);
+    let quantizer = app.use_quantizer(range, vpo);
 
     let gate_in = app.make_in_jack(1, Range::_0_10V).await;
 

--- a/faderpunk/src/apps/cv2midinote.rs
+++ b/faderpunk/src/apps/cv2midinote.rs
@@ -165,6 +165,10 @@ pub async fn run(
     }
     let input = app.make_in_jack(0, range).await;
     let quantizer = app.use_quantizer(range, vpo);
+    let counts_per_oct: i32 = match vpo {
+        VoltPerOct::Standard => 410,
+        VoltPerOct::Buchla => 492,
+    };
 
     let gate_in = app.make_in_jack(1, Range::_0_10V).await;
 
@@ -190,9 +194,12 @@ pub async fn run(
                 if !muted_glob.get() {
                     app.delay_millis(delay as u64).await;
                     note = input.get_value() as i32;
-                    let oct = (storage.query(|s| s.fader_saved[1]) as i32 * 10 / 4095 - 5) * 410;
+                    let oct =
+                        (storage.query(|s| s.fader_saved[1]) as i32 * 10 / 4095 - 5)
+                            * counts_per_oct;
                     let st = if !storage.query(|s| s.offset_toggle) {
-                        (storage.query(|s| s.fader_saved[0]) as i32 * 12 / 4095) * 410 / 12
+                        (storage.query(|s| s.fader_saved[0]) as i32 * 12 / 4095) * counts_per_oct
+                            / 12
                     } else {
                         0
                     };

--- a/faderpunk/src/apps/midi2cv.rs
+++ b/faderpunk/src/apps/midi2cv.rs
@@ -14,13 +14,13 @@ use libfp::{
     latch::LatchLayer,
     utils::{bits_7_16, clickless, scale_bits_14_12, scale_bits_7_12},
     AppIcon, Brightness, Color, Config, Curve, MidiCc, MidiChannel, MidiIn, MidiNote, Param, Range,
-    Value, APP_MAX_PARAMS,
+    Value, VoltPerOct, APP_MAX_PARAMS,
 };
 
 use crate::app::{App, AppMidiEvent, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
 
 pub const CHANNELS: usize = 1;
-pub const PARAMS: usize = 9;
+pub const PARAMS: usize = 10;
 
 const LED_BRIGHTNESS: Brightness = Brightness::Mid;
 
@@ -64,7 +64,8 @@ pub static CONFIG: Config<PARAMS> = Config::new(
 .add_param(Param::MidiIn)
 .add_param(Param::bool {
     name: "Velocity on Gate",
-});
+})
+.add_param(Param::VoltPerOct);
 
 pub struct Params {
     mode: usize,
@@ -76,6 +77,7 @@ pub struct Params {
     bend_range: i32,
     color: Color,
     gate_vel: bool,
+    vpo: VoltPerOct,
 }
 
 impl AppParams for Params {
@@ -93,6 +95,7 @@ impl AppParams for Params {
             color: Color::from_value(values[6]),
             midi_in: MidiIn::from_value(values[7]),
             gate_vel: bool::from_value(values[8]),
+            vpo: VoltPerOct::from_value(values[9]),
         })
     }
 
@@ -107,6 +110,7 @@ impl AppParams for Params {
         vec.push(self.color.into()).unwrap();
         vec.push(self.midi_in.into()).unwrap();
         vec.push(self.gate_vel.into()).unwrap();
+        vec.push(self.vpo.into()).unwrap();
         vec
     }
 }
@@ -142,6 +146,7 @@ pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMut
         bend_range: 12,
         color: Color::Cyan,
         gate_vel: false,
+        vpo: VoltPerOct::Standard,
     });
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
 
@@ -187,8 +192,8 @@ pub async fn run(
     params: &ParamStore<Params>,
     storage: &ManagedStorage<Storage>,
 ) {
-    let (midi_in, midi_chan, midi_cc, curve, bend_range, led_color, note, mode, gate_vel) = params
-        .query(|p| {
+    let (midi_in, midi_chan, midi_cc, curve, bend_range, led_color, note, mode, gate_vel, vpo) =
+        params.query(|p| {
             (
                 p.midi_in,
                 p.midi_channel,
@@ -199,8 +204,14 @@ pub async fn run(
                 p.midi_note,
                 p.mode,
                 p.gate_vel,
+                p.vpo,
             )
         });
+
+    let counts_per_oct: u32 = match vpo {
+        VoltPerOct::Standard => 410,
+        VoltPerOct::Buchla => 492,
+    };
 
     let mut midi_in = app.use_midi_input(midi_in, midi_chan);
     let muted_glob = app.make_global(false);
@@ -444,11 +455,11 @@ pub async fn run(
                                 note_num += 1;
 
                                 let mut note_in = bits_7_16(key);
-                                note_in = (note_in as u32 * 410 / 12) as u16;
+                                note_in = (note_in as u32 * counts_per_oct / 12) as u16;
                                 let main_val = storage.query(|s| s.main_layer_val);
                                 let oct = (main_val as i32 * 10 / 4095) - 5;
                                 let note_out =
-                                    (note_in as i32 + oct * 410).clamp(0, 4095) as u16;
+                                    (note_in as i32 + oct * counts_per_oct as i32).clamp(0, 4095) as u16;
                                 pitch_glob.set(note_out);
                                 leds.set(
                                     0,
@@ -509,7 +520,7 @@ pub async fn run(
                 }
                 MidiMessage::PitchBend { bend } => match mode {
                     1 | 5 => {
-                        let out = (bend.as_f32() * bend_range as f32 * 410. / 12. + 2048.) as u16;
+                        let out = (bend.as_f32() * bend_range as f32 * counts_per_oct as f32 / 12. + 2048.) as u16;
                         offset_glob.set(out);
                         leds.set(
                             0,

--- a/faderpunk/src/apps/notefader.rs
+++ b/faderpunk/src/apps/notefader.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use libfp::{
     ext::FromValue, latch::LatchLayer, AppIcon, Brightness, ClockDivision, Color, Config,
-    MidiChannel, MidiNote, MidiOut, Param, Range, Value, APP_MAX_PARAMS,
+    MidiChannel, MidiNote, MidiOut, Param, Range, Value, VoltPerOct, APP_MAX_PARAMS,
 };
 
 use crate::app::{
@@ -17,7 +17,7 @@ use crate::app::{
 };
 
 pub const CHANNELS: usize = 1;
-pub const PARAMS: usize = 7;
+pub const PARAMS: usize = 8;
 
 const LED_BRIGHTNESS: Brightness = Brightness::Mid;
 
@@ -58,7 +58,8 @@ pub static CONFIG: Config<PARAMS> = Config::new(
         Color::Yellow,
     ],
 })
-.add_param(Param::MidiOut);
+.add_param(Param::MidiOut)
+.add_param(Param::VoltPerOct);
 
 pub struct Params {
     midi_channel: MidiChannel,
@@ -68,6 +69,7 @@ pub struct Params {
     gatel: i32,
     outmode: usize,
     color: Color,
+    vpo: VoltPerOct,
 }
 
 impl AppParams for Params {
@@ -83,6 +85,7 @@ impl AppParams for Params {
             outmode: usize::from_value(values[4]),
             color: Color::from_value(values[5]),
             midi_out: MidiOut::from_value(values[6]),
+            vpo: VoltPerOct::from_value(values[7]),
         })
     }
 
@@ -95,6 +98,7 @@ impl AppParams for Params {
         vec.push(self.outmode.into()).unwrap();
         vec.push(self.color.into()).unwrap();
         vec.push(self.midi_out.into()).unwrap();
+        vec.push(self.vpo.into()).unwrap();
         vec
     }
 }
@@ -129,6 +133,7 @@ pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMut
         gatel: 50,
         outmode: 0,
         color: Color::Rose,
+        vpo: VoltPerOct::Standard,
     });
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
 
@@ -155,7 +160,7 @@ pub async fn run(
     storage: &ManagedStorage<Storage>,
 ) {
     let range = Range::_0_10V;
-    let (midi_out, midi_chan, gatel, base_note, span, outmode, led_color) = params.query(|p| {
+    let (midi_out, midi_chan, gatel, base_note, span, outmode, led_color, vpo) = params.query(|p| {
         (
             p.midi_out,
             p.midi_channel,
@@ -164,12 +169,13 @@ pub async fn run(
             p.span,
             p.outmode,
             p.color,
+            p.vpo,
         )
     });
 
     let mut clock = app.use_clock();
     let ticks = clock.get_ticker();
-    let quantizer = app.use_quantizer(range);
+    let quantizer = app.use_quantizer(range, vpo);
 
     let fader = app.use_faders();
     let buttons = app.use_buttons();
@@ -205,7 +211,7 @@ pub async fn run(
 
         let out = quantizer.get_quantized_note(fadval).await;
         if outmode == 0 {
-            jack.set_value(out.as_counts(range));
+            jack.set_value(out.as_counts(range, vpo));
         } else {
             jack.set_value(4095)
         }

--- a/faderpunk/src/apps/quantizer.rs
+++ b/faderpunk/src/apps/quantizer.rs
@@ -130,6 +130,11 @@ pub async fn run(
         }
     }
 
+    let counts_per_oct: i16 = match vpo {
+        VoltPerOct::Standard => 410,
+        VoltPerOct::Buchla => 492,
+    };
+
     let main_loop = async {
         loop {
             app.delay_millis(1).await;
@@ -139,13 +144,15 @@ pub async fn run(
             let oct = if storage.query(|s| s.offset_toggles[1]) {
                 0
             } else {
-                (((storage.query(|s| s.oct) * 10 / 4095) as f32 - 5.) * 410.) as i16
+                (((storage.query(|s| s.oct) * 10 / 4095) as f32 - 5.) * counts_per_oct as f32)
+                    as i16
             };
 
             let st = if storage.query(|s| s.offset_toggles[0]) {
                 0
             } else {
-                ((storage.query(|s| s.st) * 12 / 4095) as f32 * 410. / 12.) as i16
+                ((storage.query(|s| s.st) * 12 / 4095) as f32 * counts_per_oct as f32 / 12.)
+                    as i16
             };
 
             let outval = quantizer
@@ -160,7 +167,7 @@ pub async fn run(
                 0,
                 Led::Top,
                 led_color,
-                Brightness::Custom((st * 255 / 410) as u8),
+                Brightness::Custom((st * 255 / counts_per_oct) as u8),
             );
         }
     };

--- a/faderpunk/src/apps/quantizer.rs
+++ b/faderpunk/src/apps/quantizer.rs
@@ -10,12 +10,12 @@ use libfp::{
 };
 use serde::{Deserialize, Serialize};
 
-use libfp::{Config, Param, Range, Value};
+use libfp::{Config, Param, Range, Value, VoltPerOct};
 
 use crate::app::{App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
 
 pub const CHANNELS: usize = 2;
-pub const PARAMS: usize = 1;
+pub const PARAMS: usize = 2;
 
 pub static CONFIG: Config<PARAMS> = Config::new(
     "Quantizer",
@@ -35,10 +35,12 @@ pub static CONFIG: Config<PARAMS> = Config::new(
         Color::Violet,
         Color::Yellow,
     ],
-});
+})
+.add_param(Param::VoltPerOct);
 
 pub struct Params {
     color: Color,
+    vpo: VoltPerOct,
 }
 
 impl AppParams for Params {
@@ -48,12 +50,14 @@ impl AppParams for Params {
         }
         Some(Self {
             color: Color::from_value(values[0]),
+            vpo: VoltPerOct::from_value(values[1]),
         })
     }
 
     fn to_values(&self) -> Vec<Value, APP_MAX_PARAMS> {
         let mut vec = Vec::new();
         vec.push(self.color.into()).unwrap();
+        vec.push(self.vpo.into()).unwrap();
         vec
     }
 }
@@ -81,6 +85,7 @@ impl AppStorage for Storage {}
 pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMutex, bool>) {
     let param_store = ParamStore::<Params>::new(app.app_id, app.layout_id, Params {
         color: Color::Blue,
+        vpo: VoltPerOct::Standard,
     });
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
 
@@ -106,7 +111,7 @@ pub async fn run(
     params: &ParamStore<Params>,
     storage: &ManagedStorage<Storage>,
 ) {
-    let led_color = params.query(|p| p.color);
+    let (led_color, vpo) = params.query(|p| (p.color, p.vpo));
     let buttons = app.use_buttons();
     let faders = app.use_faders();
     let leds = app.use_leds();
@@ -114,7 +119,7 @@ pub async fn run(
     leds.set(1, Led::Button, led_color, Brightness::Mid);
 
     let range = Range::_Neg5_5V;
-    let quantizer = app.use_quantizer(range);
+    let quantizer = app.use_quantizer(range, vpo);
     let _input = app.make_in_jack(0, range).await;
     let output = app.make_out_jack(1, range).await;
     for chan in 0..2 {
@@ -147,8 +152,8 @@ pub async fn run(
                 .get_quantized_note((inval + oct + st).clamp(0, 4095) as u16)
                 .await;
 
-            output.set_value(outval.as_counts(range));
-            let oct_led = split_unsigned_value(outval.as_counts(range));
+            output.set_value(outval.as_counts(range, vpo));
+            let oct_led = split_unsigned_value(outval.as_counts(range, vpo));
             leds.set(1, Led::Top, led_color, Brightness::Custom(oct_led[0]));
             leds.set(1, Led::Bottom, led_color, Brightness::Custom(oct_led[1]));
             leds.set(

--- a/faderpunk/src/apps/seq8.rs
+++ b/faderpunk/src/apps/seq8.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use libfp::{
     ext::FromValue, latch::LatchLayer, AppIcon, Brightness, ClockDivision, Color, Config,
-    MidiChannel, MidiNote, MidiOut, Param, Range, Value, APP_MAX_PARAMS,
+    MidiChannel, MidiNote, MidiOut, Param, Range, Value, VoltPerOct, APP_MAX_PARAMS,
 };
 
 use crate::app::{
@@ -17,7 +17,7 @@ use crate::app::{
 };
 
 pub const CHANNELS: usize = 8;
-pub const PARAMS: usize = 5;
+pub const PARAMS: usize = 6;
 
 pub static CONFIG: Config<PARAMS> = Config::new(
     "Sequencer",
@@ -37,7 +37,8 @@ pub static CONFIG: Config<PARAMS> = Config::new(
 .add_param(Param::MidiChannel {
     name: "MIDI Channel 4",
 })
-.add_param(Param::MidiOut);
+.add_param(Param::MidiOut)
+.add_param(Param::VoltPerOct);
 
 pub struct Params {
     midi_channel1: MidiChannel,
@@ -45,6 +46,7 @@ pub struct Params {
     midi_channel3: MidiChannel,
     midi_channel4: MidiChannel,
     midi_out: MidiOut,
+    vpo: VoltPerOct,
 }
 
 impl AppParams for Params {
@@ -58,6 +60,7 @@ impl AppParams for Params {
             midi_channel3: MidiChannel::from_value(values[2]),
             midi_channel4: MidiChannel::from_value(values[3]),
             midi_out: MidiOut::from_value(values[4]),
+            vpo: VoltPerOct::from_value(values[5]),
         })
     }
 
@@ -68,6 +71,7 @@ impl AppParams for Params {
         vec.push(self.midi_channel3.into()).unwrap();
         vec.push(self.midi_channel4.into()).unwrap();
         vec.push(self.midi_out.into()).unwrap();
+        vec.push(self.vpo.into()).unwrap();
         vec
     }
 }
@@ -111,6 +115,7 @@ pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMut
         midi_channel3: MidiChannel::from(3),
         midi_channel4: MidiChannel::from(4),
         midi_out: MidiOut::default(),
+        vpo: VoltPerOct::Standard,
     });
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
 
@@ -137,13 +142,14 @@ pub async fn run(
     storage: &ManagedStorage<Storage>,
 ) {
     let range = Range::_0_10V;
-    let (midi_out, midi_chan1, midi_chan2, midi_chan3, midi_chan4) = params.query(|p| {
+    let (midi_out, midi_chan1, midi_chan2, midi_chan3, midi_chan4, vpo) = params.query(|p| {
         (
             p.midi_out,
             p.midi_channel1,
             p.midi_channel2,
             p.midi_channel3,
             p.midi_channel4,
+            p.vpo,
         )
     });
 
@@ -173,7 +179,7 @@ pub async fn run(
         app.make_gate_jack(7, 4095).await,
     ];
 
-    let quantizer = app.use_quantizer(range);
+    let quantizer = app.use_quantizer(range, vpo);
 
     let page_glob: Global<usize> = app.make_global(0);
     let led_flag_glob: Global<bool> = app.make_global(true);
@@ -529,7 +535,7 @@ pub async fn run(
 
                                 midi[n].send_note_on(lastnote[n], 4095).await;
                                 gatelength1 = gatelength_glob.get();
-                                cv_out[n].set_value(out.as_counts(range));
+                                cv_out[n].set_value(out.as_counts(range, vpo));
                                 gate_out[n].set_high().await;
                             } else {
                                 gate_out[n].set_low().await;

--- a/faderpunk/src/apps/seq8.rs
+++ b/faderpunk/src/apps/seq8.rs
@@ -180,6 +180,10 @@ pub async fn run(
     ];
 
     let quantizer = app.use_quantizer(range, vpo);
+    let counts_per_oct: u32 = match vpo {
+        VoltPerOct::Standard => 410,
+        VoltPerOct::Buchla => 492,
+    };
 
     let page_glob: Global<usize> = app.make_global(0);
     let led_flag_glob: Global<bool> = app.make_global(true);
@@ -526,9 +530,10 @@ pub async fn run(
                                         (seq[clkindex] as u32
                                             * ((storage.query(|s| s.range_fader[n]) / 1000 + 1)
                                                 as u32)
-                                            * 410
+                                            * counts_per_oct
                                             / 4095) as u16
-                                            + (storage.query(|s| s.oct_fader[n]) / 1000) * 410,
+                                            + (storage.query(|s| s.oct_fader[n]) / 1000)
+                                                * counts_per_oct as u16,
                                     )
                                     .await;
                                 lastnote[n] = out.as_midi();

--- a/faderpunk/src/apps/turing.rs
+++ b/faderpunk/src/apps/turing.rs
@@ -12,7 +12,8 @@ use serde::{Deserialize, Serialize};
 
 use libfp::{
     ext::FromValue, latch::LatchLayer, AppIcon, Brightness, ClockDivision, Color, Config, Curve,
-    MidiCc, MidiChannel, MidiMode, MidiNote, MidiOut, Param, Range, Value, APP_MAX_PARAMS,
+    MidiCc, MidiChannel, MidiMode, MidiNote, MidiOut, Param, Range, Value, VoltPerOct,
+    APP_MAX_PARAMS,
 };
 
 use crate::app::{
@@ -20,7 +21,7 @@ use crate::app::{
 };
 
 pub const CHANNELS: usize = 1;
-pub const PARAMS: usize = 9;
+pub const PARAMS: usize = 10;
 
 pub static CONFIG: Config<PARAMS> = Config::new(
     "Turing",
@@ -57,7 +58,8 @@ pub static CONFIG: Config<PARAMS> = Config::new(
     variants: &[Range::_0_10V, Range::_0_5V, Range::_Neg5_5V],
 })
 .add_param(Param::MidiNrpn)
-.add_param(Param::MidiOut);
+.add_param(Param::MidiOut)
+.add_param(Param::VoltPerOct);
 
 pub struct Params {
     midi_mode: MidiMode,
@@ -69,6 +71,7 @@ pub struct Params {
     color: Color,
     range: Range,
     nrpn: bool,
+    vpo: VoltPerOct,
 }
 
 impl AppParams for Params {
@@ -86,6 +89,7 @@ impl AppParams for Params {
             range: Range::from_value(values[6]),
             nrpn: bool::from_value(values[7]),
             midi_out: MidiOut::from_value(values[8]),
+            vpo: VoltPerOct::from_value(values[9]),
         })
     }
 
@@ -100,6 +104,7 @@ impl AppParams for Params {
         vec.push(self.range.into()).unwrap();
         vec.push(Value::MidiNrpn(self.nrpn)).unwrap();
         vec.push(self.midi_out.into()).unwrap();
+        vec.push(self.vpo.into()).unwrap();
         vec
     }
 }
@@ -139,6 +144,7 @@ pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMut
             color: Color::Blue,
             range: Range::_0_5V,
             nrpn: false,
+            vpo: VoltPerOct::Standard,
         },
     );
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
@@ -165,7 +171,7 @@ pub async fn run(
     params: &ParamStore<Params>,
     storage: &ManagedStorage<Storage>,
 ) {
-    let (midi_out, midi_mode, midi_cc, led_color, midi_chan, base_note, gatel, range, nrpn) =
+    let (midi_out, midi_mode, midi_cc, led_color, midi_chan, base_note, gatel, range, nrpn, vpo) =
         params.query(|p| {
             (
                 p.midi_out,
@@ -177,6 +183,7 @@ pub async fn run(
                 p.gatel as u32,
                 p.range,
                 p.nrpn,
+                p.vpo,
             )
         });
 
@@ -186,7 +193,7 @@ pub async fn run(
     let mut clock = app.use_clock();
     let ticks = clock.get_ticker();
     let die = app.use_die();
-    let quantizer = app.use_quantizer(range);
+    let quantizer = app.use_quantizer(range, vpo);
 
     let midi = app.use_midi_output(midi_out, midi_chan, nrpn);
 
@@ -257,7 +264,7 @@ pub async fn run(
 
                         let out = quantizer.get_quantized_note(att_reg).await;
 
-                        jack.set_value(out.as_counts(range));
+                        jack.set_value(out.as_counts(range, vpo));
                         leds.set(
                             0,
                             Led::Top,

--- a/gen-bindings/src/main.rs
+++ b/gen-bindings/src/main.rs
@@ -43,6 +43,7 @@ fn main() {
             libfp::ResetSrc,
             libfp::TakeoverMode,
             libfp::Value,
+            libfp::VoltPerOct,
             libfp::Waveform
         ),
     )

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -918,6 +918,7 @@ pub enum Param {
     },
     MidiOut,
     MidiNrpn,
+    VoltPerOct,
 }
 
 #[allow(non_camel_case_types)]
@@ -939,6 +940,7 @@ pub enum Value {
     MidiNote(MidiNote),
     MidiOut(MidiOut),
     MidiNrpn(bool),
+    VoltPerOct(VoltPerOct),
 }
 
 impl From<Curve> for Value {
@@ -1157,6 +1159,29 @@ impl FromValue for Range {
     fn from_value(value: Value) -> Self {
         match value {
             Value::Range(r) => r,
+            _ => Self::default(),
+        }
+    }
+}
+
+/// Pitch CV standard: 1V/Oct (Eurorack) or 1.2V/Oct (Buchla)
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PostcardBindings, PartialEq)]
+pub enum VoltPerOct {
+    #[default]
+    Standard,
+    Buchla,
+}
+
+impl From<VoltPerOct> for Value {
+    fn from(value: VoltPerOct) -> Self {
+        Value::VoltPerOct(value)
+    }
+}
+
+impl FromValue for VoltPerOct {
+    fn from_value(value: Value) -> Self {
+        match value {
+            Value::VoltPerOct(v) => v,
             _ => Self::default(),
         }
     }

--- a/libfp/src/quantizer.rs
+++ b/libfp/src/quantizer.rs
@@ -1,7 +1,7 @@
 // V/oct quantizer, based on the ideas in
 // https://github.com/pichenettes/eurorack/blob/master/braids/quantizer_scales.h
 
-use crate::{Key, MidiNote, Note, Range};
+use crate::{Key, MidiNote, Note, Range, VoltPerOct};
 use heapless::Vec;
 use libm::roundf;
 
@@ -18,12 +18,16 @@ impl Pitch {
         self.octave as f32 + (self.note as u8 as f32 / 12.0)
     }
 
-    pub fn as_counts(&self, range: Range) -> u16 {
+    pub fn as_counts(&self, range: Range, vpo: VoltPerOct) -> u16 {
         let voltage = self.as_v_oct();
+        let scaled = match vpo {
+            VoltPerOct::Standard => voltage,
+            VoltPerOct::Buchla => voltage * 1.2,
+        };
         let counts = match range {
-            Range::_0_10V => (voltage / 10.0) * 4095.0,
-            Range::_0_5V => (voltage / 5.0) * 4095.0,
-            Range::_Neg5_5V => ((voltage + 5.0) / 10.0) * 4095.0,
+            Range::_0_10V => (scaled / 10.0) * 4095.0,
+            Range::_0_5V => (scaled / 5.0) * 4095.0,
+            Range::_Neg5_5V => ((scaled + 5.0) / 10.0) * 4095.0,
         };
 
         roundf(counts).clamp(0.0, 4095.0) as u16
@@ -141,6 +145,7 @@ impl Quantizer {
         state: &mut QuantizerState,
         value: u16,
         range: Range,
+        vpo: VoltPerOct,
     ) -> Pitch {
         // Version keeps track of the scale changes, if version does not match, reset state
         if state.version != self.version {
@@ -153,9 +158,12 @@ impl Quantizer {
             Range::_Neg5_5V => (value as f32 * (10.0 / 4095.0)) - 5.0,
         };
 
-        // Convert voltage to our fixed-point pitch representation (semitones * 128)
-        // We assume 1V/Oct, and 0V corresponds to C0 (semitone 0)
-        let pitch = roundf(input_voltage * 12.0 * 128.0) as i32;
+        // Convert voltage to semitones * 128 fixed-point. 0V = C0.
+        let semitones_per_volt = match vpo {
+            VoltPerOct::Standard => 12.0, // 1V/Oct
+            VoltPerOct::Buchla => 10.0,   // 1.2V/Oct: 1V = 10 semitones
+        };
+        let pitch = roundf(input_voltage * semitones_per_volt * 128.0) as i32;
 
         if pitch < state.previous_boundary || pitch > state.next_boundary {
             // Input is outside the current note's hysteresis boundary; find a new note
@@ -227,7 +235,7 @@ mod tests {
 
         // 0V -> should be C0
         assert_eq!(
-            q.get_quantized_note(&mut state, 0, Range::_0_10V),
+            q.get_quantized_note(&mut state, 0, Range::_0_10V, VoltPerOct::Standard),
             Pitch {
                 octave: 0,
                 note: Note::C
@@ -236,7 +244,7 @@ mod tests {
 
         // ~1V -> should be C1
         assert_eq!(
-            q.get_quantized_note(&mut state, 410, Range::_0_10V),
+            q.get_quantized_note(&mut state, 410, Range::_0_10V, VoltPerOct::Standard),
             Pitch {
                 octave: 1,
                 note: Note::C
@@ -247,7 +255,7 @@ mod tests {
         // 0.08V -> ~33 counts. Should snap down to C0
         let mut state_c0 = QuantizerState::default();
         assert_eq!(
-            q.get_quantized_note(&mut state_c0, 33, Range::_0_10V),
+            q.get_quantized_note(&mut state_c0, 33, Range::_0_10V, VoltPerOct::Standard),
             Pitch {
                 octave: 0,
                 note: Note::C
@@ -257,7 +265,7 @@ mod tests {
         // 0.09V -> ~37 counts. Should snap up to D0
         let mut state_d0 = QuantizerState::default();
         assert_eq!(
-            q.get_quantized_note(&mut state_d0, 37, Range::_0_10V),
+            q.get_quantized_note(&mut state_d0, 37, Range::_0_10V, VoltPerOct::Standard),
             Pitch {
                 octave: 0,
                 note: Note::D
@@ -269,7 +277,7 @@ mod tests {
         // Should quantize to closest note in scale: either F0 or G0.
         // 0.5V = 205 counts. F0=170 counts, G0=239 counts. 205 is closer to G0
         assert_eq!(
-            q.get_quantized_note(&mut state, 205, Range::_0_10V),
+            q.get_quantized_note(&mut state, 205, Range::_0_10V, VoltPerOct::Standard),
             Pitch {
                 octave: 0,
                 note: Note::G
@@ -285,7 +293,7 @@ mod tests {
 
         // ADC midpoint 2048 should map to 0V. Closest note in A minor is C0
         assert_eq!(
-            q.get_quantized_note(&mut state, 2048, Range::_Neg5_5V),
+            q.get_quantized_note(&mut state, 2048, Range::_Neg5_5V, VoltPerOct::Standard),
             Pitch {
                 octave: 0,
                 note: Note::C
@@ -294,7 +302,7 @@ mod tests {
 
         // -5V -> 0 counts. Should be C-5. Closest note is C-5
         assert_eq!(
-            q.get_quantized_note(&mut state, 0, Range::_Neg5_5V),
+            q.get_quantized_note(&mut state, 0, Range::_Neg5_5V, VoltPerOct::Standard),
             Pitch {
                 octave: -5,
                 note: Note::C
@@ -303,7 +311,7 @@ mod tests {
 
         // ~5V -> 4095 counts. Should be C5. Closest note is C5
         assert_eq!(
-            q.get_quantized_note(&mut state, 4095, Range::_Neg5_5V),
+            q.get_quantized_note(&mut state, 4095, Range::_Neg5_5V, VoltPerOct::Standard),
             Pitch {
                 octave: 5,
                 note: Note::C
@@ -320,7 +328,7 @@ mod tests {
         // Test the top of the 0-10V range
         // 10V -> 4095 counts. Should be C10
         assert_eq!(
-            q.get_quantized_note(&mut state, 4095, Range::_0_10V),
+            q.get_quantized_note(&mut state, 4095, Range::_0_10V, VoltPerOct::Standard),
             Pitch {
                 octave: 10,
                 note: Note::C
@@ -330,7 +338,7 @@ mod tests {
         // Test the bottom of the bipolar -5V to 5V range
         // -5V -> 0 counts. Should be C-5
         assert_eq!(
-            q.get_quantized_note(&mut state, 0, Range::_Neg5_5V),
+            q.get_quantized_note(&mut state, 0, Range::_Neg5_5V, VoltPerOct::Standard),
             Pitch {
                 octave: -5,
                 note: Note::C
@@ -340,7 +348,7 @@ mod tests {
         // Test the top of the bipolar -5V to 5V range
         // ~5V -> 4095 counts. Should be C5
         assert_eq!(
-            q.get_quantized_note(&mut state, 4095, Range::_Neg5_5V),
+            q.get_quantized_note(&mut state, 4095, Range::_Neg5_5V, VoltPerOct::Standard),
             Pitch {
                 octave: 5,
                 note: Note::C
@@ -360,7 +368,7 @@ mod tests {
 
         // Quantize a value just ABOVE the midpoint. It should snap to D0
         assert_eq!(
-            q.get_quantized_note(&mut state, 37, Range::_0_10V),
+            q.get_quantized_note(&mut state, 37, Range::_0_10V, VoltPerOct::Standard),
             Pitch {
                 octave: 0,
                 note: Note::D
@@ -371,7 +379,7 @@ mod tests {
         // A stateless quantizer would snap back to C0
         // With hysteresis, it should STAY on D0 because it hasn't crossed the new, lower boundary
         assert_eq!(
-            q.get_quantized_note(&mut state, 33, Range::_0_10V),
+            q.get_quantized_note(&mut state, 33, Range::_0_10V, VoltPerOct::Standard),
             Pitch {
                 octave: 0,
                 note: Note::D
@@ -381,11 +389,36 @@ mod tests {
         // Only when we provide a value far away from the boundary does it snap back
         // 10 counts is ~0.024V, clearly closer to C0
         assert_eq!(
-            q.get_quantized_note(&mut state, 10, Range::_0_10V),
+            q.get_quantized_note(&mut state, 10, Range::_0_10V, VoltPerOct::Standard),
             Pitch {
                 octave: 0,
                 note: Note::C
             }
+        );
+    }
+
+    #[test]
+    fn test_buchla_quantize() {
+        let mut q = Quantizer::default();
+        q.set_scale(Key::Chromatic, Note::C);
+        let mut state = QuantizerState::default();
+
+        // 1.2V → C1 (491 counts at 0-10V, 1.2/10 * 4095 ≈ 491)
+        assert_eq!(
+            q.get_quantized_note(&mut state, 491, Range::_0_10V, VoltPerOct::Buchla),
+            Pitch {
+                octave: 1,
+                note: Note::C
+            }
+        );
+        // C1 back to 491 counts
+        assert_eq!(
+            Pitch {
+                octave: 1,
+                note: Note::C
+            }
+            .as_counts(Range::_0_10V, VoltPerOct::Buchla),
+            491
         );
     }
 
@@ -400,10 +433,10 @@ mod tests {
             octave: 4,
             note: Note::A,
         };
-        assert_eq!(c4.as_counts(Range::_0_10V), 1638);
-        assert_eq!(a4.as_counts(Range::_0_10V), 1945);
-        assert_eq!(c4.as_counts(Range::_0_5V), 3276);
-        assert_eq!(c4.as_counts(Range::_Neg5_5V), 3686);
+        assert_eq!(c4.as_counts(Range::_0_10V, VoltPerOct::Standard), 1638);
+        assert_eq!(a4.as_counts(Range::_0_10V, VoltPerOct::Standard), 1945);
+        assert_eq!(c4.as_counts(Range::_0_5V, VoltPerOct::Standard), 3276);
+        assert_eq!(c4.as_counts(Range::_Neg5_5V, VoltPerOct::Standard), 3686);
     }
 
     #[test]
@@ -474,9 +507,9 @@ mod tests {
         let mut state = QuantizerState::default();
 
         // Perform some quantization operations
-        q.get_quantized_note(&mut state, 410, Range::_0_10V);
-        q.get_quantized_note(&mut state, 820, Range::_0_10V);
-        q.get_quantized_note(&mut state, 1230, Range::_0_10V);
+        q.get_quantized_note(&mut state, 410, Range::_0_10V, VoltPerOct::Standard);
+        q.get_quantized_note(&mut state, 820, Range::_0_10V, VoltPerOct::Standard);
+        q.get_quantized_note(&mut state, 1230, Range::_0_10V, VoltPerOct::Standard);
 
         // Key and tonic should remain unchanged
         assert_eq!(q.get_key(), Key::Mixolydian);


### PR DESCRIPTION
Closes #515

## Summary

- Adds `VoltPerOct` enum to `libfp` (`Standard` = 1V/Oct Eurorack, `Buchla` = 1.2V/Oct) with full serde/postcard support
- Updates quantizer math: `get_quantized_note` uses 10 semitones/V for Buchla (vs 12 for Standard); `Pitch::as_counts` scales voltage by 1.2× before range mapping
- Adds `VoltPerOct` param to all 6 quantizer-using apps: Quantizer, Turing, Turing+, Sequencer, Note Fader, CV→MIDI Note
- Adds `VoltPerOct` param to MIDI to CV (pitch mode uses hardcoded `410` counts/oct — replaced with `counts_per_oct` variable: 410 Standard / 492 Buchla); gate-floor `410` values are unchanged
- Regenerates TypeScript bindings; adds `ParamVoltPerOct` configurator component with "1V/Oct (Eurorack)" / "1.2V/Oct (Buchla)" labels

## Test plan

- [ ] All 76 `libfp` unit tests pass, including `test_buchla_quantize` (C1 at 1.2V → 491 counts round-trip)
- [ ] `cargo clippy` and `cargo fmt --check` clean
- [ ] Configurator TypeScript type-check and lint clean
- [ ] Hardware: set Turing or Quantizer to `1.2V/Oct (Buchla)`, verify one octave = 1.2V output with a tuner
- [ ] Hardware: set MIDI to CV (Pitch mode) to Buchla, verify pitch tracking is correct on a Buchla-compatible system

🤖 Generated with [Claude Code](https://claude.ai/claude-code)