### PR TITLE
fix: load params for duplicated apps so they appear in Active Apps

### DIFF
--- a/configurator/src/components/EditLayoutModal.tsx
+++ b/configurator/src/components/EditLayoutModal.tsx
@@ -268,11 +268,24 @@ export const EditLayoutModal = ({
             await setGlobalConfig(usbDevice, modalConfig.recallConfig);
             setConfig(modalConfig.recallConfig);
           }
-        } else if (modalConfig.mode === ModalMode.AddApp && newAppId !== null) {
-          // Wait 500ms for the new app to spawn
-          await delay(500);
-          const params = await getAppParams(usbDevice, newAppId);
-          setParams(newAppId, params);
+        } else {
+          // AddApp or EditLayout: fetch params for every newly-added slot.
+          // This covers a single AddApp placement plus any duplicates made
+          // via the duplicate button, each of which gets its own layout id.
+          const existingIds = new Set(
+            initialLayout.filter((s) => s.app).map((s) => s.id),
+          );
+          const newIds = layout
+            .filter((slot) => slot.app && !existingIds.has(slot.id))
+            .map((slot) => slot.id);
+          if (newIds.length > 0) {
+            // Wait 500ms for the new app(s) to spawn before reading params
+            await delay(500);
+            for (const id of newIds) {
+              const params = await getAppParams(usbDevice, id);
+              setParams(id, params);
+            }
+          }
         }
         onSave(newLayout);
       } else if (isSimulator) {
@@ -325,7 +338,6 @@ export const EditLayoutModal = ({
     modalConfig.recallParams,
     modalConfig.mode,
     modalConfig.recallConfig,
-    newAppId,
     onSave,
     recallParams,
     recallConfig,


### PR DESCRIPTION
## Problem

Duplicating apps in the configurator left the duplicates out of the "Active Apps" list, even though the channel-overview graphic and the device itself showed them. A page refresh made them appear.

Reported on 1.10 beta: adding three Control apps then duplicating the third four times showed seven channels in use on the device and in the channel graphic, but only the original three apps in the Active Apps list below.

## Cause

`EditLayoutModal.handleSave` only fetched parameters for the single newly-added app (`newAppId`) after saving to the device. Each duplicate gets its own layout id, so their params were never loaded into the store. `ActiveApps` hides any slot whose id has no params, so the duplicates stayed invisible until a refresh re-fetched everything. Duplicates created in plain Edit Layout mode got no param fetch at all.

## Fix

Diff the saved layout against the initial layout and fetch params for every newly-added slot id, not just the single AddApp placement. Covers single adds and any number of duplicates, in both AddApp and EditLayout modes.

## Test checklist (configurator + live device)

- [ ] Connect a device, start from an empty layout
- [ ] Add an app, then use Duplicate to make 2-3 copies, Save
- [ ] All copies appear in the Active Apps list immediately (no page refresh)
- [ ] Open Edit Layout, duplicate an existing app, Save — the new copy appears in Active Apps immediately
- [ ] Each duplicate's params are editable and persist correctly