### PR TITLE
fix(clock): auto-start from MIDI ticks when Start is dropped on USB resume

### DIFF
--- a/faderpunk/src/tasks/clock.rs
+++ b/faderpunk/src/tasks/clock.rs
@@ -468,6 +468,10 @@ async fn run_unified_clock_engine() {
     // to straight passthrough (not predicted — e.g. swing was 0 or there
     // was no measured period at the anchor). Cleared at window rollover.
     let mut window_predicted = false;
+    // Counts consecutive MIDI clock ticks received while not running.
+    // Used to synthesize an implicit Start when the Start message was dropped
+    // (e.g. during USB device resume after host-side suspension).
+    let mut ticks_while_stopped: u8 = 0;
     let mut config = config;
 
     // If clock was already running at startup (persisted state) with internal source,
@@ -605,6 +609,8 @@ async fn run_unified_clock_engine() {
                     if event.source() != config.clock.clock_src {
                         continue;
                     }
+                    // Any explicit transport event resets the implicit-start counter.
+                    ticks_while_stopped = 0;
                     clock_in_sender.send(event).await;
                     match event {
                         ClockInEvent::Start(_) => {
@@ -654,6 +660,24 @@ async fn run_unified_clock_engine() {
                             if timestamp.duration_since(last) < DEBOUNCE_THRESHOLD {
                                 continue;
                             }
+                        }
+                    }
+
+                    // Auto-start recovery: if MIDI clock ticks arrive while
+                    // stopped, the Start message was likely dropped during USB
+                    // device resume (host suspends the RP2350 USB peripheral
+                    // after ~10 min of inactivity; the first USB packet — the
+                    // Start — is lost while the link is waking up). Require 2
+                    // consecutive ticks to avoid false-starting from a stale
+                    // message left in SYNC_ENGINE_CHANNEL after a Stop.
+                    if !is_running && matches!(source, ClockSrc::MidiUsb | ClockSrc::MidiIn) {
+                        ticks_while_stopped += 1;
+                        if ticks_while_stopped >= 2 {
+                            clock_in_sender.send(ClockInEvent::Start(source)).await;
+                            is_running = true;
+                            ticks_while_stopped = 0;
+                            pending_emissions.clear();
+                            tick_in_window = 0;
                         }
                     }
 


### PR DESCRIPTION
Closes #526.

## Problem

After ~10 minutes of no USB activity, the macOS USB host suspends the RP2350 USB peripheral (standard USB 2.0 behavior: 3 ms of bus inactivity triggers suspend). When the user presses Play in Ableton, the first USB packet — `0xFA` (MIDI Start) — is lost while the USB link is waking up. The firmware never receives the Start event, so `is_running` stays `false`. The `0xF8` timing clock ticks that follow arrive correctly but the gatekeeper drops them (`ClockInEvent::Tick` from a MIDI source requires `is_running == true`). Result: the sequencer ignores the first Play press. A second press works because the USB link is already awake.

Reported by Marius: "after ~10 min rest the first Start is always missed; it always starts on the second press."

## Fix

In `run_unified_clock_engine`, count consecutive MIDI clock ticks received while `is_running == false`. After 2 consecutive ticks, synthesize a `ClockInEvent::Start` into `CLOCK_IN_CHANNEL`, set `is_running = true`, and reset the counter. The synthesized Start flows through the gatekeeper identically to a real Start: it publishes `ClockEvent::Reset` + `ClockEvent::Start` to apps, so all sequencers start from step 0 on the first real tick.

Requiring 2 ticks (rather than 1) prevents a false start from a single stale message that might remain in `SYNC_ENGINE_CHANNEL` after a Stop event. Any explicit transport event (Start, Stop, Continue, Reset) resets the counter to 0.

Applied to both `MidiUsb` and `MidiIn` sources — DIN MIDI doesn't suspend but the behavior is harmless there (a real Start always arrives first, resetting the counter before it reaches 2).

## Test checklist

- [ ] Connect via USB MIDI to Ableton on Mac
- [ ] Start the clock, let it run for a bit, then stop it
- [ ] Leave idle for 10+ minutes
- [ ] Press Play in Ableton → clock should start on the **first** press
- [ ] Confirm normal start/stop behavior still works at shorter idle times