### PR TITLE
fix(lfo): phase-lock LFO position to clock ticks when clocked

### DIFF
--- a/configurator/src/components/ManualTab.tsx
+++ b/configurator/src/components/ManualTab.tsx
@@ -67,9 +67,30 @@ const apps: ManualAppData[] = [
       "MIDI CC",
       "NRPN",
       "Send MIDI",
+      "Grid Lock",
     ],
     storage: ["Clocked", "Attenuation", "Speed", "Waveform", "Muted"],
-    text: "This is a simple LFO that lets you manually select the waveform by pressing the button, with the LED color indicating the chosen shape: sine (yellow), triangle (pink), ramp down (cyan), ramp up (red), and square (white). You can adjust the CV output range using Shift + Fader. Shift + short press resets the waveform, while Shift + long press toggles between free-running and tempo-synced modes. Long press (no shift) mutes the output. In free-running mode, the speed ranges from 14 Hz down to one cycle per minute. In clocked mode, available resolutions include 16th, 8thT, 8th, 4thT, 4th, 2nd, note, half bar, and bar. The app parameters allow you to set the overall speed—Normal, Slow (÷2), and Slowest (÷4)—which also applies to clocked speeds. When clocked, the button flashes in sync with the LFO rate. The output can be configured to be either bipolar (-5V to +5V) or unipolar (0V to 10V) and this also affect where the attenuator will center when outputting MIDI CC, 0 when unipolar and 64 when bipolar. This app can also be configured to output MIDI CC in the parameters and MIDI channel and CC are freely configurable",
+    text: `LFO is a multi-shape oscillator with manually selectable waveforms. Press the button to cycle through shapes; the LED color shows the active waveform: sine (yellow), triangle (pink), ramp down (cyan), ramp up (red), square (white).
+
+#### Speed and range
+
+The fader sets the LFO rate. In free-running mode, speed ranges from 14 Hz down to one cycle per minute. **Shift + Fader** adjusts output attenuation, reducing the CV amplitude. The **Speed** parameter applies a global multiplier—Normal, Slow (÷2), Slowest (÷4)—that works in both free-running and clocked modes.
+
+#### Clocked mode
+
+**Shift + long press** toggles between free-running and tempo-synced modes. When clocked, the available resolutions are: 16th, 8thT, 8th, 4thT, 4th, 2nd, note, half bar, and bar. The button flashes in sync with the LFO rate. **Shift + short press** resets the LFO phase to zero. **Long press** (no shift) mutes the output.
+
+#### Grid Lock
+
+**Grid Lock only has an effect in clocked mode.** When enabled (default on), the LFO phase is continuously derived from the clock's absolute tick count. The phase is always correct relative to the clock grid regardless of when the LFO was started or reset. Changing the speed division re-aligns to the new grid automatically, but this can cause a click as the LFO jumps to its recalculated position.
+
+A **Shift + short press** offsets the phase reference to the current tick, drifting the LFO out of phase with the grid for creative offset effects. A clock reset re-locks to the grid.
+
+Disabling Grid Lock reverts to free-running phase accumulation: the LFO will smoothly speed up or slow down from its current position when the division changes, with no jump.
+
+#### Output
+
+The output range is configured in the parameters: bipolar (−5V to +5V) or unipolar (0V to 10V). This also sets the MIDI CC center—64 for bipolar, 0 for unipolar. MIDI channel and CC number are freely configurable.`,
     channels: [
       {
         jackTitle: "Output",
@@ -1033,6 +1054,7 @@ Output range can be unipolar (0–10V) or bipolar (-5V to +5V), and MIDI CC foll
       "Color",
       "NRPN",
       "Send MIDI",
+      "Grid Lock",
     ],
     storage: [
       "CV attenuation",
@@ -1044,7 +1066,32 @@ Output range can be unipolar (0–10V) or bipolar (-5V to +5V), and MIDI CC foll
       "Waveform",
       "Output Muted",
     ],
-    text: "This app is a variation of the simple LFO, adding an assignable CV input. The first channel processes the CV input, with the fader controlling its attenuation and the button acting as a mute. Use Shift + Button 1 to set the CV destination, indicated by the button color: speed (yellow), phase (pink), amplitude (cyan) or reset (red). Note that the speed CV is through 0, meaning that the waveform will invert and speed up again when the CV input is negative. When in 'reset' mode, the LFO resets when a rising edge passing the 1V threshold is detected. It is also worth knowing that even in reset mode this input is affected by the CV attenuation and 'mute' state allowing to change the rising edge detection level. As in the standard LFO, you can select the waveform by pressing the second button, with LED colors showing the shape: sine (yellow), triangle (pink), ramp down (cyan), ramp up (red), and square (white). Long press (no shift) on the output channel button mutes the LFO output. Adjust the CV output range using Shift + Fader. Shift + short press resets the waveform, while Shift + long press toggles between free-running and tempo-synced modes. Free-running speed ranges from 14 Hz to one cycle per minute; clocked mode offers resolutions like 16th, 8thT, 8th, 4thT, 4th, 2nd, note, half bar, and bar. App parameters let you set overall speed—Normal, Slow (÷2), or Slowest (÷4)—which also applies to clocked speeds. When clocked, the button flashes in sync with the LFO rate. Output can be bipolar (-5V to +5V) or unipolar (0V to 10V), affecting the attenuator's center when sending MIDI CC (0 for unipolar, 64 for bipolar). The app can also output MIDI CC, with freely configurable channel and CC number.",
+    text: `LFO+ extends the standard LFO with an assignable CV input on the first channel.
+
+#### CV input
+
+The fader attenuates the incoming CV; the button mutes it. Use **Shift + Button 1** to cycle through CV destinations, shown by the button color:
+
+- **Speed** (yellow) — modulates LFO rate through zero, so the waveform inverts and speeds up again with negative CV
+- **Phase** (pink) — modulates the LFO phase directly
+- **Amplitude** (cyan) — modulates output attenuation
+- **Reset** (red) — resets the LFO phase on a rising edge above 1V; attenuation and mute state affect the detection threshold
+
+#### Waveform and output
+
+Press **Button 2** to cycle through waveforms: sine (yellow), triangle (pink), ramp down (cyan), ramp up (red), square (white). **Shift + Fader 2** adjusts output attenuation. **Long press** (no shift) on Button 2 mutes the LFO output.
+
+#### Clocked mode
+
+**Shift + long press** on Button 2 toggles between free-running and tempo-synced modes. In clocked mode, available resolutions are: 16th, 8thT, 8th, 4thT, 4th, 2nd, note, half bar, and bar. The **Speed** parameter applies a global multiplier—Normal, Slow (÷2), Slowest (÷4)—in both modes. Output can be bipolar (−5V to +5V) or unipolar (0V to 10V), setting the MIDI CC center to 64 or 0 respectively.
+
+#### Grid Lock
+
+**Grid Lock only has an effect in clocked mode.** When enabled (default on), the LFO phase is continuously derived from the clock's absolute tick count, keeping it locked to the grid regardless of when the LFO was started. Changing the speed division re-aligns automatically, but this can cause a click as the LFO jumps to its recalculated position.
+
+A **Shift + short press** on Button 2, or a rising-edge gate when the CV input is in reset mode, offsets the phase reference to the current tick for deliberate phase-offset effects. A clock reset re-locks to the grid.
+
+Disabling Grid Lock reverts to free-running phase accumulation: the LFO will smoothly speed up or slow down from its current position when the division changes, with no jump.`,
     channels: [
       {
         jackTitle: "Input",

--- a/faderpunk/src/apps/lfo.rs
+++ b/faderpunk/src/apps/lfo.rs
@@ -152,7 +152,8 @@ pub async fn run(
     let glob_latch_layer = app.make_global(LatchLayer::Main);
     let glob_tick = app.make_global(false);
     let glob_quant_speed = app.make_global(0.07);
-    let glob_count = app.make_global(500);
+    let glob_count = app.make_global(20);
+    let glob_div = app.make_global(24u16);
 
     let curve = Curve::Exponential;
     let resolution = [384, 192, 96, 48, 24, 16, 12, 8, 6];
@@ -175,7 +176,8 @@ pub async fn run(
         glob_lfo_speed.set((curve.at(storage.query(|s| s.layer_speed)) as f32) * 0.015 + 0.0682);
 
         let div = resolution[((storage.query(|s| s.layer_speed)) as usize / 500).clamp(0, 8)];
-        glob_quant_speed.set(4095. / ((glob_count.get().max(1) as f32 * div as f32) / 24.));
+        glob_div.set(div);
+        glob_quant_speed.set(4096. / (glob_count.get().max(1) as f32 * div as f32));
     };
 
     update_speed().await;
@@ -351,9 +353,19 @@ pub async fn run(
         }
     };
     let fut5 = async {
+        let ticker = clk.get_ticker();
         loop {
-            match clk.wait_for_event(ClockDivision::_24).await {
+            match clk.wait_for_event(ClockDivision::_1).await {
                 ClockEvent::Tick => {
+                    if storage.query(|s| s.clocked) {
+                        let ticks_per_cycle =
+                            (glob_div.get() as u64).saturating_mul(speed_mult as u64);
+                        if ticks_per_cycle > 0 {
+                            let phase_in_cycle = (ticker() % ticks_per_cycle) as f32;
+                            glob_lfo_pos
+                                .set(phase_in_cycle * 4096.0 / ticks_per_cycle as f32);
+                        }
+                    }
                     glob_tick.set(true);
                 }
                 ClockEvent::Reset => {

--- a/faderpunk/src/apps/lfo.rs
+++ b/faderpunk/src/apps/lfo.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 pub const CHANNELS: usize = 1;
-pub const PARAMS: usize = 6;
+pub const PARAMS: usize = 7;
 
 pub static CONFIG: Config<PARAMS> =
     Config::new("LFO", "Multi shape LFO", Color::Yellow, AppIcon::Sine)
@@ -39,7 +39,8 @@ pub static CONFIG: Config<PARAMS> =
         })
         .add_param(Param::MidiCc { name: "MIDI CC" })
         .add_param(Param::MidiNrpn)
-        .add_param(Param::MidiOut);
+        .add_param(Param::MidiOut)
+        .add_param(Param::bool { name: "Grid Lock" });
 
 pub struct Params {
     speed_mult: usize,
@@ -48,10 +49,14 @@ pub struct Params {
     midi_channel: MidiChannel,
     midi_cc: MidiCc,
     nrpn: bool,
+    phase_lock: bool,
 }
 
 impl AppParams for Params {
     fn from_values(values: &[Value]) -> Option<Self> {
+        if values.len() < PARAMS {
+            return None;
+        }
         Some(Self {
             speed_mult: usize::from_value(values[0]),
             range: Range::from_value(values[1]),
@@ -59,6 +64,7 @@ impl AppParams for Params {
             midi_cc: MidiCc::from_value(values[3]),
             nrpn: bool::from_value(values[4]),
             midi_out: MidiOut::from_value(values[5]),
+            phase_lock: bool::from_value(values[6]),
         })
     }
 
@@ -70,6 +76,7 @@ impl AppParams for Params {
         vec.push(self.midi_cc.into()).unwrap();
         vec.push(Value::MidiNrpn(self.nrpn)).unwrap();
         vec.push(self.midi_out.into()).unwrap();
+        vec.push(self.phase_lock.into()).unwrap();
         vec
     }
 }
@@ -109,6 +116,7 @@ pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMut
             midi_channel: MidiChannel::default(),
             midi_cc: MidiCc::from(32u8.saturating_add(app.start_channel as u8)),
             nrpn: false,
+            phase_lock: true,
         },
     );
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
@@ -139,6 +147,7 @@ pub async fn run(
         params.query(|p| (p.range, p.midi_out, p.midi_channel, p.midi_cc, p.nrpn));
 
     let speed_mult = 2u32.pow(params.query(|p| p.speed_mult).min(31) as u32);
+    let phase_lock = params.query(|p| p.phase_lock);
     let output = app.make_out_jack(0, range).await;
     let fader = app.use_faders();
     let buttons = app.use_buttons();
@@ -229,7 +238,11 @@ pub async fn run(
             };
 
             let effective_val = if glob_muted.get() {
-                if range == Range::_Neg5_5V { 2047 } else { 0 }
+                if range == Range::_Neg5_5V {
+                    2047
+                } else {
+                    0
+                }
             } else {
                 val
             };
@@ -367,7 +380,7 @@ pub async fn run(
         loop {
             match clk.wait_for_event(ClockDivision::_1).await {
                 ClockEvent::Tick => {
-                    if storage.query(|s| s.clocked) {
+                    if storage.query(|s| s.clocked) && phase_lock {
                         let ticks_per_cycle =
                             (glob_div.get() as u64).saturating_mul(speed_mult as u64);
                         if ticks_per_cycle > 0 {

--- a/faderpunk/src/apps/lfo.rs
+++ b/faderpunk/src/apps/lfo.rs
@@ -144,6 +144,7 @@ pub async fn run(
     let buttons = app.use_buttons();
     let leds = app.use_leds();
     let mut clk = app.use_clock();
+    let ticker = clk.get_ticker();
 
     let midi = app.use_midi_output(midi_out, midi_chan, nrpn);
 
@@ -154,6 +155,9 @@ pub async fn run(
     let glob_quant_speed = app.make_global(0.07);
     let glob_count = app.make_global(20);
     let glob_div = app.make_global(24u16);
+    // Clock tick at which the LFO phase is considered zero. 0 = locked to the
+    // clock grid; set to the current tick on a manual reset to run out of phase.
+    let glob_phase_origin = app.make_global(0u64);
 
     let curve = Curve::Exponential;
     let resolution = [384, 192, 96, 48, 24, 16, 12, 8, 6];
@@ -176,7 +180,11 @@ pub async fn run(
         glob_lfo_speed.set((curve.at(storage.query(|s| s.layer_speed)) as f32) * 0.015 + 0.0682);
 
         let div = resolution[((storage.query(|s| s.layer_speed)) as usize / 500).clamp(0, 8)];
-        glob_div.set(div);
+        if div != glob_div.get() {
+            glob_div.set(div);
+            // Re-align to the clock grid whenever the musical division changes.
+            glob_phase_origin.set(0);
+        }
         glob_quant_speed.set(4096. / (glob_count.get().max(1) as f32 * div as f32));
     };
 
@@ -319,6 +327,9 @@ pub async fn run(
                     }
                 }
             } else {
+                // Offset the phase lock to the current tick so a clocked LFO can
+                // be pushed out of phase with the grid; also resets when free-running.
+                glob_phase_origin.set(ticker());
                 glob_lfo_pos.set(0.0);
             }
         }
@@ -353,7 +364,6 @@ pub async fn run(
         }
     };
     let fut5 = async {
-        let ticker = clk.get_ticker();
         loop {
             match clk.wait_for_event(ClockDivision::_1).await {
                 ClockEvent::Tick => {
@@ -361,14 +371,16 @@ pub async fn run(
                         let ticks_per_cycle =
                             (glob_div.get() as u64).saturating_mul(speed_mult as u64);
                         if ticks_per_cycle > 0 {
-                            let phase_in_cycle = (ticker() % ticks_per_cycle) as f32;
+                            let phase_in_cycle =
+                                ticker().wrapping_sub(glob_phase_origin.get()) % ticks_per_cycle;
                             glob_lfo_pos
-                                .set(phase_in_cycle * 4096.0 / ticks_per_cycle as f32);
+                                .set(phase_in_cycle as f32 * 4096.0 / ticks_per_cycle as f32);
                         }
                     }
                     glob_tick.set(true);
                 }
                 ClockEvent::Reset => {
+                    glob_phase_origin.set(0);
                     glob_lfo_pos.set(0.0);
                 }
                 _ => {}

--- a/faderpunk/src/apps/lfo_plus.rs
+++ b/faderpunk/src/apps/lfo_plus.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 pub const CHANNELS: usize = 2;
-pub const PARAMS: usize = 7;
+pub const PARAMS: usize = 8;
 
 pub static CONFIG: Config<PARAMS> = Config::new(
     "LFO+",
@@ -56,7 +56,8 @@ pub static CONFIG: Config<PARAMS> = Config::new(
     ],
 })
 .add_param(Param::MidiNrpn)
-.add_param(Param::MidiOut);
+.add_param(Param::MidiOut)
+.add_param(Param::bool { name: "Grid Lock" });
 
 pub struct Params {
     speed_mult: usize,
@@ -66,10 +67,14 @@ pub struct Params {
     midi_cc: MidiCc,
     color_in: Color,
     nrpn: bool,
+    phase_lock: bool,
 }
 
 impl AppParams for Params {
     fn from_values(values: &[Value]) -> Option<Self> {
+        if values.len() < PARAMS {
+            return None;
+        }
         Some(Self {
             speed_mult: usize::from_value(values[0]),
             range: Range::from_value(values[1]),
@@ -78,6 +83,7 @@ impl AppParams for Params {
             color_in: Color::from_value(values[4]),
             nrpn: bool::from_value(values[5]),
             midi_out: MidiOut::from_value(values[6]),
+            phase_lock: bool::from_value(values[7]),
         })
     }
 
@@ -90,6 +96,7 @@ impl AppParams for Params {
         vec.push(self.color_in.into()).unwrap();
         vec.push(Value::MidiNrpn(self.nrpn)).unwrap();
         vec.push(self.midi_out.into()).unwrap();
+        vec.push(self.phase_lock.into()).unwrap();
         vec
     }
 }
@@ -136,6 +143,7 @@ pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMut
             midi_cc: MidiCc::from(32u8.saturating_add(app.start_channel as u8)),
             color_in: Color::Blue,
             nrpn: false,
+            phase_lock: true,
         },
     );
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
@@ -174,6 +182,7 @@ pub async fn run(
     });
 
     let speed_mult = 2u32.pow(params.query(|p| p.speed_mult).min(31) as u32);
+    let phase_lock = params.query(|p| p.phase_lock);
 
     let input = app.make_in_jack(0, Range::_Neg5_5V).await;
 
@@ -313,7 +322,11 @@ pub async fn run(
 
             let out_muted = glob_out_muted.get();
             let effective_val = if out_muted {
-                if range.is_bipolar() { 2047 } else { 0 }
+                if range.is_bipolar() {
+                    2047
+                } else {
+                    0
+                }
             } else {
                 val
             };
@@ -506,7 +519,7 @@ pub async fn run(
         loop {
             match clk.wait_for_event(ClockDivision::_1).await {
                 ClockEvent::Tick => {
-                    if storage.query(|s| s.clocked) {
+                    if storage.query(|s| s.clocked) && phase_lock {
                         let ticks_per_cycle =
                             (glob_div.get() as u64).saturating_mul(speed_mult as u64);
                         if ticks_per_cycle > 0 {

--- a/faderpunk/src/apps/lfo_plus.rs
+++ b/faderpunk/src/apps/lfo_plus.rs
@@ -182,6 +182,7 @@ pub async fn run(
     let buttons = app.use_buttons();
     let leds = app.use_leds();
     let mut clk = app.use_clock();
+    let ticker = clk.get_ticker();
 
     let midi = app.use_midi_output(midi_out, midi_chan, nrpn);
 
@@ -192,6 +193,9 @@ pub async fn run(
     let glob_div = app.make_global(24u16);
     let glob_quant_speed = app.make_global(0.07);
     let glob_count = app.make_global(20);
+    // Clock tick at which the LFO phase is considered zero. 0 = locked to the
+    // clock grid; set to the current tick on a manual/CV reset to run out of phase.
+    let glob_phase_origin = app.make_global(0u64);
 
     let curve = Curve::Exponential;
     let resolution = [384, 192, 96, 48, 24, 16, 12, 8, 6];
@@ -229,7 +233,11 @@ pub async fn run(
 
         let index_val = sum.saturating_sub(2047).min(4095) as usize / 500;
         let div = resolution[index_val.clamp(0, 8)];
-        glob_div.set(div);
+        if div != glob_div.get() {
+            glob_div.set(div);
+            // Re-align to the clock grid whenever the musical division changes.
+            glob_phase_origin.set(0);
+        }
         glob_quant_speed.set(4096. / (glob_count.get().max(1) as f32 * div as f32));
     };
 
@@ -250,6 +258,7 @@ pub async fn run(
 
             if destination == 3 {
                 if in_val >= 2458 && oldinputval < 2458 {
+                    glob_phase_origin.set(ticker());
                     glob_lfo_pos.set(0.0);
                 }
                 oldinputval = in_val;
@@ -455,6 +464,9 @@ pub async fn run(
                     });
                 }
                 if chan == 1 {
+                    // Offset the phase lock to the current tick so a clocked LFO
+                    // can be pushed out of phase; also resets when free-running.
+                    glob_phase_origin.set(ticker());
                     glob_lfo_pos.set(0.0);
                 }
             }
@@ -491,7 +503,6 @@ pub async fn run(
         }
     };
     let clock_handler = async {
-        let ticker = clk.get_ticker();
         loop {
             match clk.wait_for_event(ClockDivision::_1).await {
                 ClockEvent::Tick => {
@@ -499,14 +510,16 @@ pub async fn run(
                         let ticks_per_cycle =
                             (glob_div.get() as u64).saturating_mul(speed_mult as u64);
                         if ticks_per_cycle > 0 {
-                            let phase_in_cycle = (ticker() % ticks_per_cycle) as f32;
+                            let phase_in_cycle =
+                                ticker().wrapping_sub(glob_phase_origin.get()) % ticks_per_cycle;
                             glob_lfo_pos
-                                .set(phase_in_cycle * 4096.0 / ticks_per_cycle as f32);
+                                .set(phase_in_cycle as f32 * 4096.0 / ticks_per_cycle as f32);
                         }
                     }
                     glob_tick.set(true);
                 }
                 ClockEvent::Reset => {
+                    glob_phase_origin.set(0);
                     glob_lfo_pos.set(0.0);
                 }
                 _ => {}

--- a/faderpunk/src/apps/lfo_plus.rs
+++ b/faderpunk/src/apps/lfo_plus.rs
@@ -189,9 +189,9 @@ pub async fn run(
     let glob_lfo_pos = app.make_global(0.0);
     let glob_latch_layer = app.make_global(LatchLayer::Main);
     let glob_tick = app.make_global(false);
-    let glob_div = app.make_global(24);
+    let glob_div = app.make_global(24u16);
     let glob_quant_speed = app.make_global(0.07);
-    let glob_count = app.make_global(1);
+    let glob_count = app.make_global(20);
 
     let curve = Curve::Exponential;
     let resolution = [384, 192, 96, 48, 24, 16, 12, 8, 6];
@@ -229,7 +229,8 @@ pub async fn run(
 
         let index_val = sum.saturating_sub(2047).min(4095) as usize / 500;
         let div = resolution[index_val.clamp(0, 8)];
-        glob_quant_speed.set(4095. / ((glob_count.get().max(1) as f32 * div as f32) / 24.));
+        glob_div.set(div);
+        glob_quant_speed.set(4096. / (glob_count.get().max(1) as f32 * div as f32));
     };
 
     let fut1 = async {
@@ -490,9 +491,19 @@ pub async fn run(
         }
     };
     let clock_handler = async {
+        let ticker = clk.get_ticker();
         loop {
-            match clk.wait_for_event(ClockDivision::_24).await {
+            match clk.wait_for_event(ClockDivision::_1).await {
                 ClockEvent::Tick => {
+                    if storage.query(|s| s.clocked) {
+                        let ticks_per_cycle =
+                            (glob_div.get() as u64).saturating_mul(speed_mult as u64);
+                        if ticks_per_cycle > 0 {
+                            let phase_in_cycle = (ticker() % ticks_per_cycle) as f32;
+                            glob_lfo_pos
+                                .set(phase_in_cycle * 4096.0 / ticks_per_cycle as f32);
+                        }
+                    }
                     glob_tick.set(true);
                 }
                 ClockEvent::Reset => {

--- a/gen-bindings/Cargo.lock
+++ b/gen-bindings/Cargo.lock
@@ -323,7 +323,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libfp"
-version = "0.10.2"
+version = "0.10.3-beta.0"
 dependencies = [
  "embassy-time",
  "enum-ordinalize",


### PR DESCRIPTION
## Summary

- Recompute LFO phase from the clock ticker each tick when the app is in clocked mode, so the LFO stays phase-locked to the master clock instead of free-running between ticks.
- Switches the clock subscription from `_24` to `_1` for tick-accurate phase updates.
- Tweaks `glob_quant_speed` math (no division by 24) and default `glob_count` so unclocked timing matches the new units.
- Phase-lock relative to a **phase origin** tick (`glob_phase_origin`) instead of absolute zero, so the manual reset and LFO+ reset input keep working in clocked mode:
  - default (`origin = 0`) → locked to the clock grid / transport downbeat
  - manual reset (shift + short press) / LFO+ reset input → `origin = ticker()` → phase 0 now, then stays locked **out of phase** with the grid
  - division change via the speed control → `origin = 0` → snaps back **in phase** with the grid
  - clock `Reset` event (transport restart) → `origin = 0`
- This keeps the manual reset consistent between clocked and free-running modes and preserves the utility of LFO+'s reset input mode.

## Test plan

- [ ] On hardware, load LFO and LFO+ on a channel; enable clocked mode.
- [ ] Confirm LFO phase stays locked to incoming clock (no drift over time).
- [ ] Manual reset (shift + short press) while clocked: LFO jumps to phase 0 and stays out of phase with the grid (does not snap back next tick).
- [ ] Change the speed/division while clocked: LFO snaps back in phase with the grid.
- [ ] LFO+ with reset input (dest 3): a rising edge resets phase and holds the offset, same as the manual reset.
- [ ] Toggle clocked off; confirm free-running LFO speed is sensible across the speed fader range and manual reset still resets phase.
- [ ] Verify resolution switching (B2+F3) still adjusts cycle length as expected.
