### PR TITLE
fix(genseq): fix octave shift clipping at negative offsets

### DIFF
--- a/faderpunk/src/apps/genseq.rs
+++ b/faderpunk/src/apps/genseq.rs
@@ -1,0 +1,662 @@
+use embassy_futures::{
+    join::join4,
+    select::{select, select3},
+};
+use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
+use heapless::Vec;
+use serde::{Deserialize, Serialize};
+
+use libfp::{
+    ext::FromValue,
+    latch::LatchLayer,
+    quantizer::Pitch,
+    utils::{attenuate, euclidean_at, rotate_select_bit, scale_to_12bit},
+    AppIcon, Brightness, ClockDivision, Color, Config, MidiChannel, MidiNote, MidiOut, Param,
+    Range, Value, VoltPerOct, APP_MAX_PARAMS,
+};
+use midly::num::u7;
+
+use crate::app::{
+    App, AppParams, AppStorage, ClockEvent, Led, ManagedStorage, ParamStore, SceneEvent,
+};
+
+pub const CHANNELS: usize = 3;
+pub const PARAMS: usize = 4;
+
+/// LED colors for the 5 octave shift steps -2..+2 (F1 Third layer)
+const OCT_COLORS: [Color; 5] = [
+    Color::Blue,
+    Color::Cyan,
+    Color::Green,
+    Color::Yellow,
+    Color::Red,
+];
+
+pub static CONFIG: Config<PARAMS> = Config::new(
+    "GenSeq",
+    "Generative sequencer with Turing machine registers",
+    Color::Blue,
+    AppIcon::SequenceSquare,
+)
+.add_param(Param::MidiChannel { name: "MIDI Channel" })
+.add_param(Param::MidiNote { name: "Base Note" })
+.add_param(Param::Color {
+    name: "Color",
+    variants: &[
+        Color::Blue,
+        Color::Green,
+        Color::Rose,
+        Color::Orange,
+        Color::Cyan,
+        Color::Pink,
+        Color::Violet,
+        Color::Yellow,
+    ],
+})
+.add_param(Param::MidiOut);
+
+pub struct Params {
+    midi_channel: MidiChannel,
+    note: MidiNote,
+    color: Color,
+    midi_out: MidiOut,
+}
+
+impl Default for Params {
+    fn default() -> Self {
+        Self {
+            midi_channel: MidiChannel::default(),
+            note: MidiNote::from(36),
+            color: Color::Blue,
+            midi_out: MidiOut::default(),
+        }
+    }
+}
+
+impl AppParams for Params {
+    fn from_values(values: &[Value]) -> Option<Self> {
+        if values.len() < PARAMS {
+            return None;
+        }
+        Some(Self {
+            midi_channel: MidiChannel::from_value(values[0]),
+            note: MidiNote::from_value(values[1]),
+            color: Color::from_value(values[2]),
+            midi_out: MidiOut::from_value(values[3]),
+        })
+    }
+
+    fn to_values(&self) -> Vec<Value, APP_MAX_PARAMS> {
+        let mut vec = Vec::new();
+        vec.push(self.midi_channel.into()).unwrap();
+        vec.push(self.note.into()).unwrap();
+        vec.push(self.color.into()).unwrap();
+        vec.push(self.midi_out.into()).unwrap();
+        vec
+    }
+}
+
+/// Fader layout:
+///   F0 Main=pitch_att     Alt=pitch_length_saved  Third=res_saved
+///   F1 Main=length_att    Alt=legato_att          Third=octave_shift
+///   F2 Main=beat_density  Alt=accent_att          Third=gate_length
+///
+/// Buttons (no shift): hold to mutate that register
+///   Btn0=pitch  Btn1=length
+///
+/// Shift+Button counting (while shift held, each press increments; release commits):
+///   Shift+Btn0: pitch TM length (1–16) → pitch_tm_length
+///   Shift+Btn1: length TM register width (1–16) → length_tm_length
+///
+/// Outputs:
+///   Jack0=CV (quantized pitch)  Jack1=Gate  Jack2=Accent CV (4095 when accented)
+#[derive(Serialize, Deserialize)]
+pub struct Storage {
+    // Main layer
+    pitch_att: u16,
+    length_att: u16,
+    beat_density: u16,
+    // Alt layer
+    pitch_length_saved: u16,
+    legato_att: u16,
+    accent_att: u16,
+    // Third layer
+    res_saved: u16,
+    octave_shift: u16,
+    gate_length: u16,
+    // Turing machine state (register_pitch persists; register_length is ephemeral)
+    register_pitch: u16,
+    register_length: u16,
+    // TM register widths (1–16, set by Shift+Button counting)
+    pitch_tm_length: u8,
+    length_tm_length: u8,
+    muted: bool,
+}
+
+impl Default for Storage {
+    fn default() -> Self {
+        Self {
+            pitch_att: 3000,
+            length_att: 2048,
+            beat_density: 2048,
+            pitch_length_saved: 2048, // ~9 steps
+            legato_att: 1024,
+            accent_att: 1024,
+            res_saved: 2048,  // resolution[4] = 6 PPQN
+            octave_shift: 1638, // 1638/819=2 → 2-2=0 octave shift
+            gate_length: 2048,  // ~50%
+            register_pitch: 7632,
+            register_length: 534,
+            pitch_tm_length: 9,
+            length_tm_length: 16,
+            muted: false,
+        }
+    }
+}
+
+impl AppStorage for Storage {}
+
+#[embassy_executor::task(pool_size = 16 / CHANNELS)]
+pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMutex, bool>) {
+    let param_store = ParamStore::<Params>::new(app.app_id, app.layout_id, Params::default());
+    let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
+
+    param_store.load().await;
+    storage.load().await;
+
+    let app_loop = async {
+        loop {
+            select3(
+                run(&app, &param_store, &storage),
+                param_store.param_handler(),
+                storage.saver_task(),
+            )
+            .await;
+        }
+    };
+
+    select(app_loop, app.exit_handler(exit_signal)).await;
+}
+
+pub async fn run(
+    app: &App<CHANNELS>,
+    params: &ParamStore<Params>,
+    storage: &ManagedStorage<Storage>,
+) {
+    let (led_color, midi_chan, base_note, midi_out) =
+        params.query(|p| (p.color, p.midi_channel, p.note, p.midi_out));
+
+    let buttons = app.use_buttons();
+    let fader = app.use_faders();
+    let leds = app.use_leds();
+    let mut clock = app.use_clock();
+    let die = app.use_die();
+    let quantizer = app.use_quantizer(Range::_0_10V, VoltPerOct::Standard, false);
+    let midi = app.use_midi_output(midi_out, midi_chan, false);
+
+    let prob_pitch_glob = app.make_global(0u16);
+    let prob_length_glob = app.make_global(0u16);
+    let recall_flag = app.make_global(false);
+    let div_glob = app.make_global(4u32);
+    let midi_note = app.make_global(MidiNote::from(0));
+    let last_note_on = app.make_global(MidiNote::from(0));
+    let glob_latch_layer = app.make_global(LatchLayer::Main);
+    let glob_muted = app.make_global(storage.query(|s| s.muted));
+
+    let resolution = [24u32, 16, 12, 8, 6, 4, 3, 2];
+
+    leds.set(0, Led::Button, led_color, Brightness::Low);
+    leds.set(1, Led::Button, led_color, Brightness::Low);
+    if storage.query(|s| s.muted) {
+        leds.unset(2, Led::Button);
+    } else {
+        leds.set(2, Led::Button, led_color, Brightness::Low);
+    }
+
+    let cv_out = app.make_out_jack(0, Range::_0_10V).await;
+    let gate_out = app.make_out_jack(1, Range::_0_10V).await;
+    let aux_out = app.make_out_jack(2, Range::_0_10V).await;
+
+    let (mut register_pitch, mut register_length) =
+        storage.query(|s| (s.register_pitch, s.register_length));
+
+    let res = storage.query(|s| s.res_saved);
+    div_glob.set(resolution[(res / 512).min(7) as usize]);
+
+    // Clock-driven sequencer loop
+    let fut1 = async {
+        let mut clkn: u32 = 0;
+        let mut gate_on = false;
+        let mut clkn_euclid: u16 = 0;
+        let mut beat_reg_length: u8 = storage.query(|s| s.length_tm_length).clamp(1, 16);
+        let mut euclid_length: u8 = attenuate(
+            length_register_scaled(register_length, beat_reg_length),
+            storage.query(|s| s.length_att),
+        )
+        .max(1) as u8;
+        let mut euclid_beat: u8 = (storage.query(|s| s.beat_density) as u32
+            * euclid_length as u32
+            / 4095)
+            .clamp(1, euclid_length as u32) as u8;
+        let mut pending_note_off = false;
+        let mut legato = false;
+        let mut legato_register: u16 = register_pitch ^ register_length;
+        let mut accent_register: u16 = register_pitch ^ register_length.rotate_right(8);
+
+        loop {
+            let div = div_glob.get();
+            match clock.wait_for_event(ClockDivision::_1).await {
+                ClockEvent::Reset => {
+                    clkn = 0;
+                    if gate_on {
+                        gate_out.set_value(0);
+                        midi.send_note_off(last_note_on.get()).await;
+                        gate_on = false;
+                    }
+                    register_pitch = storage.query(|s| s.register_pitch);
+                }
+                ClockEvent::Tick => {
+                    if clkn.is_multiple_of(div) {
+                        clkn_euclid = (clkn_euclid + 1) % euclid_length.max(1) as u16;
+
+                        if clkn_euclid == 0 {
+                            // Cycle boundary: rotate TMs, recompute pattern params and pitch
+                            let prob_pitch = prob_pitch_glob.get();
+                            let prob_length = prob_length_glob.get();
+
+                            beat_reg_length = storage.query(|s| s.length_tm_length).clamp(1, 16);
+
+                            let rand = die.roll().clamp(100, 3900);
+                            register_length = rotate_select_bit(
+                                register_length,
+                                prob_length,
+                                rand,
+                                beat_reg_length as u16,
+                            )
+                            .0;
+
+                            euclid_length = attenuate(
+                                length_register_scaled(register_length, beat_reg_length),
+                                storage.query(|s| s.length_att),
+                            )
+                            .max(1) as u8;
+
+                            euclid_beat = (storage.query(|s| s.beat_density) as u32
+                                * euclid_length as u32
+                                / 4095)
+                                .clamp(1, euclid_length as u32) as u8;
+
+                            let length = storage.query(|s| s.pitch_tm_length).clamp(1, 16) as u16;
+                            let rand = die.roll().clamp(100, 3900);
+                            register_pitch =
+                                rotate_select_bit(register_pitch, prob_pitch, rand, length).0;
+
+                            let register_scaled = scale_to_12bit(register_pitch, length as u8);
+                            let att_reg =
+                                attenuate(register_scaled, storage.query(|s| s.pitch_att));
+
+                            let octave_offset =
+                                (storage.query(|s| s.octave_shift) / 819).min(4) as i32 - 2;
+
+                            // When shifting down, raise the quantizer input floor so the
+                            // bottom of the pitch range maps to C0 rather than clipping
+                            // negative DAC values to 0V.
+                            let input_floor: u16 = match (-octave_offset).max(0) {
+                                1 => 410, // C1 in 0–10 V counts
+                                2 => 819, // C2 in 0–10 V counts
+                                _ => 0,
+                            };
+                            let quantizer_input =
+                                (att_reg as u32 / 2 + input_floor as u32).min(4095) as u16;
+                            let out = quantizer.get_quantized_note(quantizer_input).await;
+
+                            // Apply the octave shift in pitch space to avoid the ±1 count
+                            // rounding error from the integer counts_per_oct approximation.
+                            let shifted = Pitch {
+                                octave: (out.octave as i32 + octave_offset) as i8,
+                                note: out.note,
+                                raw: None,
+                            };
+
+                            let base_note_i = u7::from(base_note).as_int() as i32;
+                            let shifted_midi_val =
+                                u7::from(shifted.as_midi()).as_int() as i32;
+                            let note = MidiNote::from(
+                                (base_note_i + shifted_midi_val - 12).clamp(0, 127),
+                            );
+                            midi_note.set(note);
+
+                            if !glob_muted.get() {
+                                cv_out.set_value(
+                                    shifted.as_counts(Range::_0_10V, VoltPerOct::Standard),
+                                );
+                            }
+                            leds.set(
+                                0,
+                                Led::Top,
+                                led_color,
+                                Brightness::Custom((register_scaled / 16) as u8),
+                            );
+
+                            let reg_old = storage.query(|s| s.register_pitch);
+                            if recall_flag.get() {
+                                register_pitch = reg_old;
+                                recall_flag.set(false);
+                            } else if register_pitch != reg_old {
+                                storage.modify_and_save(|s| s.register_pitch = register_pitch);
+                            }
+
+                            // Derive legato/accent registers from XOR of both TMs
+                            legato_register = register_pitch ^ register_length;
+                            accent_register = register_pitch ^ register_length.rotate_right(8);
+                        } else {
+                            // Every other step: rotate derived registers
+                            legato_register = legato_register.rotate_right(1);
+                            accent_register = accent_register.rotate_right(1);
+                        }
+
+                        let is_legato =
+                            scale_to_12bit(legato_register, 16) < storage.query(|s| s.legato_att);
+                        let is_accented = scale_to_12bit(accent_register, 16)
+                            < storage.query(|s| s.accent_att);
+
+                        let is_beat =
+                            euclidean_at(euclid_length, euclid_beat, 0, clkn_euclid as u32);
+
+                        if is_beat && !glob_muted.get() {
+                            if gate_on {
+                                midi.send_note_off(last_note_on.get()).await;
+                            }
+                            let note = midi_note.get();
+                            last_note_on.set(note);
+                            gate_out.set_value(4095);
+                            gate_on = true;
+                            pending_note_off = false;
+                            aux_out.set_value(if is_accented { 4095 } else { 0 });
+                            midi.send_note_on(note, if is_accented { 4095 } else { 2048 })
+                                .await;
+                            leds.set(1, Led::Top, led_color, Brightness::Low);
+                        }
+
+                        legato = is_legato;
+                        if is_legato {
+                            leds.set(2, Led::Top, led_color, Brightness::Low);
+                        } else {
+                            leds.set(2, Led::Top, led_color, Brightness::Custom(0));
+                            if pending_note_off && gate_on {
+                                gate_out.set_value(0);
+                                gate_on = false;
+                                pending_note_off = false;
+                                leds.set(1, Led::Top, led_color, Brightness::Custom(0));
+                                midi.send_note_off(last_note_on.get()).await;
+                            }
+                        }
+                    }
+
+                    // Resolution flash on Ch0 Bottom while in Third layer
+                    if matches!(glob_latch_layer.get(), LatchLayer::Third) {
+                        if clkn.is_multiple_of(div) {
+                            let color = if matches!(div, 2 | 4 | 8 | 16) {
+                                Color::Orange
+                            } else {
+                                Color::Blue
+                            };
+                            leds.set(0, Led::Bottom, color, Brightness::High);
+                        } else if clkn % div == (div / 2).max(1) {
+                            leds.unset(0, Led::Bottom);
+                        }
+                    }
+
+                    // Gate off
+                    let gate_pct =
+                        (storage.query(|s| s.gate_length) as u32 * 100 / 4095).clamp(1, 99);
+                    if clkn % div == (div * gate_pct / 100).clamp(1, div - 1) {
+                        if gate_on && !legato {
+                            gate_out.set_value(0);
+                            gate_on = false;
+                            leds.set(1, Led::Top, led_color, Brightness::Custom(0));
+                            midi.send_note_off(last_note_on.get()).await;
+                        } else if gate_on && legato {
+                            pending_note_off = true;
+                        }
+                    }
+
+                    clkn += 1;
+                }
+                _ => {}
+            }
+        }
+    };
+
+    // Fader handler
+    let fut2 = async {
+        let mut latch = [
+            app.make_latch(fader.get_value_at(0)),
+            app.make_latch(fader.get_value_at(1)),
+            app.make_latch(fader.get_value_at(2)),
+        ];
+
+        loop {
+            let chan = fader.wait_for_any_change().await;
+            let layer = glob_latch_layer.get();
+
+            let target = match (chan, layer) {
+                (0, LatchLayer::Main) => storage.query(|s| s.pitch_att),
+                (0, LatchLayer::Alt) => {
+                    (storage.query(|s| s.pitch_tm_length).saturating_sub(1) as u32 * 4095 / 15)
+                        as u16
+                }
+                (0, LatchLayer::Third) => storage.query(|s| s.res_saved),
+                (1, LatchLayer::Main) => storage.query(|s| s.length_att),
+                (1, LatchLayer::Alt) => storage.query(|s| s.legato_att),
+                (1, LatchLayer::Third) => storage.query(|s| s.octave_shift),
+                (2, LatchLayer::Main) => storage.query(|s| s.beat_density),
+                (2, LatchLayer::Alt) => storage.query(|s| s.accent_att),
+                (2, LatchLayer::Third) => storage.query(|s| s.gate_length),
+                _ => 0,
+            };
+
+            if let Some(v) = latch[chan].update(fader.get_value_at(chan), layer, target) {
+                match (chan, layer) {
+                    (0, LatchLayer::Main) => storage.modify_and_save(|s| s.pitch_att = v),
+                    (0, LatchLayer::Alt) => storage.modify_and_save(|s| {
+                        s.pitch_tm_length = (v as u32 * 15 / 4095 + 1).min(16) as u8;
+                    }),
+                    (0, LatchLayer::Third) => {
+                        div_glob.set(resolution[(v / 512).min(7) as usize]);
+                        midi.send_note_off(last_note_on.get()).await;
+                        storage.modify_and_save(|s| s.res_saved = v);
+                    }
+                    (1, LatchLayer::Main) => storage.modify_and_save(|s| s.length_att = v),
+                    (1, LatchLayer::Alt) => storage.modify_and_save(|s| s.legato_att = v),
+                    (1, LatchLayer::Third) => storage.modify_and_save(|s| s.octave_shift = v),
+                    (2, LatchLayer::Main) => storage.modify_and_save(|s| s.beat_density = v),
+                    (2, LatchLayer::Alt) => storage.modify_and_save(|s| s.accent_att = v),
+                    (2, LatchLayer::Third) => storage.modify_and_save(|s| s.gate_length = v),
+                    _ => {}
+                }
+            }
+        }
+    };
+
+    // Layer management, mutation, TM length counting, mute, and LED feedback
+    let fut3 = async {
+        let mut shift_old = false;
+        let mut btn0_old = false;
+        let mut btn1_old = false;
+        let mut btn2_old = false;
+        let mut pitch_len_count: u8 = 0;
+        let mut length_len_count: u8 = 0;
+        let mut was_overlay = false;
+
+        loop {
+            app.delay_millis(1).await;
+
+            let shift = buttons.is_shift_pressed();
+            let btn0 = buttons.is_button_pressed(0);
+            let btn1 = buttons.is_button_pressed(1);
+            let btn2 = buttons.is_button_pressed(2);
+
+            // Mute toggle: btn2 short press without shift
+            if btn2 && !btn2_old && !shift {
+                let muted = !glob_muted.get();
+                glob_muted.set(muted);
+                storage.modify_and_save(|s| s.muted = muted);
+            }
+            btn2_old = btn2;
+
+            // TM length counting: Shift + Btn0/Btn1 presses (edge-triggered)
+            let was_shift = shift_old;
+            shift_old = shift;
+
+            // Reset at the start of a new Shift session, before counting
+            if shift && !was_shift {
+                pitch_len_count = 0;
+                length_len_count = 0;
+            }
+
+            // Count presses (safe now — reset already fired this tick if needed)
+            if shift {
+                if btn0 && !btn0_old {
+                    pitch_len_count = pitch_len_count.saturating_add(1).min(16);
+                }
+                if btn1 && !btn1_old {
+                    length_len_count = length_len_count.saturating_add(1).min(16);
+                }
+            }
+            btn0_old = btn0;
+            btn1_old = btn1;
+
+            // Commit on Shift release
+            if !shift && was_shift {
+                if pitch_len_count >= 1 {
+                    storage.modify_and_save(|s| s.pitch_tm_length = pitch_len_count);
+                }
+                if length_len_count >= 1 {
+                    storage.modify_and_save(|s| s.length_tm_length = length_len_count);
+                }
+                pitch_len_count = 0;
+                length_len_count = 0;
+            }
+
+            let layer = if shift {
+                LatchLayer::Alt
+            } else if btn0 {
+                LatchLayer::Third
+            } else {
+                LatchLayer::Main
+            };
+            glob_latch_layer.set(layer);
+
+            if !shift {
+                prob_pitch_glob.set(if btn0 { 2048 } else { 0 });
+                prob_length_glob.set(if btn1 { 2048 } else { 0 });
+            } else {
+                prob_pitch_glob.set(0);
+                prob_length_glob.set(0);
+            }
+
+            let muted = glob_muted.get();
+            let is_overlay = !matches!(layer, LatchLayer::Main);
+
+            // Returning to Main: clear overlay LEDs so fut1 takes over cleanly
+            if was_overlay && !is_overlay {
+                leds.unset(0, Led::Top);
+                leds.unset(1, Led::Top);
+                leds.unset(2, Led::Top);
+                leds.unset(0, Led::Bottom);
+            }
+            was_overlay = is_overlay;
+
+            match layer {
+                LatchLayer::Main => {
+                    // Btn0/Btn1: brighter when held (mutating)
+                    leds.set(0, Led::Button, led_color, if btn0 { Brightness::High } else { Brightness::Low });
+                    leds.set(1, Led::Button, led_color, if btn1 { Brightness::High } else { Brightness::Low });
+                    // Btn2: mute indicator — dim when active, off when muted
+                    if muted {
+                        leds.unset(2, Led::Button);
+                    } else {
+                        leds.set(2, Led::Button, led_color, Brightness::Low);
+                    }
+                }
+                LatchLayer::Alt => {
+                    // Button LEDs: brightness shows live count while counting
+                    leds.set(0, Led::Button, Color::White, Brightness::Custom(pitch_len_count.saturating_mul(16)));
+                    leds.set(1, Led::Button, Color::Green, Brightness::Custom(length_len_count.saturating_mul(16)));
+                    if muted {
+                        leds.unset(2, Led::Button);
+                    } else {
+                        leds.set(2, Led::Button, led_color, Brightness::Low);
+                    }
+                    // Top LEDs: fader values (brightness = current setting)
+                    leds.set(
+                        0,
+                        Led::Top,
+                        Color::White,
+                        Brightness::Custom(
+                            (storage.query(|s| s.pitch_tm_length) * 16).saturating_sub(1),
+                        ),
+                    );
+                    leds.set(
+                        1,
+                        Led::Top,
+                        Color::Cyan,
+                        Brightness::Custom((storage.query(|s| s.legato_att) / 16) as u8),
+                    );
+                    leds.set(
+                        2,
+                        Led::Top,
+                        Color::Yellow,
+                        Brightness::Custom((storage.query(|s| s.accent_att) / 16) as u8),
+                    );
+                }
+                LatchLayer::Third => {
+                    leds.set(0, Led::Button, led_color, Brightness::Low);
+                    let oct_idx = (storage.query(|s| s.octave_shift) / 819).min(4) as usize;
+                    leds.set(1, Led::Button, OCT_COLORS[oct_idx], Brightness::High);
+                    if muted {
+                        leds.unset(2, Led::Button);
+                    } else {
+                        leds.set(2, Led::Button, led_color, Brightness::Low);
+                    }
+                    leds.set(
+                        2,
+                        Led::Top,
+                        Color::White,
+                        Brightness::Custom((storage.query(|s| s.gate_length) / 16) as u8),
+                    );
+                }
+            }
+        }
+    };
+
+    let scene_handler = async {
+        loop {
+            match app.wait_for_scene_event().await {
+                SceneEvent::LoadScene(scene) => {
+                    storage.load_from_scene(scene).await;
+                    let res = storage.query(|s| s.res_saved);
+                    div_glob.set(resolution[(res / 512).min(7) as usize]);
+                    recall_flag.set(true);
+                }
+                SceneEvent::SaveScene(scene) => {
+                    storage.save_to_scene(scene).await;
+                }
+            }
+        }
+    };
+
+    join4(fut1, fut2, fut3, scene_handler).await;
+}
+
+/// Scale the length register to the 0–16 range used for euclid_length.
+/// When bit_length == 1, bypasses the register and returns 16 (full scale) so
+/// length_att becomes a direct euclidean length control.
+fn length_register_scaled(register: u16, bit_length: u8) -> u16 {
+    if bit_length == 1 {
+        16
+    } else {
+        (scale_to_12bit(register, bit_length) as u32 * 16 / 4095) as u16
+    }
+}

