### PR TITLE
feat(quantizer): add 1.2V/Oct Buchla mode, Key::Off passthrough, and per-app bypass

### DIFF
--- a/configurator/src/components/input/AppParam.tsx
+++ b/configurator/src/components/input/AppParam.tsx
@@ -21,6 +21,7 @@ import { ParamMidiMode } from "./ParamMidiMode.tsx";
 import { ParamMidiNote } from "./ParamMidiNote.tsx";
 import { ParamMidiNrpn } from "./ParamMidiNrpn.tsx";
 import { ParamMidiOut } from "./ParamMidiOut.tsx";
+import { ParamVoltPerOct } from "./ParamVoltPerOct.tsx";
 
 interface Props {
   defaultValue:
@@ -197,6 +198,15 @@ export const AppParam = ({
       return (
         <ParamMidiNrpn
           defaultValue={defaultValue as boolean}
+          paramIndex={paramIndex}
+          register={register}
+        />
+      );
+    }
+    case "VoltPerOct": {
+      return (
+        <ParamVoltPerOct
+          defaultValue={defaultValue as string}
           paramIndex={paramIndex}
           register={register}
         />

--- a/configurator/src/components/input/ParamVoltPerOct.tsx
+++ b/configurator/src/components/input/ParamVoltPerOct.tsx
@@ -1,0 +1,39 @@
+import { useMemo } from "react";
+import { type UseFormRegister, type FieldValues } from "react-hook-form";
+import { Select, SelectItem } from "@heroui/select";
+
+import { selectProps } from "./defaultProps";
+
+interface Props {
+  defaultValue: string;
+  paramIndex: number;
+  register: UseFormRegister<FieldValues>;
+}
+
+type Item = { key: string; value: string };
+
+const ITEMS: Item[] = [
+  { key: "Standard", value: "1V/Oct (Eurorack)" },
+  { key: "Buchla", value: "1.2V/Oct (Buchla)" },
+];
+
+export const ParamVoltPerOct = ({
+  defaultValue,
+  paramIndex,
+  register,
+}: Props) => {
+  const items = useMemo(() => ITEMS, []);
+
+  return (
+    <Select
+      defaultSelectedKeys={[defaultValue]}
+      {...register(`param-VoltPerOct-${paramIndex}`)}
+      {...selectProps}
+      label="V/Oct Standard"
+      items={items}
+      placeholder="V/Oct Standard"
+    >
+      {(item: Item) => <SelectItem key={item.key}>{item.value}</SelectItem>}
+    </Select>
+  );
+};

--- a/configurator/src/components/settings/QuantizerSettings.tsx
+++ b/configurator/src/components/settings/QuantizerSettings.tsx
@@ -37,6 +37,7 @@ const keyItems: QuantizerKeyItem[] = [
   { key: "Japanese", value: "Japanese" },
   { key: "Gamelan", value: "Gamelan" },
   { key: "HungarianMin", value: "Hungarian Minor" },
+  { key: "Off", value: "Off (passthrough)" },
 ];
 
 const tonicItems: QuantizerTonicItem[] = [

--- a/configurator/src/utils/class-helpers.ts
+++ b/configurator/src/utils/class-helpers.ts
@@ -65,6 +65,7 @@ export const QUANTIZER_KEY_COLORS: Record<string, string> = {
   Japanese: "bg-palette-violet",
   Gamelan: "bg-palette-light-blue",
   HungarianMin: "bg-palette-rose",
+  Off: "bg-black",
 };
 
 export const QUANTIZER_TONIC_COLORS: Record<string, string> = {

--- a/configurator/src/utils/utils.ts
+++ b/configurator/src/utils/utils.ts
@@ -5,6 +5,7 @@ import {
   type Note,
   type Range,
   type Value,
+  type VoltPerOct,
   type Waveform,
 } from "@atov/fp-config";
 
@@ -85,6 +86,9 @@ export const getDefaultValue = (val: Value) => {
     case "MidiNrpn": {
       return val.value;
     }
+    case "VoltPerOct": {
+      return val.value.tag;
+    }
   }
 };
 
@@ -139,6 +143,8 @@ const getParamValue = (
       return { tag: "MidiMode", value: { tag: value as MidiModeTag } };
     case "MidiNrpn":
       return { tag: "MidiNrpn", value: value as boolean };
+    case "VoltPerOct":
+      return { tag: "VoltPerOct", value: { tag: value as VoltPerOct["tag"] } };
     default:
       return undefined;
   }

--- a/configurator/src/utils/validators.ts
+++ b/configurator/src/utils/validators.ts
@@ -130,6 +130,17 @@ export const getParamSchema = (param: Param) => {
           value: { tag: "Note" },
         });
     }
+    case "VoltPerOct": {
+      return z
+        .object({
+          tag: z.literal("VoltPerOct"),
+          value: z.object({ tag: z.enum(["Standard", "Buchla"]) }),
+        })
+        .catch({
+          tag: "VoltPerOct",
+          value: { tag: "Standard" },
+        });
+    }
     default: {
       return z.never();
     }

--- a/faderpunk/src/app.rs
+++ b/faderpunk/src/app.rs
@@ -16,7 +16,7 @@ use libfp::{
     quantizer::{Pitch, QuantizerState},
     utils::{scale_bits_12_7, scale_bits_14_12},
     Brightness, ClockDivision, Color, Key, MidiCc, MidiChannel, MidiIn, MidiNote, MidiOut, Note,
-    Range, TakeoverMode,
+    Range, TakeoverMode, VoltPerOct,
 };
 
 use crate::{
@@ -624,22 +624,34 @@ impl Die {
 
 pub struct Quantizer {
     range: Range,
+    vpo: VoltPerOct,
+    bypass: bool,
     state: RefCell<QuantizerState>,
 }
 
 impl Quantizer {
-    pub fn new(range: Range) -> Self {
+    pub fn new(range: Range, vpo: VoltPerOct, bypass: bool) -> Self {
         Self {
             range,
+            vpo,
+            bypass,
             state: RefCell::new(QuantizerState::default()),
         }
     }
-    /// Quantize a note
+    /// Quantize a note.
+    ///
+    /// Returns a `Pitch` with `raw` set when either the global scale is `Key::Off`
+    /// or the per-app `bypass` flag is true — `as_counts()` will then return the
+    /// original ADC value instead of the quantized voltage.
     pub async fn get_quantized_note(&self, value: u16) -> Pitch {
         let value = value.clamp(0, 4095);
         let quantizer = QUANTIZER.get().lock().await;
         let mut state = self.state.borrow_mut();
-        quantizer.get_quantized_note(&mut state, value, self.range)
+        let mut pitch = quantizer.get_quantized_note(&mut state, value, self.range, self.vpo);
+        if self.bypass || quantizer.get_key() == Key::Off {
+            pitch.raw = Some(value);
+        }
+        pitch
     }
     /// Get Quantizer scale
     #[allow(dead_code)]
@@ -784,8 +796,8 @@ impl<const N: usize> App<N> {
         Clock::new()
     }
 
-    pub fn use_quantizer(&self, range: Range) -> Quantizer {
-        Quantizer::new(range)
+    pub fn use_quantizer(&self, range: Range, vpo: VoltPerOct, bypass: bool) -> Quantizer {
+        Quantizer::new(range, vpo, bypass)
     }
 
     pub fn use_midi_input(&self, midi_in: MidiIn, midi_channel: MidiChannel) -> MidiInput {

--- a/faderpunk/src/apps/clkturing.rs
+++ b/faderpunk/src/apps/clkturing.rs
@@ -11,13 +11,13 @@ use serde::{Deserialize, Serialize};
 
 use libfp::{
     ext::FromValue, latch::LatchLayer, AppIcon, Brightness, Color, Config, Curve, MidiCc,
-    MidiChannel, MidiMode, MidiNote, MidiOut, Param, Range, Value, APP_MAX_PARAMS,
+    MidiChannel, MidiMode, MidiNote, MidiOut, Param, Range, Value, VoltPerOct, APP_MAX_PARAMS,
 };
 
 use crate::app::{App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
 
 pub const CHANNELS: usize = 2;
-pub const PARAMS: usize = 8;
+pub const PARAMS: usize = 10;
 
 pub static CONFIG: Config<PARAMS> = Config::new(
     "Turing+",
@@ -49,7 +49,9 @@ pub static CONFIG: Config<PARAMS> = Config::new(
 })
 .add_param(Param::MidiNote { name: "Base note" })
 .add_param(Param::MidiNrpn)
-.add_param(Param::MidiOut);
+.add_param(Param::MidiOut)
+.add_param(Param::VoltPerOct)
+.add_param(Param::bool { name: "Bypass quantizer" });
 
 pub struct Params {
     midi_channel: MidiChannel,
@@ -60,6 +62,8 @@ pub struct Params {
     color: Color,
     range: Range,
     nrpn: bool,
+    vpo: VoltPerOct,
+    bypass: bool,
 }
 
 impl AppParams for Params {
@@ -76,6 +80,8 @@ impl AppParams for Params {
             midi_note: MidiNote::from_value(values[5]),
             nrpn: bool::from_value(values[6]),
             midi_out: MidiOut::from_value(values[7]),
+            vpo: VoltPerOct::from_value(values[8]),
+            bypass: bool::from_value(values[9]),
         })
     }
 
@@ -89,6 +95,8 @@ impl AppParams for Params {
         vec.push(self.midi_note.into()).unwrap();
         vec.push(Value::MidiNrpn(self.nrpn)).unwrap();
         vec.push(self.midi_out.into()).unwrap();
+        vec.push(self.vpo.into()).unwrap();
+        vec.push(self.bypass.into()).unwrap();
         vec
     }
 }
@@ -121,7 +129,9 @@ pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMut
         midi_out: MidiOut::default(),
         color: Color::Pink,
         range: Range::_0_5V,
-            nrpn: false,
+        nrpn: false,
+        vpo: VoltPerOct::Standard,
+        bypass: false,
     });
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
 
@@ -147,7 +157,7 @@ pub async fn run(
     params: &ParamStore<Params>,
     storage: &ManagedStorage<Storage>,
 ) {
-    let (midi_mode, midi_cc, base_note, midi_out, midi_chan, led_color, range, nrpn) =
+    let (midi_mode, midi_cc, base_note, midi_out, midi_chan, led_color, range, nrpn, vpo, bypass) =
         params.query(|p| {
             (
                 p.midi_mode,
@@ -158,6 +168,8 @@ pub async fn run(
                 p.color,
                 p.range,
                 p.nrpn,
+                p.vpo,
+                p.bypass,
             )
         });
 
@@ -178,7 +190,7 @@ pub async fn run(
     let recall_flag = app.make_global(false);
     let midi_note = app.make_global(MidiNote::from(0));
 
-    let quantizer = app.use_quantizer(range);
+    let quantizer = app.use_quantizer(range, vpo, bypass);
 
     leds.set(0, Led::Button, led_color, Brightness::Mid);
     leds.set(1, Led::Button, led_color, Brightness::Mid);
@@ -219,7 +231,7 @@ pub async fn run(
 
                 let out = quantizer.get_quantized_note(att_reg).await;
 
-                output.set_value(out.as_counts(range));
+                output.set_value(out.as_counts(range, vpo));
                 leds.set(
                     0,
                     Led::Top,

--- a/faderpunk/src/apps/cv2midinote.rs
+++ b/faderpunk/src/apps/cv2midinote.rs
@@ -9,13 +9,14 @@ use libfp::{
     MidiNote, MidiOut, APP_MAX_PARAMS,
 };
 use serde::{Deserialize, Serialize};
+use libm;
 
-use libfp::{ext::FromValue, Config, Param, Range, Value};
+use libfp::{ext::FromValue, Config, Param, Range, Value, VoltPerOct};
 
 use crate::app::{App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
 
 pub const CHANNELS: usize = 2;
-pub const PARAMS: usize = 5;
+pub const PARAMS: usize = 7;
 
 const BUTTON_BRIGHTNESS: Brightness = Brightness::Mid;
 
@@ -50,7 +51,9 @@ pub static CONFIG: Config<PARAMS> = Config::new(
         Color::Yellow,
     ],
 })
-.add_param(Param::MidiOut);
+.add_param(Param::MidiOut)
+.add_param(Param::VoltPerOct)
+.add_param(Param::bool { name: "Bypass quantizer" });
 
 pub struct Params {
     range: Range,
@@ -58,6 +61,8 @@ pub struct Params {
     midi_out: MidiOut,
     delay: i32,
     color: Color,
+    vpo: VoltPerOct,
+    bypass: bool,
 }
 
 impl AppParams for Params {
@@ -71,6 +76,8 @@ impl AppParams for Params {
             delay: i32::from_value(values[2]),
             color: Color::from_value(values[3]),
             midi_out: MidiOut::from_value(values[4]),
+            vpo: VoltPerOct::from_value(values[5]),
+            bypass: bool::from_value(values[6]),
         })
     }
 
@@ -81,6 +88,8 @@ impl AppParams for Params {
         vec.push(self.delay.into()).unwrap();
         vec.push(self.color.into()).unwrap();
         vec.push(self.midi_out.into()).unwrap();
+        vec.push(self.vpo.into()).unwrap();
+        vec.push(self.bypass.into()).unwrap();
         vec
     }
 }
@@ -112,6 +121,8 @@ pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMut
         midi_out: MidiOut::default(),
         delay: 0,
         color: Color::Orange,
+        vpo: VoltPerOct::Standard,
+        bypass: false,
     });
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
 
@@ -141,8 +152,8 @@ pub async fn run(
     let faders = app.use_faders();
     let leds = app.use_leds();
 
-    let (range, midi_out, midi_channel, delay, led_color) =
-        params.query(|p| (p.range, p.midi_out, p.midi_channel, p.delay, p.color));
+    let (range, midi_out, midi_channel, delay, led_color, vpo, bypass) =
+        params.query(|p| (p.range, p.midi_out, p.midi_channel, p.delay, p.color, p.vpo, p.bypass));
 
     let midi = app.use_midi_output(midi_out, midi_channel, false);
 
@@ -159,7 +170,8 @@ pub async fn run(
         leds.set(0, Led::Button, led_color, BUTTON_BRIGHTNESS);
     }
     let input = app.make_in_jack(0, range).await;
-    let quantizer = app.use_quantizer(range);
+    let quantizer = app.use_quantizer(range, vpo, false);
+    let counts_per_oct = vpo.counts_per_oct() as i32;
 
     let gate_in = app.make_in_jack(1, Range::_0_10V).await;
 
@@ -185,15 +197,30 @@ pub async fn run(
                 if !muted_glob.get() {
                     app.delay_millis(delay as u64).await;
                     note = input.get_value() as i32;
-                    let oct = (storage.query(|s| s.fader_saved[1]) as i32 * 10 / 4095 - 5) * 410;
+                    let oct = (storage.query(|s| s.fader_saved[1]) as i32 * 10 / 4095 - 5)
+                        * counts_per_oct;
                     let st = if !storage.query(|s| s.offset_toggle) {
-                        (storage.query(|s| s.fader_saved[0]) as i32 * 12 / 4095) * 410 / 12
+                        (storage.query(|s| s.fader_saved[0]) as i32 * 12 / 4095) * counts_per_oct
+                            / 12
                     } else {
                         0
                     };
                     note = (note + oct + st).clamp(0, 4095);
 
-                    midi_out = quantizer.get_quantized_note(note as u16).await.as_midi();
+                    midi_out = if bypass {
+                        // Chromatic bypass: quantize to nearest semitone regardless of global scale.
+                        // Mirrors the quantizer's internal voltage→semitone conversion.
+                        let voltage = match range {
+                            Range::_0_10V => note as f32 * (10.0 / 4095.0),
+                            Range::_0_5V => note as f32 * (5.0 / 4095.0),
+                            Range::_Neg5_5V => note as f32 * (10.0 / 4095.0) - 5.0,
+                        };
+                        let semitone =
+                            libm::roundf(voltage * vpo.semitones_per_volt()) as i32;
+                        MidiNote::from(semitone.clamp(0, 127))
+                    } else {
+                        quantizer.get_quantized_note(note as u16).await.as_midi()
+                    };
 
                     midi.send_note_on(midi_out, 4095).await;
                     note_on = true;

--- a/faderpunk/src/apps/notefader.rs
+++ b/faderpunk/src/apps/notefader.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use libfp::{
     ext::FromValue, latch::LatchLayer, AppIcon, Brightness, ClockDivision, Color, Config,
-    MidiChannel, MidiNote, MidiOut, Param, Range, Value, APP_MAX_PARAMS,
+    MidiChannel, MidiNote, MidiOut, Param, Range, Value, VoltPerOct, APP_MAX_PARAMS,
 };
 
 use crate::app::{
@@ -17,7 +17,7 @@ use crate::app::{
 };
 
 pub const CHANNELS: usize = 1;
-pub const PARAMS: usize = 7;
+pub const PARAMS: usize = 9;
 
 const LED_BRIGHTNESS: Brightness = Brightness::Mid;
 
@@ -58,7 +58,9 @@ pub static CONFIG: Config<PARAMS> = Config::new(
         Color::Yellow,
     ],
 })
-.add_param(Param::MidiOut);
+.add_param(Param::MidiOut)
+.add_param(Param::VoltPerOct)
+.add_param(Param::bool { name: "Bypass quantizer" });
 
 pub struct Params {
     midi_channel: MidiChannel,
@@ -68,6 +70,8 @@ pub struct Params {
     gatel: i32,
     outmode: usize,
     color: Color,
+    vpo: VoltPerOct,
+    bypass: bool,
 }
 
 impl AppParams for Params {
@@ -83,6 +87,8 @@ impl AppParams for Params {
             outmode: usize::from_value(values[4]),
             color: Color::from_value(values[5]),
             midi_out: MidiOut::from_value(values[6]),
+            vpo: VoltPerOct::from_value(values[7]),
+            bypass: bool::from_value(values[8]),
         })
     }
 
@@ -95,6 +101,8 @@ impl AppParams for Params {
         vec.push(self.outmode.into()).unwrap();
         vec.push(self.color.into()).unwrap();
         vec.push(self.midi_out.into()).unwrap();
+        vec.push(self.vpo.into()).unwrap();
+        vec.push(self.bypass.into()).unwrap();
         vec
     }
 }
@@ -129,6 +137,8 @@ pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMut
         gatel: 50,
         outmode: 0,
         color: Color::Rose,
+        vpo: VoltPerOct::Standard,
+        bypass: false,
     });
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
 
@@ -155,21 +165,24 @@ pub async fn run(
     storage: &ManagedStorage<Storage>,
 ) {
     let range = Range::_0_10V;
-    let (midi_out, midi_chan, gatel, base_note, span, outmode, led_color) = params.query(|p| {
-        (
-            p.midi_out,
-            p.midi_channel,
-            p.gatel as u32,
-            p.midi_note,
-            p.span,
-            p.outmode,
-            p.color,
-        )
-    });
+    let (midi_out, midi_chan, gatel, base_note, span, outmode, led_color, vpo, bypass) =
+        params.query(|p| {
+            (
+                p.midi_out,
+                p.midi_channel,
+                p.gatel as u32,
+                p.midi_note,
+                p.span,
+                p.outmode,
+                p.color,
+                p.vpo,
+                p.bypass,
+            )
+        });
 
     let mut clock = app.use_clock();
     let ticks = clock.get_ticker();
-    let quantizer = app.use_quantizer(range);
+    let quantizer = app.use_quantizer(range, vpo, bypass);
 
     let fader = app.use_faders();
     let buttons = app.use_buttons();
@@ -205,7 +218,7 @@ pub async fn run(
 
         let out = quantizer.get_quantized_note(fadval).await;
         if outmode == 0 {
-            jack.set_value(out.as_counts(range));
+            jack.set_value(out.as_counts(range, vpo));
         } else {
             jack.set_value(4095)
         }

--- a/faderpunk/src/apps/quantizer.rs
+++ b/faderpunk/src/apps/quantizer.rs
@@ -6,7 +6,7 @@ use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use heapless::Vec;
 use libfp::{
     ext::FromValue, latch::LatchLayer, utils::split_unsigned_value, AppIcon, Brightness, Color,
-    APP_MAX_PARAMS,
+    VoltPerOct, APP_MAX_PARAMS,
 };
 use serde::{Deserialize, Serialize};
 
@@ -15,7 +15,7 @@ use libfp::{Config, Param, Range, Value};
 use crate::app::{App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
 
 pub const CHANNELS: usize = 2;
-pub const PARAMS: usize = 2;
+pub const PARAMS: usize = 4;
 
 pub static CONFIG: Config<PARAMS> = Config::new(
     "Quantizer",
@@ -39,11 +39,17 @@ pub static CONFIG: Config<PARAMS> = Config::new(
 .add_param(Param::Range {
     name: "Range",
     variants: &[Range::_0_10V, Range::_Neg5_5V],
+})
+.add_param(Param::VoltPerOct)
+.add_param(Param::bool {
+    name: "Bypass quantizer",
 });
 
 pub struct Params {
     color: Color,
     range: Range,
+    vpo: VoltPerOct,
+    bypass: bool,
 }
 
 impl AppParams for Params {
@@ -54,6 +60,8 @@ impl AppParams for Params {
         Some(Self {
             color: Color::from_value(values[0]),
             range: Range::from_value(values[1]),
+            vpo: VoltPerOct::from_value(values[2]),
+            bypass: bool::from_value(values[3]),
         })
     }
 
@@ -61,6 +69,8 @@ impl AppParams for Params {
         let mut vec = Vec::new();
         vec.push(self.color.into()).unwrap();
         vec.push(self.range.into()).unwrap();
+        vec.push(self.vpo.into()).unwrap();
+        vec.push(self.bypass.into()).unwrap();
         vec
     }
 }
@@ -86,10 +96,16 @@ impl AppStorage for Storage {}
 
 #[embassy_executor::task(pool_size = 16/CHANNELS)]
 pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMutex, bool>) {
-    let param_store = ParamStore::<Params>::new(app.app_id, app.layout_id, Params {
-        color: Color::Blue,
-        range: Range::_Neg5_5V,
-    });
+    let param_store = ParamStore::<Params>::new(
+        app.app_id,
+        app.layout_id,
+        Params {
+            color: Color::Blue,
+            range: Range::_Neg5_5V,
+            vpo: VoltPerOct::Standard,
+            bypass: false,
+        },
+    );
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
 
     param_store.load().await;
@@ -114,14 +130,15 @@ pub async fn run(
     params: &ParamStore<Params>,
     storage: &ManagedStorage<Storage>,
 ) {
-    let (led_color, range) = params.query(|p| (p.color, p.range));
+    let (led_color, range, vpo, bypass) = params.query(|p| (p.color, p.range, p.vpo, p.bypass));
     let buttons = app.use_buttons();
     let faders = app.use_faders();
     let leds = app.use_leds();
     leds.set(0, Led::Button, led_color, Brightness::Mid);
     leds.set(1, Led::Button, led_color, Brightness::Mid);
 
-    let quantizer = app.use_quantizer(range);
+    let quantizer = app.use_quantizer(range, vpo, bypass);
+    let counts_per_oct = vpo.counts_per_oct();
     let _input = app.make_in_jack(0, range).await;
     let output = app.make_out_jack(1, range).await;
     for chan in 0..2 {
@@ -141,28 +158,30 @@ pub async fn run(
             let oct = if storage.query(|s| s.offset_toggles[1]) {
                 0
             } else {
-                (((storage.query(|s| s.oct) * 10 / 4095) as f32 - 5.) * 410.) as i16
+                (((storage.query(|s| s.oct) * 10 / 4095) as f32 - 5.) * counts_per_oct as f32)
+                    as i16
             };
 
             let st = if storage.query(|s| s.offset_toggles[0]) {
                 0
             } else {
-                ((storage.query(|s| s.st) * 12 / 4095) as f32 * 410. / 12.) as i16
+                ((storage.query(|s| s.st) * 12 / 4095) as f32 * counts_per_oct as f32 / 12.)
+                    as i16
             };
 
             let outval = quantizer
                 .get_quantized_note((inval + oct + st).clamp(0, 4095) as u16)
                 .await;
 
-            output.set_value(outval.as_counts(range));
-            let oct_led = split_unsigned_value(outval.as_counts(range));
+            output.set_value(outval.as_counts(range, vpo));
+            let oct_led = split_unsigned_value(outval.as_counts(range, vpo));
             leds.set(1, Led::Top, led_color, Brightness::Custom(oct_led[0]));
             leds.set(1, Led::Bottom, led_color, Brightness::Custom(oct_led[1]));
             leds.set(
                 0,
                 Led::Top,
                 led_color,
-                Brightness::Custom((st * 255 / 410) as u8),
+                Brightness::Custom((st * 255 / counts_per_oct) as u8),
             );
         }
     };

--- a/faderpunk/src/apps/seq8.rs
+++ b/faderpunk/src/apps/seq8.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use libfp::{
     ext::FromValue, latch::LatchLayer, utils::fader_to_slide_coeff, AppIcon, Brightness,
     ClockDivision, Color, Config, MidiChannel, MidiIn, MidiNote, MidiOut, Param, Range, Value,
-    APP_MAX_PARAMS,
+    VoltPerOct, APP_MAX_PARAMS,
 };
 
 use crate::app::{
@@ -19,7 +19,7 @@ use crate::app::{
 };
 
 pub const CHANNELS: usize = 8;
-pub const PARAMS: usize = 12;
+pub const PARAMS: usize = 14;
 
 pub static CONFIG: Config<PARAMS> = Config::new(
     "Sequencer",
@@ -46,7 +46,9 @@ pub static CONFIG: Config<PARAMS> = Config::new(
 .add_param(Param::MidiChannel { name: "Track 1: transpose CH" })
 .add_param(Param::MidiChannel { name: "Track 2: transpose CH" })
 .add_param(Param::MidiChannel { name: "Track 3: transpose CH" })
-.add_param(Param::MidiChannel { name: "Track 4: transpose CH" });
+.add_param(Param::MidiChannel { name: "Track 4: transpose CH" })
+.add_param(Param::VoltPerOct)
+.add_param(Param::bool { name: "Bypass quantizer" });
 
 pub struct Params {
     midi_channel1: MidiChannel,
@@ -61,6 +63,8 @@ pub struct Params {
     transpose_ch2: MidiChannel,
     transpose_ch3: MidiChannel,
     transpose_ch4: MidiChannel,
+    vpo: VoltPerOct,
+    bypass: bool,
 }
 
 impl AppParams for Params {
@@ -81,6 +85,8 @@ impl AppParams for Params {
             transpose_ch2: MidiChannel::from_value(values[9]),
             transpose_ch3: MidiChannel::from_value(values[10]),
             transpose_ch4: MidiChannel::from_value(values[11]),
+            vpo: VoltPerOct::from_value(values[12]),
+            bypass: bool::from_value(values[13]),
         })
     }
 
@@ -98,6 +104,8 @@ impl AppParams for Params {
         vec.push(self.transpose_ch2.into()).unwrap();
         vec.push(self.transpose_ch3.into()).unwrap();
         vec.push(self.transpose_ch4.into()).unwrap();
+        vec.push(self.vpo.into()).unwrap();
+        vec.push(self.bypass.into()).unwrap();
         vec
     }
 }
@@ -225,6 +233,8 @@ pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMut
             transpose_ch2: MidiChannel::from(2),
             transpose_ch3: MidiChannel::from(3),
             transpose_ch4: MidiChannel::from(4),
+            vpo: VoltPerOct::Standard,
+            bypass: false,
         },
     );
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
@@ -265,6 +275,8 @@ pub async fn run(
         transpose_ch2,
         transpose_ch3,
         transpose_ch4,
+        vpo,
+        bypass,
     ) = params.query(|p| {
         (
             p.midi_out,
@@ -279,6 +291,8 @@ pub async fn run(
             p.transpose_ch2,
             p.transpose_ch3,
             p.transpose_ch4,
+            p.vpo,
+            p.bypass,
         )
     });
     let vel_lane = [false, vel_lane_2, false, vel_lane_4];
@@ -310,7 +324,8 @@ pub async fn run(
         app.make_gate_jack(7, 4095).await,
     ];
 
-    let quantizer = app.use_quantizer(range);
+    let quantizer = app.use_quantizer(range, vpo, bypass);
+    let counts_per_oct = vpo.counts_per_oct() as u32;
 
     let page_glob: Global<usize> = app.make_global(0);
     let latch_layer_glob: Global<LatchLayer> = app.make_global(LatchLayer::Main);
@@ -671,9 +686,10 @@ pub async fn run(
                                             (seq[clkindex] as u32
                                                 * ((storage.query(|s| s.range_fader[n]) / 1000 + 1)
                                                     as u32)
-                                                * 410
+                                                * counts_per_oct
                                                 / 4095) as u16
-                                                + (storage.query(|s| s.oct_fader[n]) / 1000) * 410,
+                                                + (storage.query(|s| s.oct_fader[n]) / 1000)
+                                                    * counts_per_oct as u16,
                                         )
                                         .await;
                                     let mut base = out.as_midi();
@@ -690,8 +706,8 @@ pub async fn run(
                                     // Hand the target CV to slide_handler; slide only if
                                     // the previously played step had legato enabled.
                                     let mut targets = target_cv_glob.get();
-                                    targets[n] = (out.as_counts(range) as i32
-                                        + transpo[n] as i32 * 410 / 12)
+                                    targets[n] = (out.as_counts(range, vpo) as i32
+                                        + transpo[n] as i32 * counts_per_oct as i32 / 12)
                                         .clamp(0, 4095) as u16;
                                     target_cv_glob.set(targets);
                                     let mut slid = sliding_glob.get();

--- a/faderpunk/src/apps/tb3po.rs
+++ b/faderpunk/src/apps/tb3po.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 
 use libfp::{
     ext::FromValue, latch::LatchLayer, utils::apply_slide, AppIcon, Brightness, ClockDivision,
-    Color, Config, MidiChannel, MidiNote, MidiOut, Param, Range, Value, APP_MAX_PARAMS,
+    Color, Config, MidiChannel, MidiNote, MidiOut, Param, Range, Value, VoltPerOct, APP_MAX_PARAMS,
 };
 
 use crate::app::{
@@ -323,7 +323,7 @@ pub async fn run(
     let leds = app.use_leds();
     let mut clock = app.use_clock();
     let ticks = clock.get_ticker();
-    let quantizer = app.use_quantizer(pitch_range);
+    let quantizer = app.use_quantizer(pitch_range, VoltPerOct::Standard, false);
     let midi = app.use_midi_output(midi_out, midi_chan, false);
 
     let pitch_out = app.make_out_jack(0, pitch_range).await;
@@ -441,12 +441,12 @@ pub async fn run(
                     if is_slid_prev {
                         // Glide: output_task will interpolate toward new target
                         let out = quantizer.get_quantized_note(target_raw).await;
-                        slide_target_glob.set(out.as_counts(pitch_range));
+                        slide_target_glob.set(out.as_counts(pitch_range, VoltPerOct::Standard));
                         slide_active_glob.set(true);
                     } else if is_gated {
                         // Snap to new pitch
                         let out = quantizer.get_quantized_note(target_raw).await;
-                        let counts = out.as_counts(pitch_range);
+                        let counts = out.as_counts(pitch_range, VoltPerOct::Standard);
                         slide_target_glob.set(counts);
                         slide_active_glob.set(false);
                     }

--- a/faderpunk/src/apps/turing.rs
+++ b/faderpunk/src/apps/turing.rs
@@ -12,7 +12,8 @@ use serde::{Deserialize, Serialize};
 
 use libfp::{
     ext::FromValue, latch::LatchLayer, AppIcon, Brightness, ClockDivision, Color, Config, Curve,
-    MidiCc, MidiChannel, MidiMode, MidiNote, MidiOut, Param, Range, Value, APP_MAX_PARAMS,
+    MidiCc, MidiChannel, MidiMode, MidiNote, MidiOut, Param, Range, Value, VoltPerOct,
+    APP_MAX_PARAMS,
 };
 
 use crate::app::{
@@ -20,7 +21,7 @@ use crate::app::{
 };
 
 pub const CHANNELS: usize = 1;
-pub const PARAMS: usize = 10;
+pub const PARAMS: usize = 12;
 
 pub static CONFIG: Config<PARAMS> = Config::new(
     "Turing",
@@ -58,7 +59,9 @@ pub static CONFIG: Config<PARAMS> = Config::new(
 })
 .add_param(Param::MidiNrpn)
 .add_param(Param::MidiOut)
-.add_param(Param::bool { name: "Gate Out" });
+.add_param(Param::bool { name: "Gate Out" })
+.add_param(Param::VoltPerOct)
+.add_param(Param::bool { name: "Bypass quantizer" });
 
 pub struct Params {
     midi_mode: MidiMode,
@@ -71,6 +74,8 @@ pub struct Params {
     range: Range,
     nrpn: bool,
     gate_out: bool,
+    vpo: VoltPerOct,
+    bypass: bool,
 }
 
 impl AppParams for Params {
@@ -89,6 +94,8 @@ impl AppParams for Params {
             nrpn: bool::from_value(values[7]),
             midi_out: MidiOut::from_value(values[8]),
             gate_out: bool::from_value(values[9]),
+            vpo: VoltPerOct::from_value(values[10]),
+            bypass: bool::from_value(values[11]),
         })
     }
 
@@ -104,6 +111,8 @@ impl AppParams for Params {
         vec.push(Value::MidiNrpn(self.nrpn)).unwrap();
         vec.push(self.midi_out.into()).unwrap();
         vec.push(self.gate_out.into()).unwrap();
+        vec.push(self.vpo.into()).unwrap();
+        vec.push(self.bypass.into()).unwrap();
         vec
     }
 }
@@ -146,6 +155,8 @@ pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMut
             range: Range::_0_5V,
             nrpn: false,
             gate_out: false,
+            vpo: VoltPerOct::Standard,
+            bypass: false,
         },
     );
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
@@ -183,6 +194,8 @@ pub async fn run(
         range,
         nrpn,
         gate_out,
+        vpo,
+        bypass,
     ) = params.query(|p| {
         (
             p.midi_out,
@@ -195,6 +208,8 @@ pub async fn run(
             p.range,
             p.nrpn,
             p.gate_out,
+            p.vpo,
+            p.bypass,
         )
     });
 
@@ -204,7 +219,7 @@ pub async fn run(
     let mut clock = app.use_clock();
     let ticks = clock.get_ticker();
     let die = app.use_die();
-    let quantizer = app.use_quantizer(range);
+    let quantizer = app.use_quantizer(range, vpo, bypass);
 
     let midi = app.use_midi_output(midi_out, midi_chan, nrpn);
 
@@ -313,7 +328,7 @@ pub async fn run(
                             }
                         } else {
                             let out = quantizer.get_quantized_note(att_reg).await;
-                            cv_jack.as_ref().unwrap().set_value(out.as_counts(range));
+                            cv_jack.as_ref().unwrap().set_value(out.as_counts(range, vpo));
                             leds.set(
                                 0,
                                 Led::Top,

--- a/faderpunk/src/tasks/global_config.rs
+++ b/faderpunk/src/tasks/global_config.rs
@@ -47,7 +47,7 @@ pub fn get_fader_value_from_config(chan: usize, config: &GlobalConfig) -> u16 {
     match chan {
         INTERNAL_BPM_FADER => (((config.clock.internal_bpm - 45.0) * 16.0) as u16).clamp(0, 4095),
         SWING_FADER => swing_to_val(config.clock.swing_amount),
-        QUANTIZER_KEY_FADER => (config.quantizer.key as u16 * 256).clamp(0, 4095),
+        QUANTIZER_KEY_FADER => (config.quantizer.key as u16 * 241).clamp(0, 4095),
         QUANTIZER_TONIC_FADER => (config.quantizer.tonic as u16 * 342).clamp(0, 4095),
         LED_BRIGHTNESS_FADER => {
             let brightness_range = (LED_BRIGHTNESS_RANGE.end - LED_BRIGHTNESS_RANGE.start) as u32;
@@ -89,7 +89,7 @@ pub fn set_global_config_via_chan(chan: usize, val: u16) {
         QUANTIZER_KEY_FADER => {
             global_config_sender.send_if_modified(|c| {
                 if let Some(config) = c {
-                    let new_key: Key = unsafe { core::mem::transmute((val / 256) as u8) };
+                    let new_key: Key = unsafe { core::mem::transmute((val / 241).min(16) as u8) };
                     if config.quantizer.key != new_key {
                         config.quantizer.key = new_key;
                         return true;

--- a/faderpunk/src/tasks/input_handlers.rs
+++ b/faderpunk/src/tasks/input_handlers.rs
@@ -124,6 +124,18 @@ async fn run_input_handlers() {
 }
 
 pub async fn show_scale_keyboard(key: Key, tonic: Note) {
+    if key == Key::Off {
+        for ch in 0..NUM_CHANNELS {
+            set_led_overlay_mode(
+                ch,
+                Led::Bottom,
+                LedMode::Static(Color::White, Brightness::Off),
+            )
+            .await;
+        }
+        return;
+    }
+
     let mask = key.as_u16_key();
     let tonic_offset = tonic as usize;
 
@@ -178,11 +190,15 @@ pub async fn show_config_top_leds(config: &GlobalConfig) {
     )
     .await;
 
-    let key_color = Color::from(config.quantizer.key as usize);
+    let (key_color, key_brightness) = if config.quantizer.key == Key::Off {
+        (Color::White, Brightness::Off)
+    } else {
+        (Color::from(config.quantizer.key as usize), Brightness::Mid)
+    };
     set_led_overlay_mode(
         QUANTIZER_KEY_FADER,
         Led::Top,
-        LedMode::Static(key_color, Brightness::Mid),
+        LedMode::Static(key_color, key_brightness),
     )
     .await;
 

--- a/gen-bindings/src/main.rs
+++ b/gen-bindings/src/main.rs
@@ -43,6 +43,7 @@ fn main() {
             libfp::ResetSrc,
             libfp::TakeoverMode,
             libfp::Value,
+            libfp::VoltPerOct,
             libfp::Waveform
         ),
     )

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -349,6 +349,9 @@ pub enum Key {
     Gamelan,
     #[n(15)]
     HungarianMin,
+    /// CV passes through unmodified; MIDI output still uses nearest chromatic semitone.
+    #[n(16)]
+    Off,
 }
 
 impl Key {
@@ -371,6 +374,55 @@ impl Key {
             Key::Japanese => 0b110001011000,
             Key::Gamelan => 0b110100011000,
             Key::HungarianMin => 0b101100111001,
+            // Off: internally treated as Chromatic for MIDI output
+            Key::Off => 0b111111111111,
+        }
+    }
+}
+
+/// Volts-per-octave standard. Selects pitch calibration for quantizer and pitch apps.
+/// `Standard` = 1V/Oct (Eurorack), `Buchla` = 1.2V/Oct.
+#[derive(Clone, Copy, Default, Debug, PartialEq, Serialize, Deserialize, PostcardBindings)]
+pub enum VoltPerOct {
+    #[default]
+    Standard,
+    Buchla,
+}
+
+impl VoltPerOct {
+    pub fn counts_per_oct(self) -> i16 {
+        match self {
+            VoltPerOct::Standard => 410,
+            VoltPerOct::Buchla => 492,
+        }
+    }
+
+    pub fn semitones_per_volt(self) -> f32 {
+        match self {
+            VoltPerOct::Standard => 12.0,
+            VoltPerOct::Buchla => 10.0,
+        }
+    }
+
+    pub fn voltage_scale(self) -> f32 {
+        match self {
+            VoltPerOct::Standard => 1.0,
+            VoltPerOct::Buchla => 1.2,
+        }
+    }
+}
+
+impl From<VoltPerOct> for Value {
+    fn from(value: VoltPerOct) -> Self {
+        Value::VoltPerOct(value)
+    }
+}
+
+impl FromValue for VoltPerOct {
+    fn from_value(value: Value) -> Self {
+        match value {
+            Value::VoltPerOct(v) => v,
+            _ => Self::default(),
         }
     }
 }
@@ -918,6 +970,7 @@ pub enum Param {
     },
     MidiOut,
     MidiNrpn,
+    VoltPerOct,
 }
 
 #[allow(non_camel_case_types)]
@@ -939,6 +992,7 @@ pub enum Value {
     MidiNote(MidiNote),
     MidiOut(MidiOut),
     MidiNrpn(bool),
+    VoltPerOct(VoltPerOct),
 }
 
 impl From<Curve> for Value {

--- a/libfp/src/quantizer.rs
+++ b/libfp/src/quantizer.rs
@@ -1,7 +1,7 @@
 // V/oct quantizer, based on the ideas in
 // https://github.com/pichenettes/eurorack/blob/master/braids/quantizer_scales.h
 
-use crate::{Key, MidiNote, Note, Range};
+use crate::{Key, MidiNote, Note, Range, VoltPerOct};
 use heapless::Vec;
 use libm::roundf;
 
@@ -11,6 +11,9 @@ const CODEBOOK_SIZE: usize = 216;
 pub struct Pitch {
     pub octave: i8,
     pub note: Note,
+    /// When set, `as_counts()` returns this raw ADC value instead of the quantized voltage.
+    /// Used for global (`Key::Off`) and per-app bypass passthrough mode.
+    pub raw: Option<u16>,
 }
 
 impl Pitch {
@@ -18,12 +21,16 @@ impl Pitch {
         self.octave as f32 + (self.note as u8 as f32 / 12.0)
     }
 
-    pub fn as_counts(&self, range: Range) -> u16 {
+    pub fn as_counts(&self, range: Range, vpo: VoltPerOct) -> u16 {
+        if let Some(raw) = self.raw {
+            return raw;
+        }
         let voltage = self.as_v_oct();
+        let scaled = voltage * vpo.voltage_scale();
         let counts = match range {
-            Range::_0_10V => (voltage / 10.0) * 4095.0,
-            Range::_0_5V => (voltage / 5.0) * 4095.0,
-            Range::_Neg5_5V => ((voltage + 5.0) / 10.0) * 4095.0,
+            Range::_0_10V => (scaled / 10.0) * 4095.0,
+            Range::_0_5V => (scaled / 5.0) * 4095.0,
+            Range::_Neg5_5V => ((scaled + 5.0) / 10.0) * 4095.0,
         };
 
         roundf(counts).clamp(0.0, 4095.0) as u16
@@ -77,7 +84,9 @@ impl Quantizer {
         self.key = key;
         self.tonic = tonic;
 
-        let mask = key.as_u16_key();
+        // When Off, use chromatic internally so MIDI quantizes to nearest semitone
+        let effective_key = if key == Key::Off { Key::Chromatic } else { key };
+        let mask = effective_key.as_u16_key();
         let notes: Vec<i16, 12> = (0..12)
             .filter(|i| (mask >> (11 - i)) & 1 != 0) // Read from MSB (C) to LSB (B)
             .map(|i| i as i16)
@@ -141,6 +150,7 @@ impl Quantizer {
         state: &mut QuantizerState,
         value: u16,
         range: Range,
+        vpo: VoltPerOct,
     ) -> Pitch {
         // Version keeps track of the scale changes, if version does not match, reset state
         if state.version != self.version {
@@ -153,9 +163,8 @@ impl Quantizer {
             Range::_Neg5_5V => (value as f32 * (10.0 / 4095.0)) - 5.0,
         };
 
-        // Convert voltage to our fixed-point pitch representation (semitones * 128)
-        // We assume 1V/Oct, and 0V corresponds to C0 (semitone 0)
-        let pitch = roundf(input_voltage * 12.0 * 128.0) as i32;
+        // Convert voltage to semitones * 128 fixed-point. 0V = C0.
+        let pitch = roundf(input_voltage * vpo.semitones_per_volt() * 128.0) as i32;
 
         if pitch < state.previous_boundary || pitch > state.next_boundary {
             // Input is outside the current note's hysteresis boundary; find a new note
@@ -197,6 +206,7 @@ impl Quantizer {
         Pitch {
             octave,
             note: note.into(),
+            raw: None,
         }
     }
 }
@@ -227,19 +237,21 @@ mod tests {
 
         // 0V -> should be C0
         assert_eq!(
-            q.get_quantized_note(&mut state, 0, Range::_0_10V),
+            q.get_quantized_note(&mut state, 0, Range::_0_10V, VoltPerOct::Standard),
             Pitch {
                 octave: 0,
-                note: Note::C
+                note: Note::C,
+                raw: None
             }
         );
 
         // ~1V -> should be C1
         assert_eq!(
-            q.get_quantized_note(&mut state, 410, Range::_0_10V),
+            q.get_quantized_note(&mut state, 410, Range::_0_10V, VoltPerOct::Standard),
             Pitch {
                 octave: 1,
-                note: Note::C
+                note: Note::C,
+                raw: None
             }
         );
 
@@ -247,20 +259,22 @@ mod tests {
         // 0.08V -> ~33 counts. Should snap down to C0
         let mut state_c0 = QuantizerState::default();
         assert_eq!(
-            q.get_quantized_note(&mut state_c0, 33, Range::_0_10V),
+            q.get_quantized_note(&mut state_c0, 33, Range::_0_10V, VoltPerOct::Standard),
             Pitch {
                 octave: 0,
-                note: Note::C
+                note: Note::C,
+                raw: None
             }
         );
 
         // 0.09V -> ~37 counts. Should snap up to D0
         let mut state_d0 = QuantizerState::default();
         assert_eq!(
-            q.get_quantized_note(&mut state_d0, 37, Range::_0_10V),
+            q.get_quantized_note(&mut state_d0, 37, Range::_0_10V, VoltPerOct::Standard),
             Pitch {
                 octave: 0,
-                note: Note::D
+                note: Note::D,
+                raw: None
             }
         );
 
@@ -269,10 +283,11 @@ mod tests {
         // Should quantize to closest note in scale: either F0 or G0.
         // 0.5V = 205 counts. F0=170 counts, G0=239 counts. 205 is closer to G0
         assert_eq!(
-            q.get_quantized_note(&mut state, 205, Range::_0_10V),
+            q.get_quantized_note(&mut state, 205, Range::_0_10V, VoltPerOct::Standard),
             Pitch {
                 octave: 0,
-                note: Note::G
+                note: Note::G,
+                raw: None
             }
         );
     }
@@ -285,28 +300,31 @@ mod tests {
 
         // ADC midpoint 2048 should map to 0V. Closest note in A minor is C0
         assert_eq!(
-            q.get_quantized_note(&mut state, 2048, Range::_Neg5_5V),
+            q.get_quantized_note(&mut state, 2048, Range::_Neg5_5V, VoltPerOct::Standard),
             Pitch {
                 octave: 0,
-                note: Note::C
+                note: Note::C,
+                raw: None
             }
         );
 
         // -5V -> 0 counts. Should be C-5. Closest note is C-5
         assert_eq!(
-            q.get_quantized_note(&mut state, 0, Range::_Neg5_5V),
+            q.get_quantized_note(&mut state, 0, Range::_Neg5_5V, VoltPerOct::Standard),
             Pitch {
                 octave: -5,
-                note: Note::C
+                note: Note::C,
+                raw: None
             }
         );
 
         // ~5V -> 4095 counts. Should be C5. Closest note is C5
         assert_eq!(
-            q.get_quantized_note(&mut state, 4095, Range::_Neg5_5V),
+            q.get_quantized_note(&mut state, 4095, Range::_Neg5_5V, VoltPerOct::Standard),
             Pitch {
                 octave: 5,
-                note: Note::C
+                note: Note::C,
+                raw: None
             }
         );
     }
@@ -320,30 +338,33 @@ mod tests {
         // Test the top of the 0-10V range
         // 10V -> 4095 counts. Should be C10
         assert_eq!(
-            q.get_quantized_note(&mut state, 4095, Range::_0_10V),
+            q.get_quantized_note(&mut state, 4095, Range::_0_10V, VoltPerOct::Standard),
             Pitch {
                 octave: 10,
-                note: Note::C
+                note: Note::C,
+                raw: None
             }
         );
 
         // Test the bottom of the bipolar -5V to 5V range
         // -5V -> 0 counts. Should be C-5
         assert_eq!(
-            q.get_quantized_note(&mut state, 0, Range::_Neg5_5V),
+            q.get_quantized_note(&mut state, 0, Range::_Neg5_5V, VoltPerOct::Standard),
             Pitch {
                 octave: -5,
-                note: Note::C
+                note: Note::C,
+                raw: None
             }
         );
 
         // Test the top of the bipolar -5V to 5V range
         // ~5V -> 4095 counts. Should be C5
         assert_eq!(
-            q.get_quantized_note(&mut state, 4095, Range::_Neg5_5V),
+            q.get_quantized_note(&mut state, 4095, Range::_Neg5_5V, VoltPerOct::Standard),
             Pitch {
                 octave: 5,
-                note: Note::C
+                note: Note::C,
+                raw: None
             }
         );
     }
@@ -360,10 +381,11 @@ mod tests {
 
         // Quantize a value just ABOVE the midpoint. It should snap to D0
         assert_eq!(
-            q.get_quantized_note(&mut state, 37, Range::_0_10V),
+            q.get_quantized_note(&mut state, 37, Range::_0_10V, VoltPerOct::Standard),
             Pitch {
                 octave: 0,
-                note: Note::D
+                note: Note::D,
+                raw: None
             }
         );
 
@@ -371,20 +393,22 @@ mod tests {
         // A stateless quantizer would snap back to C0
         // With hysteresis, it should STAY on D0 because it hasn't crossed the new, lower boundary
         assert_eq!(
-            q.get_quantized_note(&mut state, 33, Range::_0_10V),
+            q.get_quantized_note(&mut state, 33, Range::_0_10V, VoltPerOct::Standard),
             Pitch {
                 octave: 0,
-                note: Note::D
+                note: Note::D,
+                raw: None
             }
         );
 
         // Only when we provide a value far away from the boundary does it snap back
         // 10 counts is ~0.024V, clearly closer to C0
         assert_eq!(
-            q.get_quantized_note(&mut state, 10, Range::_0_10V),
+            q.get_quantized_note(&mut state, 10, Range::_0_10V, VoltPerOct::Standard),
             Pitch {
                 octave: 0,
-                note: Note::C
+                note: Note::C,
+                raw: None
             }
         );
     }
@@ -395,15 +419,17 @@ mod tests {
         let c4 = Pitch {
             octave: 4,
             note: Note::C,
+            raw: None,
         };
         let a4 = Pitch {
             octave: 4,
             note: Note::A,
+            raw: None,
         };
-        assert_eq!(c4.as_counts(Range::_0_10V), 1638);
-        assert_eq!(a4.as_counts(Range::_0_10V), 1945);
-        assert_eq!(c4.as_counts(Range::_0_5V), 3276);
-        assert_eq!(c4.as_counts(Range::_Neg5_5V), 3686);
+        assert_eq!(c4.as_counts(Range::_0_10V, VoltPerOct::Standard), 1638);
+        assert_eq!(a4.as_counts(Range::_0_10V, VoltPerOct::Standard), 1945);
+        assert_eq!(c4.as_counts(Range::_0_5V, VoltPerOct::Standard), 3276);
+        assert_eq!(c4.as_counts(Range::_Neg5_5V, VoltPerOct::Standard), 3686);
     }
 
     #[test]
@@ -411,16 +437,19 @@ mod tests {
         let c4 = Pitch {
             octave: 4,
             note: Note::C,
+            raw: None,
         };
         assert_eq!(c4.as_midi(), MidiNote(60));
         let a4 = Pitch {
             octave: 4,
             note: Note::A,
+            raw: None,
         };
         assert_eq!(a4.as_midi(), MidiNote(69));
         let c_minus_1 = Pitch {
             octave: -1,
             note: Note::C,
+            raw: None,
         };
         assert_eq!(c_minus_1.as_midi(), MidiNote(0));
     }
@@ -474,9 +503,9 @@ mod tests {
         let mut state = QuantizerState::default();
 
         // Perform some quantization operations
-        q.get_quantized_note(&mut state, 410, Range::_0_10V);
-        q.get_quantized_note(&mut state, 820, Range::_0_10V);
-        q.get_quantized_note(&mut state, 1230, Range::_0_10V);
+        q.get_quantized_note(&mut state, 410, Range::_0_10V, VoltPerOct::Standard);
+        q.get_quantized_note(&mut state, 820, Range::_0_10V, VoltPerOct::Standard);
+        q.get_quantized_note(&mut state, 1230, Range::_0_10V, VoltPerOct::Standard);
 
         // Key and tonic should remain unchanged
         assert_eq!(q.get_key(), Key::Mixolydian);


### PR DESCRIPTION
## Summary

Three related quantizer features shipped together:

### Key::Off — global passthrough scale (closes #329)
A 17th scale option in global config. When active, CV outputs the raw input voltage unchanged (no quantization). MIDI falls back to chromatic (nearest semitone). The scale fader mapping is updated from 256→241 steps to fit all 17 values in the 4095-count range. The scale overlay LEDs go dark when Off is selected.

### 1.2V/Oct Buchla mode (closes #515)
A new `VoltPerOct` param (Standard = 1V/Oct, Buchla = 1.2V/Oct) added to all six quantizer-using apps: **quantizer**, **turing**, **clkturing**, **seq8**, **notefader**, **cv2midinote**. Affects both CV output voltage scaling and the pitch→semitone conversion used when reading CV inputs. All hardcoded `410` counts/oct values replaced with `vpo.counts_per_oct()` at runtime.

### Per-app quantizer bypass (closes #347)
A `Bypass quantizer` boolean param on the same six apps. Behaviour differs by output type:
- **CV output apps** (quantizer, turing, clkturing, seq8, notefader): bypass routes the raw ADC value directly to `as_counts()`, skipping scale quantization entirely.
- **MIDI output app** (cv2midinote): bypass overrides the global scale with chromatic quantization — nearest semitone regardless of global scale setting.

## Implementation notes

- New `Pitch::raw: Option<u16>` field: when set, `as_counts()` returns the raw value; `as_midi()` is unaffected.
- `Key::Off` uses `Key::Chromatic` internally in `set_scale` so MIDI always quantizes to a valid semitone.
- Both the global `Key::Off` flag and per-app `bypass` are OR'd together — either gate triggers passthrough.
- Bug fix: panic when `Key::Off` is selected and the scene overlay is shown, caused by `Color::from(key as usize)` indexing `PALETTE[16]` out of bounds. Fixed with an explicit guard in `show_config_top_leds`.
- Configurator: new `ParamVoltPerOct` dropdown component, `Key::Off` entry in global scale selector, both new params routed through `AppParam`.

## Testing
Tested on hardware. All 75 `libfp` unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)