### PR TITLE
feat(tb3po): move resolution to B2+F3, mute on release, rework Ch0 LEDs

### DIFF
--- a/configurator/src/components/ManualTab.tsx
+++ b/configurator/src/components/ManualTab.tsx
@@ -1345,7 +1345,8 @@ On a clock **Reset**, the step counter resets to step 1 — the pattern is not c
         faderPlusFnDescription:
           "Hold Shift while moving Fader 3 to transpose by whole octaves (−4 to +4). Both offsets are summed.",
         fnTitle: "Mute",
-        fnDescription: "Short press mutes/unmutes. Inhibit-only: current note rings out, pitch CV holds, no new gates until unmuted.",
+        fnDescription:
+          "Short press mutes/unmutes. Inhibit-only: current note rings out, pitch CV holds, no new gates until unmuted.",
         ledTop: "Orange when an accented gate is firing",
         ledBottom:
           "Transpose distance from center — dim = no offset, bright = far from center.",

--- a/configurator/src/components/ManualTab.tsx
+++ b/configurator/src/components/ManualTab.tsx
@@ -1256,19 +1256,18 @@ Fader functions vary by output mode. Drums / Euclidean / DnB descriptions are sh
       "Transpose (semitones)",
       "Octave transpose",
       "Clock resolution",