--- a/faderpunk/src/apps/mod.rs
+++ b/faderpunk/src/apps/mod.rs
@@ -24,4 +24,5 @@ register_apps!(
     23 => fp_grids,
     24 => tb3po,
     25 => automator,
+    26 => genseq,
 );

--- a/libfp/src/utils.rs
+++ b/libfp/src/utils.rs
@@ -214,6 +214,31 @@ pub fn euclidean_at(num_steps: u8, num_beats: u8, rotation: u8, clock: u32) -> b
     (pattern & (1 << pos)) != 0
 }
 
+/// Scale the top `x` bits of a 16-bit shift register (`x` in 1..=16) to a 12-bit value
+/// (`0..=4095`). Used by the Turing-machine apps to turn register state into a CV/level.
+pub fn scale_to_12bit(input: u16, x: u8) -> u16 {
+    let x = x.clamp(1, 16);
+    let top_x_bits = input >> (16 - x);
+    let max_x_val = (1u32 << x) - 1;
+    ((top_x_bits as u32 * 4095) / max_x_val) as u16
+}
+
+/// Turing-machine shift-register step. Rotates `x` right by one bit, re-injecting the
+/// looped bit at the MSB. The looped bit is read from the bottom of the active
+/// `length`-bit window (`length` in 1..=16) so the pattern repeats with period `length`;
+/// when `a > b` the bit is inverted (the probabilistic mutation).
+/// Returns `(new_register, was_flipped, output_bit)`.
+pub fn rotate_select_bit(x: u16, a: u16, b: u16, length: u16) -> (u16, bool, bool) {
+    let bit_index = (16 - length).clamp(0, 16);
+    let original_bit = ((x >> bit_index) & 1) as u8;
+    let mut bit = original_bit;
+    if a > b {
+        bit ^= 1;
+    }
+    let result = (x >> 1) | ((bit as u16) << 15);
+    (result, bit != original_bit, bit != 0)
+}
+
 /// RC-filter coefficient for an exponential approach with the given `tau` (in ticks).
 /// `tau <= 0` returns 1.0 (instant). Apply each tick: `current += (target - current) * coeff`.
 pub fn rc_coeff(tau: f32) -> f32 {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `genseq.rs` (generative sequencer, app id 26) from PR #529
- Fixes octave shift clipping: at the lowest fader position (−2 octave offset), notes in the C0–C1 range produced negative DAC counts that clipped to 0V, collapsing the bottom 2 octaves of the melody to silence
- Adds `scale_to_12bit` and `rotate_select_bit` to `libfp/src/utils.rs`, shared by genseq

## What changed

**Root cause:** `out.as_counts() + octave_offset * 410` went negative for low notes with a negative octave offset. With the pitch register spanning C0–C5, the entire bottom 2 octaves collapsed to 0V at −2 shift.

**Fix:**
1. Raise the quantizer input floor when shifting down — at −2 octave offset the floor is set to 819 counts (C2), so the minimum quantized note after shifting is C0 (0V) rather than C−2 (unrepresentable)
2. Apply the octave shift in Pitch space rather than count space, avoiding the ±1 count rounding error from the integer 410 counts/octave approximation (exact value is 409.5)
3. Derive the MIDI note from the shifted pitch so CV and MIDI stay in sync across all octave offsets

## Test plan

- Set octave shift fader (Third layer, F1) to minimum — confirm pitch plays in a useful range rather than clustering at 0V
- Set octave shift to centre (default, 0 offset) — confirm melody unchanged vs before
- Set octave shift to maximum (+2) — confirm melody shifts up two octaves without clipping at top
- Verify MIDI note output matches CV pitch at all octave shift positions
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017d76LBo7N5CH4uzNkTDdV6)_