### PR TITLE
Skip auto-connect on deviceless routes and manual navigation

### DIFF
--- a/configurator/src/App.tsx
+++ b/configurator/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Routes, Route, Navigate } from "react-router-dom";
+import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 
 import { useStore } from "./store";
 import { useConnectionHealthCheck } from "./hooks/useConnectionHealthCheck";
@@ -10,12 +10,22 @@ import { ManualPage } from "./components/ManualPage";
 import { UpdatePage } from "./components/UpdatePage";
 import { TroubleshootingPage } from "./components/TroubleshootingPage";
 
+const DEVICELESS_ROUTES = ["/about", "/manual", "/update", "/troubleshooting"];
+
 const App = () => {
   const { usbDevice, autoConnect } = useStore();
+  const location = useLocation();
   useConnectionHealthCheck();
-  const [isAutoConnecting, setIsAutoConnecting] = useState(true);
+  const skipAutoConnect =
+    DEVICELESS_ROUTES.includes(location.pathname) ||
+    sessionStorage.getItem("fp-skip-autoconnect") === "1";
+  const [isAutoConnecting, setIsAutoConnecting] = useState(!skipAutoConnect);
 
   useEffect(() => {
+    if (skipAutoConnect) {
+      sessionStorage.removeItem("fp-skip-autoconnect");
+      return;
+    }
     const attemptAutoConnect = async () => {
       if (!usbDevice) {
         await autoConnect();

--- a/configurator/src/landing/App.tsx
+++ b/configurator/src/landing/App.tsx
@@ -204,6 +204,7 @@ export default function App() {
             <div className="flex justify-center gap-3">
               <button
                 onClick={() => {
+                  sessionStorage.setItem("fp-skip-autoconnect", "1");
                   window.location.href =
                     versionPath(latestVersion) + "#/update";
                 }}


### PR DESCRIPTION
## Summary
This PR adds logic to skip the auto-connect flow when navigating to routes that don't require a USB device connection, and when explicitly navigating to the update page from the landing page.

## Key Changes
- Added `DEVICELESS_ROUTES` constant listing routes that don't require device connection: `/about`, `/manual`, `/update`, `/troubleshooting`
- Imported `useLocation` hook to track current route in the App component
- Modified auto-connect initialization to skip when:
  - Current route is in the deviceless routes list
  - `fp-skip-autoconnect` session storage flag is set to "1"
- Added cleanup logic to remove the session storage flag after skipping auto-connect
- Updated landing page to set `fp-skip-autoconnect` flag before navigating to the update page, preventing unnecessary device connection attempts

## Implementation Details
- Uses session storage to communicate the skip intent between the landing page and main app
- The flag is automatically cleaned up after being read, ensuring it only affects the immediate navigation
- This allows users to access informational and update pages without being blocked by device connection requirements

https://claude.ai/code/session_01UzjY31HrGoGthsqzqSfUab