### PR TITLE
fix: CC 127 unreachable and NRPN gating resolution in LFO/RND apps

### DIFF
--- a/faderpunk/src/apps/automator.rs
+++ b/faderpunk/src/apps/automator.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use libfp::{
     ext::FromValue,
     latch::LatchLayer,
-    utils::{attenuate, attenuate_bipolar, interp_loop_sample, scale_bits_12_7, slew_2, split_unsigned_value},
+    utils::{attenuate, attenuate_bipolar, interp_loop_sample, midi_gate, slew_2, split_unsigned_value},
     AppIcon, Brightness, ClockDivision, Color, Config, MidiCc, MidiChannel, MidiOut, Param, Range,
     Value, APP_MAX_PARAMS,
 };
@@ -566,7 +566,7 @@ pub async fn run(
                 | LooperState::PendingRecording
                 | LooperState::Recording => {
                     let fader_val = fader.get_value();
-                    let midi_val = if nrpn { fader_val as u32 } else { scale_bits_12_7(fader_val).as_int() as u32 };
+                    let midi_val = midi_gate(fader_val, nrpn) as u32;
                     if last_midi_scaled != midi_val {
                         midi.send_cc(midi_cc, fader_val).await;
                         last_midi_scaled = midi_val;
@@ -594,7 +594,7 @@ pub async fn run(
                     } else {
                         loop_target_glob.get()
                     };
-                    let midi_val = if nrpn { interp as u32 } else { scale_bits_12_7(interp).as_int() as u32 };
+                    let midi_val = midi_gate(interp, nrpn) as u32;
                     if last_midi_scaled != midi_val {
                         midi.send_cc(midi_cc, interp).await;
                         last_midi_scaled = midi_val;

--- a/faderpunk/src/apps/automator.rs
+++ b/faderpunk/src/apps/automator.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use libfp::{
     ext::FromValue,
     latch::LatchLayer,
-    utils::{attenuate, attenuate_bipolar, interp_loop_sample, slew_2, split_unsigned_value},
+    utils::{attenuate, attenuate_bipolar, interp_loop_sample, scale_bits_12_7, slew_2, split_unsigned_value},
     AppIcon, Brightness, ClockDivision, Color, Config, MidiCc, MidiChannel, MidiOut, Param, Range,
     Value, APP_MAX_PARAMS,
 };
@@ -566,7 +566,7 @@ pub async fn run(
                 | LooperState::PendingRecording
                 | LooperState::Recording => {
                     let fader_val = fader.get_value();
-                    let midi_val = if nrpn { fader_val as u32 } else { (fader_val as u32 * 127) / 4095 };
+                    let midi_val = if nrpn { fader_val as u32 } else { scale_bits_12_7(fader_val).as_int() as u32 };
                     if last_midi_scaled != midi_val {
                         midi.send_cc(midi_cc, fader_val).await;
                         last_midi_scaled = midi_val;
@@ -594,7 +594,7 @@ pub async fn run(
                     } else {
                         loop_target_glob.get()
                     };
-                    let midi_val = if nrpn { interp as u32 } else { (interp as u32 * 127) / 4095 };
+                    let midi_val = if nrpn { interp as u32 } else { scale_bits_12_7(interp).as_int() as u32 };
                     if last_midi_scaled != midi_val {
                         midi.send_cc(midi_cc, interp).await;
                         last_midi_scaled = midi_val;

--- a/faderpunk/src/apps/control.rs
+++ b/faderpunk/src/apps/control.rs
@@ -7,7 +7,7 @@ use heapless::Vec;
 use libfp::{
     ext::FromValue,
     latch::LatchLayer,
-    utils::{attenuate, attenuate_bipolar, clickless, scale_bits_12_7, slew_2, split_unsigned_value},
+    utils::{attenuate, attenuate_bipolar, clickless, midi_gate, slew_2, split_unsigned_value},
     AppIcon, Brightness, Color, MidiCc, MidiChannel, MidiOut, APP_MAX_PARAMS,
 };
 use serde::{Deserialize, Serialize};
@@ -338,11 +338,7 @@ pub async fn run(
             } else {
                 attenuate_bipolar(main_layer_value, att_layer_value)
             };
-            let midi_val = if nrpn {
-                midi_out as u32
-            } else {
-                scale_bits_12_7(midi_out).as_int() as u32
-            };
+            let midi_val = midi_gate(midi_out, nrpn) as u32;
             if last_midi != midi_val {
                 midi.send_cc(midi_cc, midi_out).await;
                 last_midi = midi_val;

--- a/faderpunk/src/apps/control.rs
+++ b/faderpunk/src/apps/control.rs
@@ -7,7 +7,7 @@ use heapless::Vec;
 use libfp::{
     ext::FromValue,
     latch::LatchLayer,
-    utils::{attenuate, attenuate_bipolar, clickless, slew_2, split_unsigned_value},
+    utils::{attenuate, attenuate_bipolar, clickless, scale_bits_12_7, slew_2, split_unsigned_value},
     AppIcon, Brightness, Color, MidiCc, MidiChannel, MidiOut, APP_MAX_PARAMS,
 };
 use serde::{Deserialize, Serialize};
@@ -255,7 +255,7 @@ pub async fn run(
         let mut main_layer_value = fader.get_value();
         let mut fad_val = 0;
         let mut out: u16 = 0;
-        let mut last_midi = 0u32;
+        let mut last_midi = u32::MAX;
         let mut last_i2c = 0u16;
 
         loop {
@@ -341,7 +341,7 @@ pub async fn run(
             let midi_val = if nrpn {
                 midi_out as u32
             } else {
-                (midi_out as u32 * 127) / 4095
+                scale_bits_12_7(midi_out).as_int() as u32
             };
             if last_midi != midi_val {
                 midi.send_cc(midi_cc, midi_out).await;

--- a/faderpunk/src/apps/cv2midi.rs
+++ b/faderpunk/src/apps/cv2midi.rs
@@ -6,7 +6,7 @@ use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use heapless::Vec;
 use libfp::{
     latch::LatchLayer,
-    utils::{attenuate, attenuate_bipolar, scale_bits_12_7, split_unsigned_value},
+    utils::{attenuate, attenuate_bipolar, midi_gate, split_unsigned_value},
     AppIcon, Brightness, Color, MidiCc, MidiChannel, MidiOut, APP_MAX_PARAMS,
 };
 use serde::{Deserialize, Serialize};
@@ -220,10 +220,10 @@ pub async fn run(
             }
 
             if midi_out.is_some() {
-                let midi_gate = if nrpn { input_val } else { scale_bits_12_7(input_val).as_int() as u16 };
-                if midi_gate != old_midi {
+                let gate_val = midi_gate(input_val, nrpn);
+                if gate_val != old_midi {
                     midi.send_cc(midi_cc, input_val).await;
-                    old_midi = midi_gate;
+                    old_midi = gate_val;
                 }
             }
         }

--- a/faderpunk/src/apps/cv2midi.rs
+++ b/faderpunk/src/apps/cv2midi.rs
@@ -6,7 +6,7 @@ use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use heapless::Vec;
 use libfp::{
     latch::LatchLayer,
-    utils::{attenuate, attenuate_bipolar, split_unsigned_value},
+    utils::{attenuate, attenuate_bipolar, scale_bits_12_7, split_unsigned_value},
     AppIcon, Brightness, Color, MidiCc, MidiChannel, MidiOut, APP_MAX_PARAMS,
 };
 use serde::{Deserialize, Serialize};
@@ -175,7 +175,7 @@ pub async fn run(
     let input = app.make_in_jack(0, range).await;
 
     let fut1 = async {
-        let mut old_midi = 0;
+        let mut old_midi: u16 = u16::MAX;
 
         loop {
             app.delay_millis(1).await;
@@ -219,9 +219,12 @@ pub async fn run(
                 );
             }
 
-            if old_midi != input_val / 32 {
-                midi.send_cc(midi_cc, input_val).await;
-                old_midi = input_val / 32;
+            if midi_out.is_some() {
+                let midi_gate = if nrpn { input_val } else { scale_bits_12_7(input_val).as_int() as u16 };
+                if midi_gate != old_midi {
+                    midi.send_cc(midi_cc, input_val).await;
+                    old_midi = midi_gate;
+                }
             }
         }
     };

--- a/faderpunk/src/apps/lfo.rs
+++ b/faderpunk/src/apps/lfo.rs
@@ -4,7 +4,6 @@ use embassy_futures::{
 };
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use heapless::Vec;
-use midly::num::u7;
 use serde::{Deserialize, Serialize};
 
 use libfp::{
@@ -183,7 +182,7 @@ pub async fn run(
     }
 
     let mut count = 0;
-    let mut last_cc = u7::new(0);
+    let mut last_val: u16 = u16::MAX;
 
     let update_speed = async || {
         glob_lfo_speed.set((curve.at(storage.query(|s| s.layer_speed)) as f32) * 0.015 + 0.0682);
@@ -248,10 +247,10 @@ pub async fn run(
             };
             output.set_value(effective_val);
             if midi_out.is_some() {
-                let cc = scale_bits_12_7(effective_val);
-                if cc != last_cc {
+                let gate_val = if nrpn { effective_val } else { scale_bits_12_7(effective_val).as_int() as u16 };
+                if gate_val != last_val {
                     midi.send_cc(midi_cc, effective_val).await;
-                    last_cc = cc;
+                    last_val = gate_val;
                 }
             }
 

--- a/faderpunk/src/apps/lfo.rs
+++ b/faderpunk/src/apps/lfo.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use libfp::{
     ext::FromValue,
     latch::LatchLayer,
-    utils::{attenuate, attenuate_bipolar, scale_bits_12_7, split_unsigned_value},
+    utils::{attenuate, attenuate_bipolar, midi_gate, split_unsigned_value},
     AppIcon, Brightness, ClockDivision, Color, Config, Curve, MidiCc, MidiChannel, MidiOut, Param,
     Range, Value, Waveform, APP_MAX_PARAMS,
 };
@@ -247,7 +247,7 @@ pub async fn run(
             };
             output.set_value(effective_val);
             if midi_out.is_some() {
-                let gate_val = if nrpn { effective_val } else { scale_bits_12_7(effective_val).as_int() as u16 };
+                let gate_val = midi_gate(effective_val, nrpn);
                 if gate_val != last_val {
                     midi.send_cc(midi_cc, effective_val).await;
                     last_val = gate_val;

--- a/faderpunk/src/apps/lfo_plus.rs
+++ b/faderpunk/src/apps/lfo_plus.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use libfp::{
     ext::FromValue,
     latch::LatchLayer,
-    utils::{attenuate, attenuate_bipolar, scale_bits_12_7, split_unsigned_value},
+    utils::{attenuate, attenuate_bipolar, midi_gate, split_unsigned_value},
     AppIcon, Brightness, ClockDivision, Color, Config, Curve, MidiCc, MidiChannel, MidiOut, Param,
     Range, Value, Waveform, APP_MAX_PARAMS,
 };
@@ -331,7 +331,7 @@ pub async fn run(
             };
             output.set_value(effective_val);
             if midi_out.is_some() {
-                let gate_val = if nrpn { effective_val } else { scale_bits_12_7(effective_val).as_int() as u16 };
+                let gate_val = midi_gate(effective_val, nrpn);
                 if gate_val != last_val {
                     midi.send_cc(midi_cc, effective_val).await;
                     last_val = gate_val;

--- a/faderpunk/src/apps/lfo_plus.rs
+++ b/faderpunk/src/apps/lfo_plus.rs
@@ -4,7 +4,6 @@ use embassy_futures::{
 };
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use heapless::Vec;
-use midly::num::u7;
 use serde::{Deserialize, Serialize};
 
 use libfp::{
@@ -224,7 +223,7 @@ pub async fn run(
     glob_div.set(resolution[(speed as usize / 500).clamp(0, 8)]);
     let mut count = 0;
 
-    let mut last_cc = u7::new(0);
+    let mut last_val: u16 = u16::MAX;
 
     if storage.query(|s| s.in_mute) {
         leds.unset(0, Led::Button);
@@ -332,10 +331,10 @@ pub async fn run(
             };
             output.set_value(effective_val);
             if midi_out.is_some() {
-                let cc = scale_bits_12_7(effective_val);
-                if cc != last_cc {
+                let gate_val = if nrpn { effective_val } else { scale_bits_12_7(effective_val).as_int() as u16 };
+                if gate_val != last_val {
                     midi.send_cc(midi_cc, effective_val).await;
-                    last_cc = cc;
+                    last_val = gate_val;
                 }
             }
 

--- a/faderpunk/src/apps/panner.rs
+++ b/faderpunk/src/apps/panner.rs
@@ -7,7 +7,7 @@ use heapless::Vec;
 use libfp::{
     ext::FromValue,
     latch::LatchLayer,
-    utils::{attenuate_bipolar, clickless, slew_2, split_unsigned_value},
+    utils::{attenuate_bipolar, clickless, scale_bits_12_7, slew_2, split_unsigned_value},
     AppIcon, Brightness, Color, MidiCc, MidiChannel, MidiOut, Waveform, APP_MAX_PARAMS,
 };
 
@@ -248,7 +248,7 @@ pub async fn run(
         let mut main_layer_value = faders.get_value_at(0);
         let mut out_r = 0;
         let mut out_l = 0;
-        let mut last_out = [0, 0];
+        let mut last_out: [u16; 2] = [u16::MAX, u16::MAX];
 
         let mut val_left = 0;
         let mut val_right = 0;
@@ -368,22 +368,22 @@ pub async fn run(
             out_l = slew_2(out_l, out_left, 3, 4);
             out_r = slew_2(out_r, out_right, 3, 4);
 
-            // MIDI output if changed
-            let scaled_out = (out_l as u32 * 127) / 4095;
-            if last_out[0] != scaled_out {
-                midi.send_cc(midi_cc_l, out_l).await;
-            }
-            let scaled_out = (out_r as u32 * 127) / 4095;
-            if last_out[1] != scaled_out {
-                midi.send_cc(midi_cc_r, out_r).await;
-            }
-
             // Output to jacks
             jacks[0].set_value(out_l);
             jacks[1].set_value(out_r);
 
-            last_out[0] = (out_l as u32 * 127) / 4095;
-            last_out[1] = (out_r as u32 * 127) / 4095;
+            if midi_out.is_some() {
+                let gate_l = if nrpn { out_l } else { scale_bits_12_7(out_l).as_int() as u16 };
+                if last_out[0] != gate_l {
+                    midi.send_cc(midi_cc_l, out_l).await;
+                    last_out[0] = gate_l;
+                }
+                let gate_r = if nrpn { out_r } else { scale_bits_12_7(out_r).as_int() as u16 };
+                if last_out[1] != gate_r {
+                    midi.send_cc(midi_cc_r, out_r).await;
+                    last_out[1] = gate_r;
+                }
+            }
 
             // Update LEDs
             match latch_active_layer {

--- a/faderpunk/src/apps/panner.rs
+++ b/faderpunk/src/apps/panner.rs
@@ -7,7 +7,7 @@ use heapless::Vec;
 use libfp::{
     ext::FromValue,
     latch::LatchLayer,
-    utils::{attenuate_bipolar, clickless, scale_bits_12_7, slew_2, split_unsigned_value},
+    utils::{attenuate_bipolar, clickless, midi_gate, slew_2, split_unsigned_value},
     AppIcon, Brightness, Color, MidiCc, MidiChannel, MidiOut, Waveform, APP_MAX_PARAMS,
 };
 
@@ -373,12 +373,12 @@ pub async fn run(
             jacks[1].set_value(out_r);
 
             if midi_out.is_some() {
-                let gate_l = if nrpn { out_l } else { scale_bits_12_7(out_l).as_int() as u16 };
+                let gate_l = midi_gate(out_l, nrpn);
                 if last_out[0] != gate_l {
                     midi.send_cc(midi_cc_l, out_l).await;
                     last_out[0] = gate_l;
                 }
-                let gate_r = if nrpn { out_r } else { scale_bits_12_7(out_r).as_int() as u16 };
+                let gate_r = midi_gate(out_r, nrpn);
                 if last_out[1] != gate_r {
                     midi.send_cc(midi_cc_r, out_r).await;
                     last_out[1] = gate_r;

--- a/faderpunk/src/apps/rnd.rs
+++ b/faderpunk/src/apps/rnd.rs
@@ -8,7 +8,6 @@ use embassy_futures::{
 };
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use heapless::Vec;
-use midly::num::u7;
 use serde::{Deserialize, Serialize};
 
 use crate::app::{
@@ -313,7 +312,7 @@ pub async fn run(
 
     let timed_loop = async {
         let mut out: u16 = 0;
-        let mut last_cc = u7::new(0);
+        let mut last_val: u16 = u16::MAX;
         let mut count: u32 = 0;
         loop {
             app.delay_millis(1).await;
@@ -350,10 +349,10 @@ pub async fn run(
 
             output.set_value(out);
 
-            let cc = scale_bits_12_7(out);
-            if cc != last_cc {
+            let gate_val = if nrpn { out } else { scale_bits_12_7(out).as_int() as u16 };
+            if gate_val != last_val {
                 midi.send_cc(midi_cc, out).await;
-                last_cc = cc;
+                last_val = gate_val;
             }
 
             if latch_active_layer == LatchLayer::Main {

--- a/faderpunk/src/apps/rnd.rs
+++ b/faderpunk/src/apps/rnd.rs
@@ -349,10 +349,12 @@ pub async fn run(
 
             output.set_value(out);
 
-            let gate_val = if nrpn { out } else { scale_bits_12_7(out).as_int() as u16 };
-            if gate_val != last_val {
-                midi.send_cc(midi_cc, out).await;
-                last_val = gate_val;
+            if midi_out.is_some() {
+                let gate_val = if nrpn { out } else { scale_bits_12_7(out).as_int() as u16 };
+                if gate_val != last_val {
+                    midi.send_cc(midi_cc, out).await;
+                    last_val = gate_val;
+                }
             }
 
             if latch_active_layer == LatchLayer::Main {

--- a/faderpunk/src/apps/rnd.rs
+++ b/faderpunk/src/apps/rnd.rs
@@ -17,7 +17,7 @@ use crate::app::{
 use libfp::{
     ext::FromValue,
     latch::LatchLayer,
-    utils::{attenuate, attenuate_bipolar, scale_bits_12_7, slew_2, split_unsigned_value},
+    utils::{attenuate, attenuate_bipolar, midi_gate, slew_2, split_unsigned_value},
     AppIcon, Brightness, ClockDivision, Color, Config, Curve, MidiCc, MidiChannel, MidiOut, Param,
     Range, Value, APP_MAX_PARAMS,
 };
@@ -350,7 +350,7 @@ pub async fn run(
             output.set_value(out);
 
             if midi_out.is_some() {
-                let gate_val = if nrpn { out } else { scale_bits_12_7(out).as_int() as u16 };
+                let gate_val = midi_gate(out, nrpn);
                 if gate_val != last_val {
                     midi.send_cc(midi_cc, out).await;
                     last_val = gate_val;

--- a/faderpunk/src/apps/rnd_plus.rs
+++ b/faderpunk/src/apps/rnd_plus.rs
@@ -4,7 +4,6 @@ use embassy_futures::{
 };
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use heapless::Vec;
-use midly::num::u7;
 use serde::{Deserialize, Serialize};
 
 use crate::app::{
@@ -388,7 +387,7 @@ pub async fn run(
 
     let timed_loop = async {
         let mut out: u16 = 0;
-        let mut last_cc = u7::new(0);
+        let mut last_val: u16 = u16::MAX;
         let mut count: u32 = 0;
         let mut oldinputval = 0;
         loop {
@@ -461,10 +460,10 @@ pub async fn run(
 
             output.set_value(out);
 
-            let cc = scale_bits_12_7(out);
-            if cc != last_cc {
+            let gate_val = if nrpn { out } else { scale_bits_12_7(out).as_int() as u16 };
+            if gate_val != last_val {
                 midi.send_cc(midi_cc, out).await;
-                last_cc = cc;
+                last_val = gate_val;
             }
 
             if latch_active_layer == LatchLayer::Main {

--- a/faderpunk/src/apps/rnd_plus.rs
+++ b/faderpunk/src/apps/rnd_plus.rs
@@ -13,7 +13,7 @@ use crate::app::{
 use libfp::{
     ext::FromValue,
     latch::LatchLayer,
-    utils::{attenuate, attenuate_bipolar, scale_bits_12_7, slew_2, split_unsigned_value},
+    utils::{attenuate, attenuate_bipolar, midi_gate, slew_2, split_unsigned_value},
     AppIcon, Brightness, ClockDivision, Color, Config, Curve, MidiCc, MidiChannel, MidiOut, Param,
     Range, Value, APP_MAX_PARAMS,
 };
@@ -461,7 +461,7 @@ pub async fn run(
             output.set_value(out);
 
             if midi_out.is_some() {
-                let gate_val = if nrpn { out } else { scale_bits_12_7(out).as_int() as u16 };
+                let gate_val = midi_gate(out, nrpn);
                 if gate_val != last_val {
                     midi.send_cc(midi_cc, out).await;
                     last_val = gate_val;

--- a/faderpunk/src/apps/rnd_plus.rs
+++ b/faderpunk/src/apps/rnd_plus.rs
@@ -460,10 +460,12 @@ pub async fn run(
 
             output.set_value(out);
 
-            let gate_val = if nrpn { out } else { scale_bits_12_7(out).as_int() as u16 };
-            if gate_val != last_val {
-                midi.send_cc(midi_cc, out).await;
-                last_val = gate_val;
+            if midi_out.is_some() {
+                let gate_val = if nrpn { out } else { scale_bits_12_7(out).as_int() as u16 };
+                if gate_val != last_val {
+                    midi.send_cc(midi_cc, out).await;
+                    last_val = gate_val;
+                }
             }
 
             if latch_active_layer == LatchLayer::Main {

--- a/libfp/src/utils.rs
+++ b/libfp/src/utils.rs
@@ -8,9 +8,11 @@ pub const fn bpm_to_clock_duration(bpm: f32, ppqn: u8) -> Duration {
     Duration::from_nanos((1_000_000_000.0 / (bpm as f64 / 60.0 * ppqn as f64)) as u64)
 }
 
-/// Scale from 4095 u16 to 127 u7
+/// Scale a 12-bit value (0..=4095) to a 7-bit MIDI value (0..=127).
+/// Uses integer division by 32 (4096/128) so each CC step covers exactly
+/// 32 input values and CC 127 is reachable for any input >= 4064.
 pub fn scale_bits_12_7(value: u16) -> u7 {
-    u7::new(((value as u32 * 127) / 4095) as u8)
+    u7::new((value / 32) as u8)
 }
 
 /// Scale from 4095 u16 to 255 u8
@@ -296,6 +298,15 @@ pub fn interp_loop_sample(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn scale_bits_12_7_full_range() {
+        assert_eq!(scale_bits_12_7(0).as_int(), 0);
+        assert_eq!(scale_bits_12_7(2048).as_int(), 64);
+        assert_eq!(scale_bits_12_7(4063).as_int(), 126);
+        assert_eq!(scale_bits_12_7(4064).as_int(), 127);
+        assert_eq!(scale_bits_12_7(4095).as_int(), 127);
+    }
 
     #[test]
     fn scale_to_12bit_full_window() {

--- a/libfp/src/utils.rs
+++ b/libfp/src/utils.rs
@@ -15,6 +15,16 @@ pub fn scale_bits_12_7(value: u16) -> u7 {
     u7::new((value / 32) as u8)
 }
 
+/// Resolution at which a 12-bit value should be de-duplicated before
+/// emitting MIDI: full 12-bit in NRPN mode, 7-bit-quantized in CC mode.
+pub fn midi_gate(value: u16, nrpn: bool) -> u16 {
+    if nrpn {
+        value
+    } else {
+        scale_bits_12_7(value).as_int() as u16
+    }
+}
+
 /// Scale from 4095 u16 to 255 u8
 pub fn scale_bits_12_8(value: u16) -> u8 {
     ((value as u32 * 255) / 4095) as u8


### PR DESCRIPTION
## Summary

- `scale_bits_12_7` used `(value * 127) / 4095`, which only maps the single input `4095` to CC 127 — values 4063–4094 all produced CC 126. Changed to `value / 32` (4096/128 = 32 exactly) so CC 127 covers inputs 4064–4095. This also fixes the Saw waveform whose table max is 4094 and could never reach CC 127 at all.
- In NRPN mode, the dedup gate in all four apps (`lfo`, `lfo_plus`, `rnd`, `rnd_plus`) was comparing a 7-bit-quantized value, discarding 7 bits of NRPN resolution. Gate now compares raw 12-bit values in NRPN mode and 7-bit-quantized values in CC mode.
- Added unit tests for `scale_bits_12_7` covering 0, midpoint, boundary around 127, and max.

## Test checklist

- [ ] LFO (all waveforms): sweep to max attenuation, confirm CC 127 is reached and held for a meaningful window at the peak
- [ ] LFO Saw waveform specifically: confirm CC 127 is now reached (it never was before)
- [ ] LFO NRPN mode: enable NRPN, sweep — confirm smooth 14-bit changes visible in a MIDI monitor, no coarse 7-bit stepping
- [ ] RND / RND+ CC mode: confirm random values reach CC 127
- [ ] RND NRPN mode: confirm individual random steps are transmitted without 7-bit gating