-      "Seed lock",
-      "No slides",
+      "Muted",
       "No accents",
     ],
     text: `
-TB-3PO is a deterministic acid bass pattern generator, ported from the TB-3PO Hemisphere applet by Logarhythm/djphazer. It generates TB-303-style patterns — complete with gates, slides, accents, and octave shifts — from a single 16-bit seed value. Because patterns are fully deterministic, the same seed always produces the same sequence, making it easy to recall and lock in a favourite groove.
+TB-3PO is a deterministic acid bass pattern generator, ported from the TB-3PO Hemisphere applet by Logarhythm/djphazer. It generates TB-303-style patterns — complete with gates, accents, and octave shifts — from a single 16-bit seed value. Because patterns are fully deterministic, the same seed always produces the same sequence, making it easy to recall and lock in a favourite groove.
 
 #### Pattern Generation
 
 Every pattern is generated in two passes from the current seed and density:
 
 1. **Pitch pass:** assigns scale degrees (0–8) and octave-up/down flags to each of 32 steps. Higher density means more pitch variety and fewer repeated notes.
-2. **Gate/slide/accent pass:** rolls gate, slide, and accent probability for each step. Slides are less likely to run consecutively; accents cluster similarly to a real 303.
+2. **Gate/accent pass:** rolls gate and accent probability for each step. Accents cluster similarly to a real 303.
 
 The quantizer maps all pitch output to the system-wide scale and root, so TB-3PO stays in key across your whole patch.
 
@@ -1286,27 +1285,22 @@ The quantizer maps all pitch output to the system-wide scale and root, so TB-3PO
 
 #### Buttons
 
-* **Button 1 — short press:** Re-seeds the pattern. A new seed is grabbed from the internal tick counter, immediately generating a fresh pattern and resetting the step counter. Has no effect while seed lock is active.
-* **Button 1 — long press:** Toggles seed lock. When locked, clock Reset events no longer re-seed the pattern — useful for locking in a groove while still responding to transport.
-* **Button 2 — short press:** Toggles slides on/off. Button lit mid = slides active; button dim = slides suppressed (every note snaps immediately to pitch).
+* **Button 1 — short press:** Re-seeds the pattern. A new seed is grabbed from the internal tick counter, immediately generating a fresh pattern and resetting the step counter.
+* **Button 2 — short press:** Mutes or unmutes the output. When muted, CV and gate outputs are held at 0 and MIDI output is suppressed.
 * **Button 3 — short press:** Toggles accents on/off. Button lit mid = accents active; button dim = accents suppressed (accent CV stays 0, MIDI fires at normal velocity).
-
-#### 303-Style Slide
-
-When a step carries the slide flag and the previous step also did, the pitch glides exponentially toward the new target rather than snapping. The gate stays open during the glide, exactly as on a real TB-303. The glide time constant is fixed at approximately 100 ms. Slide can be disabled globally with Button 2.
 
 #### Clock & Re-seeding
 
-On a clock **Reset**, if seed lock is off, TB-3PO grabs a new random seed from the tick counter and regenerates the pattern immediately — every reset is a new groove. If seed lock is on, the existing pattern is simply reset to step 1. On a clock **Stop**, the gate closes and any held MIDI note is killed.
+On a clock **Reset**, the step counter resets to step 1 — the pattern is not changed. On a clock **Stop**, the gate closes and any held MIDI note is killed.
 
 #### LED Feedback
 
 * **Ch 1 Top:** Density level as brightness (user color)
-* **Ch 1 Bottom:** Orange = seed locked. While Button 1 is held (resolution mode), flashes in sync with the current clock division — orange for straight divisions, blue for triplets.
+* **Ch 1 Bottom:** While Button 1 is held (resolution mode), flashes in sync with the current clock division — orange for straight divisions, blue for triplets.
 * **Ch 1 Button:** Mid brightness (user color); flashes white on each reseed.
-* **Ch 2 Top:** Gate open indicator — user color for a normal gate, white while sliding
+* **Ch 2 Top:** Gate open indicator (user color)
 * **Ch 2 Bottom:** Step progress — bright at step 1, dims toward the end of the sequence
-* **Ch 2 Button:** Mid brightness = slides active; dim = slides suppressed
+* **Ch 2 Button:** Lit = unmuted; dim = muted
 * **Ch 3 Top:** Orange when an accented gate is firing
 * **Ch 3 Bottom:** Transpose distance from center — dim = centered (no offset), bright = far from center
 * **Ch 3 Button:** Mid brightness = accents active; dim = accents suppressed
@@ -1325,26 +1319,20 @@ On a clock **Reset**, if seed lock is off, TB-3PO grabs a new random seed from t
         faderPlusFnTitle: "Clock resolution",
         faderPlusFnDescription:
           "Hold Button 1 to select clock resolution: whole note → fast 32nds (8 steps, orange = straight, blue = triplet)",
-        fnTitle: "Re-seed / Seed lock",
-        fnDescription:
-          "Short press: generate a new random pattern. Long press: toggle seed lock (orange bottom LED when locked).",
+        fnTitle: "Re-seed",
+        fnDescription: "Short press: generate a new random pattern.",
         ledTop: "Density level",
-        ledBottom:
-          "Seed locked indicator (orange). In resolution mode: division flash.",
+        ledBottom: "In resolution mode: division flash.",
       },
       {
         jackTitle: "Gate",
-        jackDescription: "Gate output — high when a step is gated or sliding",
+        jackDescription: "Gate output",
         faderTitle: "Sequence length",
         faderDescription: "Sets the number of active steps (1–32)",
-        faderPlusFnTitle: "",
-        faderPlusFnDescription: "",
-        fnTitle: "Toggle slides",
-        fnDescription:
-          "Toggles 303-style portamento glide. Button lit mid = slides active; dim = slides suppressed.",
-        ledTop: "Gate open — user color for normal gate, white while sliding",
-        ledBottom:
-          "Step progress — bright at step 1, dims toward end of sequence",
+        fnTitle: "Mute",
+        fnDescription: "Short press mutes/unmutes the output.",
+        ledTop: "Gate open (user color)",
+        ledBottom: "Step progress — bright at step 1, dims toward end of sequence",
       },
       {
         jackTitle: "Accent CV",

--- a/configurator/src/components/ManualTab.tsx
+++ b/configurator/src/components/ManualTab.tsx
@@ -1332,7 +1332,8 @@ On a clock **Reset**, the step counter resets to step 1 — the pattern is not c
         fnTitle: "Mute",
         fnDescription: "Short press mutes/unmutes the output.",
         ledTop: "Gate open (user color)",
-        ledBottom: "Step progress — bright at step 1, dims toward end of sequence",
+        ledBottom:
+          "Step progress — bright at step 1, dims toward end of sequence",
       },
       {
         jackTitle: "Accent CV",

--- a/configurator/src/components/ManualTab.tsx
+++ b/configurator/src/components/ManualTab.tsx
@@ -1248,7 +1248,7 @@ Fader functions vary by output mode. Drums / Euclidean / DnB descriptions are sh
     description: "TB-303 acid pattern generator",
     color: "Orange",
     icon: "softRandom",
-    params: ["MIDI Channel", "MIDI Out", "Color"],
+    params: ["MIDI Channel", "MIDI Out", "Color", "1V/Oct"],
     storage: [
       "Seed (pattern identity)",
       "Density",
@@ -1287,7 +1287,7 @@ The quantizer maps all pitch output to the system-wide scale and root, so TB-3PO
 
 * **Button 1 — short press:** Re-seeds the pattern. A new seed is grabbed from the internal tick counter, immediately generating a fresh pattern and resetting the step counter.
 * **Button 2 — short press:** Toggles accents on/off. Button lit mid = accents active; button dim = accents suppressed (accent CV stays 0, MIDI fires at normal velocity).
-* **Button 3 — short press:** Mutes or unmutes the output. When muted, CV and gate outputs are held at 0 and MIDI output is suppressed.
+* **Button 3 — short press:** Mutes or unmutes the output. Mute is inhibit-only: the current note rings out naturally (gate closes at end of the step), pitch CV holds its last value, and no new gates open until unmuted.
 
 #### Clock & Re-seeding
 
@@ -1345,7 +1345,7 @@ On a clock **Reset**, the step counter resets to step 1 — the pattern is not c
         faderPlusFnDescription:
           "Hold Shift while moving Fader 3 to transpose by whole octaves (−4 to +4). Both offsets are summed.",
         fnTitle: "Mute",
-        fnDescription: "Short press mutes/unmutes the output.",
+        fnDescription: "Short press mutes/unmutes. Inhibit-only: current note rings out, pitch CV holds, no new gates until unmuted.",
         ledTop: "Orange when an accented gate is firing",
         ledBottom:
           "Transpose distance from center — dim = no offset, bright = far from center.",

--- a/configurator/src/components/ManualTab.tsx
+++ b/configurator/src/components/ManualTab.tsx
@@ -1286,8 +1286,8 @@ The quantizer maps all pitch output to the system-wide scale and root, so TB-3PO
 #### Buttons
 
 * **Button 1 — short press:** Re-seeds the pattern. A new seed is grabbed from the internal tick counter, immediately generating a fresh pattern and resetting the step counter.
-* **Button 2 — short press:** Mutes or unmutes the output. When muted, CV and gate outputs are held at 0 and MIDI output is suppressed.
-* **Button 3 — short press:** Toggles accents on/off. Button lit mid = accents active; button dim = accents suppressed (accent CV stays 0, MIDI fires at normal velocity).
+* **Button 2 — short press:** Toggles accents on/off. Button lit mid = accents active; button dim = accents suppressed (accent CV stays 0, MIDI fires at normal velocity).
+* **Button 3 — short press:** Mutes or unmutes the output. When muted, CV and gate outputs are held at 0 and MIDI output is suppressed.
 
 #### Clock & Re-seeding
 
@@ -1300,10 +1300,10 @@ On a clock **Reset**, the step counter resets to step 1 — the pattern is not c
 * **Ch 1 Button:** Mid brightness (user color); flashes white on each reseed.
 * **Ch 2 Top:** Gate open indicator (user color)
 * **Ch 2 Bottom:** Step progress — bright at step 1, dims toward the end of the sequence
-* **Ch 2 Button:** Lit = unmuted; dim = muted
+* **Ch 2 Button:** Mid brightness = accents active; dim = accents suppressed
 * **Ch 3 Top:** Orange when an accented gate is firing
 * **Ch 3 Bottom:** Transpose distance from center — dim = centered (no offset), bright = far from center
-* **Ch 3 Button:** Mid brightness = accents active; dim = accents suppressed
+* **Ch 3 Button:** Lit = unmuted; dim = muted
 
 #### Acknowledgements
 
@@ -1329,8 +1329,8 @@ On a clock **Reset**, the step counter resets to step 1 — the pattern is not c
         jackDescription: "Gate output",
         faderTitle: "Sequence length",
         faderDescription: "Sets the number of active steps (1–32)",
-        fnTitle: "Mute",
-        fnDescription: "Short press mutes/unmutes the output.",
+        fnTitle: "Toggle accents",
+        fnDescription: "Short press toggles accents on/off.",
         ledTop: "Gate open (user color)",
         ledBottom:
           "Step progress — bright at step 1, dims toward end of sequence",
@@ -1344,9 +1344,8 @@ On a clock **Reset**, the step counter resets to step 1 — the pattern is not c
         faderPlusFnTitle: "Octave transpose",
         faderPlusFnDescription:
           "Hold Shift while moving Fader 3 to transpose by whole octaves (−4 to +4). Both offsets are summed.",
-        fnTitle: "Toggle accents",
-        fnDescription:
-          "Toggles accent events. Button lit mid = accents active; dim = accents suppressed (accent CV stays 0, MIDI fires at normal velocity).",
+        fnTitle: "Mute",
+        fnDescription: "Short press mutes/unmutes the output.",
         ledTop: "Orange when an accented gate is firing",
         ledBottom:
           "Transpose distance from center — dim = no offset, bright = far from center.",

--- a/configurator/src/components/manual/Apps.tsx
+++ b/configurator/src/components/manual/Apps.tsx
@@ -19,12 +19,16 @@ export const Apps = ({ apps }: Props) => (
     <p className="mt-2">The gesture depends on the app:</p>
     <List>
       <li>
-        <strong>Short press (no shift)</strong> — Clock Divider, Clock Divider+,
-        Random CC/CV, Random Triggers, Euclid, Envelope Follower, Turing,
-        Turing+
+        <strong>Short press (no shift)</strong> — Control (when Button mode =
+        Mute), Clock Divider, Clock Divider+, Random CC/CV, Random Trigger,
+        Euclid, Envelope Follower, Turing, Turing+, MIDI to CV, CV2MIDI,
+        CV/OCT to MIDI, Panner, FP-Grids (per-channel trigger mutes), TB-3PO
       </li>
       <li>
         <strong>Long press (no shift)</strong> — AD Envelope, LFO, LFO+
+      </li>
+      <li>
+        <strong>Shift + short press</strong> — Random+ (output channel)
       </li>
       <li>
         <strong>Shift + long press on button 0 / 2 / 4 / 6</strong> — Sequencer

--- a/configurator/src/components/manual/Apps.tsx
+++ b/configurator/src/components/manual/Apps.tsx
@@ -21,8 +21,8 @@ export const Apps = ({ apps }: Props) => (
       <li>
         <strong>Short press (no shift)</strong> — Control (when Button mode =
         Mute), Clock Divider, Clock Divider+, Random CC/CV, Random Trigger,
-        Euclid, Envelope Follower, Turing, Turing+, MIDI to CV, CV2MIDI,
-        CV/OCT to MIDI, Panner, FP-Grids (per-channel trigger mutes), TB-3PO
+        Euclid, Envelope Follower, Turing, Turing+, MIDI to CV, CV2MIDI, CV/OCT
+        to MIDI, Panner, FP-Grids (per-channel trigger mutes), TB-3PO
       </li>
       <li>
         <strong>Long press (no shift)</strong> — AD Envelope, LFO, LFO+

--- a/faderpunk/src/apps/tb3po.rs
+++ b/faderpunk/src/apps/tb3po.rs
@@ -636,12 +636,12 @@ pub async fn run(
                     );
                 }
                 1 => {
-                    let muted = !storage.query(|s| s.muted);
-                    storage.modify_and_save(|s| s.muted = muted);
-                }
-                2 => {
                     let v = !storage.query(|s| s.no_accents);
                     storage.modify_and_save(|s| s.no_accents = v);
+                }
+                2 => {
+                    let muted = !storage.query(|s| s.muted);
+                    storage.modify_and_save(|s| s.muted = muted);
                 }
                 _ => {}
             }
@@ -702,11 +702,12 @@ pub async fn run(
             } else {
                 leds.unset(1, Led::Top);
             }
-            if muted {
-                leds.unset(1, Led::Button);
-            } else {
-                leds.set(1, Led::Button, led_color, Brightness::Mid);
-            }
+            leds.set(
+                1,
+                Led::Button,
+                led_color,
+                if no_accents { Brightness::Low } else { Brightness::Mid },
+            );
 
             // Ch 2: accent on Top, transpose position on Bottom (always visible)
             if accent && gate_active {
@@ -717,12 +718,11 @@ pub async fn run(
             let dist = (transpose_fader as i32 - 2048).unsigned_abs();
             let b = (dist * 255 / 2048) as u8;
             leds.set(2, Led::Bottom, led_color, Brightness::Custom(b));
-            leds.set(
-                2,
-                Led::Button,
-                led_color,
-                if no_accents { Brightness::Low } else { Brightness::Mid },
-            );
+            if muted {
+                leds.unset(2, Led::Button);
+            } else {
+                leds.set(2, Led::Button, led_color, Brightness::Mid);
+            }
         }
     };
 

--- a/faderpunk/src/apps/tb3po.rs
+++ b/faderpunk/src/apps/tb3po.rs
@@ -22,16 +22,12 @@ use crate::app::{
 use crate::tasks::leds::LedMode;
 
 pub const CHANNELS: usize = 3;
-pub const PARAMS: usize = 3;
+pub const PARAMS: usize = 4;
 
 const MAX_STEPS: usize = 32;
 
-// 0–10V range: 10V / 120 semitones ≈ 34 counts/semitone (1V/oct standard)
-const SEMITONE_COUNTS: i32 = 34;
 // Center pitch hint for quantizer input (midpoint of 0–4095 ≈ C5 at 0V=C0)
 const CENTER_CV: u16 = 2048;
-// One octave in counts
-const OCTAVE_COUNTS: i32 = 410;
 
 pub static CONFIG: Config<PARAMS> = Config::new(
     "TB-3PO",
@@ -52,12 +48,14 @@ pub static CONFIG: Config<PARAMS> = Config::new(
         Color::Pink,
         Color::Violet,
     ],
-});
+})
+.add_param(Param::VoltPerOct);
 
 pub struct Params {
     midi_channel: MidiChannel,
     midi_out: MidiOut,
     color: Color,
+    vpo: VoltPerOct,
 }
 
 impl Default for Params {
@@ -66,6 +64,7 @@ impl Default for Params {
             midi_channel: MidiChannel::default(),
             midi_out: MidiOut::default(),
             color: Color::Orange,
+            vpo: VoltPerOct::Standard,
         }
     }
 }
@@ -79,6 +78,7 @@ impl AppParams for Params {
             midi_channel: MidiChannel::from_value(values[0]),
             midi_out: MidiOut::from_value(values[1]),
             color: Color::from_value(values[2]),
+            vpo: VoltPerOct::from_value(values[3]),
         })
     }
 
@@ -87,6 +87,7 @@ impl AppParams for Params {
         vec.push(self.midi_channel.into()).unwrap();
         vec.push(self.midi_out.into()).unwrap();
         vec.push(self.color.into()).unwrap();
+        vec.push(self.vpo.into()).unwrap();
         vec
     }
 }
@@ -264,18 +265,20 @@ fn step_is_oct_down(p: &AcidPattern, step: u8) -> bool {
 }
 
 /// Raw pitch CV for a step before quantising (in ±5V counts 0–4095).
-fn raw_pitch_cv(p: &AcidPattern, step: u8, transpose: i16) -> u16 {
+fn raw_pitch_cv(p: &AcidPattern, step: u8, transpose: i16, vpo: VoltPerOct) -> u16 {
+    let oct = vpo.counts_per_oct() as i32;
+    let semi = oct / 12;
     let note = p.notes[step as usize] as i32;
     let cv = CENTER_CV as i32
-        + note * SEMITONE_COUNTS
+        + note * semi
         + if step_is_oct_up(p, step) {
-            OCTAVE_COUNTS
+            oct
         } else if step_is_oct_down(p, step) {
-            -OCTAVE_COUNTS
+            -oct
         } else {
             0
         }
-        + transpose as i32 * SEMITONE_COUNTS;
+        + transpose as i32 * semi;
     cv.clamp(0, 4095) as u16
 }
 
@@ -315,14 +318,15 @@ pub async fn run(
     let pitch_range = Range::_0_10V;
     let accent_range = Range::_0_5V;
 
-    let (midi_out, midi_chan, led_color) = params.query(|p| (p.midi_out, p.midi_channel, p.color));
+    let (midi_out, midi_chan, led_color, vpo) =
+        params.query(|p| (p.midi_out, p.midi_channel, p.color, p.vpo));
 
     let buttons = app.use_buttons();
     let faders = app.use_faders();
     let leds = app.use_leds();
     let mut clock = app.use_clock();
     let ticks = clock.get_ticker();
-    let quantizer = app.use_quantizer(pitch_range, VoltPerOct::Standard, false);
+    let quantizer = app.use_quantizer(pitch_range, vpo, false);
     let midi = app.use_midi_output(midi_out, midi_chan, false);
 
     let pitch_out = app.make_out_jack(0, pitch_range).await;
@@ -433,18 +437,18 @@ pub async fn run(
                         .map(|p| step_is_slid(&pattern, p as u8))
                         .unwrap_or(false);
                     let is_accent = !no_accents && step_is_accent(&pattern, step);
-                    let target_raw = raw_pitch_cv(&pattern, step, transpose);
+                    let target_raw = raw_pitch_cv(&pattern, step, transpose, vpo);
 
                     // Pitch / slide
                     if is_slid_prev {
                         // Glide: output_task will interpolate toward new target
                         let out = quantizer.get_quantized_note(target_raw).await;
-                        slide_target_glob.set(out.as_counts(pitch_range, VoltPerOct::Standard));
+                        slide_target_glob.set(out.as_counts(pitch_range, vpo));
                         slide_active_glob.set(true);
                     } else if is_gated {
                         // Snap to new pitch
                         let out = quantizer.get_quantized_note(target_raw).await;
-                        let counts = out.as_counts(pitch_range, VoltPerOct::Standard);
+                        let counts = out.as_counts(pitch_range, vpo);
                         slide_target_glob.set(counts);
                         slide_active_glob.set(false);
                     }

--- a/faderpunk/src/apps/tb3po.rs
+++ b/faderpunk/src/apps/tb3po.rs
@@ -3,7 +3,7 @@
 // Copyright (c) 2020, Logarhythm (original C++ implementation, MIT licensed)
 
 use embassy_futures::{
-    join::{join, join3, join5},
+    join::{join, join5},
     select::{select, select3},
 };
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
@@ -99,9 +99,9 @@ pub struct Storage {
     transpose_fader: u16, // 0–4095 → transpose −24..+24 semitones
     octave_fader: u16,    // 0–4095 → octave offset −4..+4 (shift + fader 3)
     res_saved: u16,       // 0–4095 → index into RESOLUTION table (8 segments of 512)
-    lock_seed: bool,
+    #[serde(default)]
+    muted: bool,
     no_accents: bool,
-    no_slides: bool,
 }
 
 impl Default for Storage {
@@ -113,9 +113,8 @@ impl Default for Storage {
             transpose_fader: 2048, // 0 semitones
             octave_fader: 2048,    // 0 octave offset
             res_saved: 2048,       // index 4 → RESOLUTION[4] = 6 (16th notes)
-            lock_seed: false,
+            muted: false,
             no_accents: false,
-            no_slides: false,
         }
     }
 }
@@ -406,11 +405,11 @@ pub async fn run(
                     last_tick = now;
 
                     let pattern = pattern_glob.get();
-                    let (num_steps, no_accents, no_slides, transpose) = storage.query(|s| {
+                    let (num_steps, no_accents, muted, transpose) = storage.query(|s| {
                         (
                             (s.length_fader as u32 * 31 / 4095 + 1) as u8,
                             s.no_accents,
-                            s.no_slides,
+                            s.muted,
                             {
                                 let semi = s.transpose_fader as i32 * 48 / 4095 - 24;
                                 let oct = s.octave_fader as i32 * 8 / 4095 - 4;
@@ -430,10 +429,9 @@ pub async fn run(
                     step_glob.set(step);
 
                     let is_gated = step_is_gated(&pattern, step);
-                    let is_slid_prev = !no_slides
-                        && prev_step
-                            .map(|p| step_is_slid(&pattern, p as u8))
-                            .unwrap_or(false);
+                    let is_slid_prev = prev_step
+                        .map(|p| step_is_slid(&pattern, p as u8))
+                        .unwrap_or(false);
                     let is_accent = !no_accents && step_is_accent(&pattern, step);
                     let target_raw = raw_pitch_cv(&pattern, step, transpose);
 
@@ -452,7 +450,7 @@ pub async fn run(
                     }
 
                     // Gate / MIDI
-                    if is_gated || is_slid_prev {
+                    if (is_gated || is_slid_prev) && !muted {
                         accent_active_glob.set(is_accent);
 
                         // Quantise for MIDI note (use target pitch for note identity)
@@ -480,16 +478,6 @@ pub async fn run(
                 }
 
                 ClockEvent::Reset => {
-                    if !storage.query(|s| s.lock_seed) {
-                        let new_seed = (ticks() & 0xFFFF) as u16;
-                        storage.modify_and_save(|s| s.seed = new_seed);
-                        let d = (storage.query(|s| s.density_fader) as u32 * 14 / 4095) as u8;
-                        pattern_glob.set(generate_pattern(new_seed, d));
-                    } else {
-                        let (s, df) = storage.query(|s| (s.seed, s.density_fader));
-                        let d = (df as u32 * 14 / 4095) as u8;
-                        pattern_glob.set(generate_pattern(s, d));
-                    }
                     step_glob.set(0);
                     slide_active_glob.set(false);
                     gate_off_ms_glob.set(0);
@@ -530,7 +518,7 @@ pub async fn run(
                     // Keep gate on during a slide (like the 303)
                     let pattern = pattern_glob.get();
                     let step = step_glob.get();
-                    if storage.query(|s| s.no_slides) || !step_is_slid(&pattern, step) {
+                    if !step_is_slid(&pattern, step) {
                         gate_active_glob.set(false);
                         gate_out.set_low().await;
                         midi.send_note_off(last_midi_note_glob.get()).await;
@@ -539,19 +527,20 @@ pub async fn run(
                 }
             }
 
-            // Pitch slide interpolation
-            let target = slide_target_glob.get() as f32;
-            if slide_active_glob.get() {
-                glide_current = apply_slide(glide_current, target, SLIDE_COEFF);
-                if (glide_current - target).abs() < 0.5 {
+            // Pitch slide interpolation — frozen while muted
+            if !storage.query(|s| s.muted) {
+                let target = slide_target_glob.get() as f32;
+                if slide_active_glob.get() {
+                    glide_current = apply_slide(glide_current, target, SLIDE_COEFF);
+                    if (glide_current - target).abs() < 0.5 {
+                        glide_current = target;
+                        slide_active_glob.set(false);
+                    }
+                } else {
                     glide_current = target;
-                    slide_active_glob.set(false);
                 }
-            } else {
-                glide_current = target;
+                pitch_out.set_value(glide_current as u16);
             }
-
-            pitch_out.set_value(glide_current as u16);
         }
     };
 
@@ -634,9 +623,7 @@ pub async fn run(
                 continue;
             }
             match chan {
-                0 if latch_layer_glob.get() != LatchLayer::Third
-                    && !storage.query(|s| s.lock_seed) =>
-                {
+                0 if latch_layer_glob.get() != LatchLayer::Third => {
                     let new_seed = (ticks() & 0xFFFF) as u16;
                     storage.modify_and_save(|s| s.seed = new_seed);
                     let d = (storage.query(|s| s.density_fader) as u32 * 14 / 4095) as u8;
@@ -649,8 +636,8 @@ pub async fn run(
                     );
                 }
                 1 => {
-                    let v = !storage.query(|s| s.no_slides);
-                    storage.modify_and_save(|s| s.no_slides = v);
+                    let muted = !storage.query(|s| s.muted);
+                    storage.modify_and_save(|s| s.muted = muted);
                 }
                 2 => {
                     let v = !storage.query(|s| s.no_accents);
@@ -661,29 +648,17 @@ pub async fn run(
         }
     };
 
-    // --- Button long-press task: B0 toggles lock_seed ---
-    let button_long_task = async {
-        loop {
-            let (chan, _) = buttons.wait_for_any_long_press().await;
-            if chan == 0 {
-                let v = !storage.query(|s| s.lock_seed);
-                storage.modify_and_save(|s| s.lock_seed = v);
-            }
-        }
-    };
-
     // --- LED task (16 ms) ---
     let led_task = async {
         loop {
             app.delay_millis(16).await;
 
-            let (density_fader, locked, no_accents, no_slides, length_fader, res_saved, transpose_fader) =
+            let (density_fader, muted, no_accents, length_fader, res_saved, transpose_fader) =
                 storage.query(|s| {
                     (
                         s.density_fader,
-                        s.lock_seed,
+                        s.muted,
                         s.no_accents,
-                        s.no_slides,
                         s.length_fader,
                         s.res_saved,
                         s.transpose_fader,
@@ -710,11 +685,7 @@ pub async fn run(
                     led_color,
                     Brightness::Custom((density as u32 * 255 / 14) as u8),
                 );
-                if locked {
-                    leds.set(0, Led::Bottom, Color::Orange, Brightness::High);
-                } else {
-                    leds.unset(0, Led::Bottom);
-                }
+                leds.unset(0, Led::Bottom);
             }
             // Button LED managed by reseed flash — only set here on first frame (handled by init)
 
@@ -731,12 +702,11 @@ pub async fn run(
             } else {
                 leds.unset(1, Led::Top);
             }
-            leds.set(
-                1,
-                Led::Button,
-                led_color,
-                if no_slides { Brightness::Low } else { Brightness::Mid },
-            );
+            if muted {
+                leds.unset(1, Led::Button);
+            } else {
+                leds.set(1, Led::Button, led_color, Brightness::Mid);
+            }
 
             // Ch 2: accent on Top, transpose position on Bottom (always visible)
             if accent && gate_active {
@@ -777,7 +747,7 @@ pub async fn run(
 
     join(
         join5(clock_task, output_task, fader_task, layer_task, button_task),
-        join3(button_long_task, led_task, scene_task),
+        join(led_task, scene_task),
     )
     .await;
 }

--- a/faderpunk/src/apps/tb3po.rs
+++ b/faderpunk/src/apps/tb3po.rs
@@ -623,7 +623,7 @@ pub async fn run(
                 continue;
             }
             match chan {
-                0 if latch_layer_glob.get() != LatchLayer::Third => {
+                0 => {
                     let new_seed = (ticks() & 0xFFFF) as u16;
                     storage.modify_and_save(|s| s.seed = new_seed);
                     let d = (storage.query(|s| s.density_fader) as u32 * 14 / 4095) as u8;


### PR DESCRIPTION
## Summary

- Resolution mode moves from Button 1 + Fader 1 to Button 3 (hold) + Fader 3
- Mute is now triggered by releasing Button 3 without having moved Fader 3 (hold-to-set-resolution, tap-to-mute)
- Shift guard prevents a shift-press mid-hold from accidentally toggling mute
- Ch 0 Top LED now shows current raw sequencer note (no transpose, scaled to 3-octave range)
- Ch 0 Bottom LED now shows density fader position
- Ch 3 LEDs show resolution index (cyan, Top) and division flash (Bottom) while Button 3 is held
- Manual graphics updated: shorter labels, octave transpose uses shift+fader slot, resolution uses fn+fader slot

## Test plan

- [ ] Short press Button 1 reseeds (flash on Ch 0 button LED)
- [ ] Short press Button 2 toggles accents (Ch 2 button LED dims when off)
- [ ] Hold Button 3 + move Fader 3: clock resolution changes, Ch 3 Top shows index (cyan), Ch 3 Bottom flashes with division
- [ ] Release Button 3 without moving Fader 3: mute toggles (Ch 3 button LED on/off)
- [ ] Hold Button 3 then press Shift mid-hold: no mute toggle on release
- [ ] Mute inhibit-only: current note rings out, pitch CV holds, no new gates until unmuted
- [ ] Shift + Fader 3: octave transpose (±4 oct)
- [ ] Fader 3 (no modifier): semitone transpose (±24)
- [ ] Ch 0 Top LED tracks current note pitch, Ch 0 Bottom tracks density fader
- [ ] Mute state and resolution survive scene save/recall