### PR TITLE
fix: recall setup in configurator

### DIFF
--- a/configurator/src/components/SaveLoadSetup.tsx
+++ b/configurator/src/components/SaveLoadSetup.tsx
@@ -1,26 +1,25 @@
+import type { GlobalConfig } from "@atov/fp-config";
 import { Input, Textarea } from "@heroui/input";
-
-import { GlobalConfig } from "@atov/fp-config";
-import {
-  AllApps,
-  LayoutFile,
-  ModalMode,
-  ParamValues,
-  RecoveredLayout,
-  type AppLayout,
-} from "../utils/types";
-import { ButtonPrimary, ButtonSecondary } from "./Button";
+import { useCallback, useState } from "react";
 import { useModalContext } from "../contexts/ModalContext";
+import { useStore } from "../store";
 import {
   deserializeLayout,
   recoverLayout,
   saveLayout,
   serializeLayout,
 } from "../utils/config";
-import { useStore } from "../store";
+import {
+  type AllApps,
+  type AppLayout,
+  type LayoutFile,
+  ModalMode,
+  type ParamValues,
+  type RecoveredLayout,
+} from "../utils/types";
+import { ButtonPrimary, ButtonSecondary } from "./Button";
 import { FileInput } from "./FileInput";
 import { inputProps } from "./input/defaultProps";
-import { useCallback, useState } from "react";
 
 const saveFile = (
   layout: AppLayout,
@@ -167,7 +166,8 @@ export const SaveLoadSetup = () => {
                     recallDescription: loadedDescription,
                   });
                   setLoadedFile(undefined);
-                } catch {
+                } catch (error) {
+                  console.log(error);
                   setError("Could not read config file");
                 }
               }}

--- a/configurator/src/utils/validators.ts
+++ b/configurator/src/utils/validators.ts
@@ -118,6 +118,14 @@ export const getParamSchema = (param: Param) => {
         })
         .default({ tag: "MidiOut", value: [[false, false, false]] });
     }
+    case "MidiNrpn": {
+      return z
+        .object({
+          tag: z.literal("MidiNrpn"),
+          value: z.boolean(),
+        })
+        .default({ tag: "MidiNrpn", value: false });
+    }
     case "MidiMode": {
       // MidiMode is still enum-like with tag-based variants
       return z


### PR DESCRIPTION
## fix(configurator): handle `MidiNrpn` param in save/load validator

  ### Problem

  Loading a setup file containing an app with a `MidiNrpn` param (e.g. the MIDI control app) threw a `ZodError` and silently fell back to "Could not read config file":

  ZodError: [{ "expected": "never", "code": "invalid_type", ... }]
      at parseParamValueFromFile (validators.ts:166)
      at recoverLayout (config.ts:306)

  `getParamSchema` in `validators.ts` had no `case "MidiNrpn"` branch, so it fell through to `default: return z.never()`. When the file value failed to parse (because `z.never()` always fails), the
  fallback `schema.parse(undefined)` also threw — because `z.never()` rejects everything, including `undefined`.

  ### Fix

  Add the missing `"MidiNrpn"` case to `getParamSchema`, matching the boolean shape used everywhere else (`AppParam.tsx`, `utils.ts`), with a `false` default.

  ### Notes

  - All other param tags (`i32`, `f32`, `bool`, `Enum`, `Curve`, `Waveform`, `Color`, `Range`, `Note`, `MidiCc`, `MidiChannel`, `MidiNote`, `MidiIn`, `MidiOut`, `MidiMode`, `VoltPerOct`) were already
  covered — `MidiNrpn` was the only gap.
  - `VoltPerOct` already includes the `"Buchla"` variant added in #543.