### PR TITLE
fix(euclid,fp_grids): remove stale tick_origin causing off-by-one on clock reset

### DIFF
--- a/faderpunk/src/apps/euclid.rs
+++ b/faderpunk/src/apps/euclid.rs
@@ -9,8 +9,8 @@ use embassy_futures::{
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use heapless::Vec;
 use libfp::{
-    ext::FromValue, latch::LatchLayer, utils::euclidean_at, AppIcon, Brightness,
-    ClockDivision, Color, Config, MidiChannel, MidiNote, MidiOut, Param, Value, APP_MAX_PARAMS,
+    ext::FromValue, latch::LatchLayer, utils::euclidean_at, AppIcon, Brightness, ClockDivision,
+    Color, Config, MidiChannel, MidiNote, MidiOut, Param, Value, APP_MAX_PARAMS,
 };
 use serde::{Deserialize, Serialize};
 
@@ -118,14 +118,18 @@ impl AppStorage for Storage {}
 
 #[embassy_executor::task(pool_size = 16/CHANNELS)]
 pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMutex, bool>) {
-    let param_store = ParamStore::<Params>::new(app.app_id, app.layout_id, Params {
-        midi_channel: MidiChannel::default(),
-        midi_out: MidiOut::default(),
-        note: MidiNote::from(32),
-        note2: MidiNote::from(33),
-        gatel: 50,
-        color: Color::Orange,
-    });
+    let param_store = ParamStore::<Params>::new(
+        app.app_id,
+        app.layout_id,
+        Params {
+            midi_channel: MidiChannel::default(),
+            midi_out: MidiOut::default(),
+            note: MidiNote::from(32),
+            note2: MidiNote::from(33),
+            gatel: 50,
+            color: Color::Orange,
+        },
+    );
     let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
 
     param_store.load().await;
@@ -185,14 +189,8 @@ pub async fn run(
 
     let resolution = [384, 192, 96, 48, 24, 16, 12, 8, 6, 4, 3, 2];
 
-    let (fader_saved, shift_fader_saved, mute, div_saved) = storage.query(|s| {
-        (
-            s.fader_saved,
-            s.shift_fader_saved,
-            s.muted,
-            s.div_saved,
-        )
-    });
+    let (fader_saved, shift_fader_saved, mute, div_saved) =
+        storage.query(|s| (s.fader_saved, s.shift_fader_saved, s.muted, s.div_saved));
 
     num_beat_glob.set((fader_saved[0] as u32 * 15 / 4095) as u8 + 1);
     num_step_glob.set((fader_saved[1] as u32 * num_beat_glob.get() as u32 / 4095) as u8);
@@ -511,4 +509,3 @@ pub async fn run(
 
     join5(fut1, fut2, fut3, scene_handler, shift).await;
 }
-

--- a/faderpunk/src/apps/euclid.rs
+++ b/faderpunk/src/apps/euclid.rs
@@ -213,12 +213,10 @@ pub async fn run(
     let fut1 = async {
         let mut note_on = false;
         let mut aux_on = false;
-        let mut tick_origin = ticks() as u32;
 
         loop {
             match clock.wait_for_event(ClockDivision::_1).await {
                 ClockEvent::Reset => {
-                    tick_origin = ticks() as u32;
                     midi.send_note_off(note).await;
                     midi.send_note_off(note2).await;
                     note_on = false;
@@ -235,7 +233,7 @@ pub async fn run(
                     jack[1].set_low().await;
                 }
                 ClockEvent::Tick => {
-                    let clkn = (ticks() as u32).wrapping_sub(tick_origin);
+                    let clkn = ticks() as u32;
                     let muted = glob_muted.get();
                     let div = div_glob.get();
 

--- a/faderpunk/src/apps/fp_grids.rs
+++ b/faderpunk/src/apps/fp_grids.rs
@@ -437,7 +437,6 @@ pub async fn run(
 
         let mut output_mode = output_mode_glob.get();
         let mut dnb_pattern = dnb_pattern_glob.get();
-        let mut tick_origin = ticks() as u32;
         let ghost_velocity = (midi_velocity - (midi_velocity / 4)).clamp(1, 127);
 
         let mut generator = PatternGenerator::default();
@@ -477,7 +476,6 @@ pub async fn run(
             match clock.wait_for_event(ClockDivision::_1).await {
                 ClockEvent::Reset => {
                     // defmt::info!("[{}] Clock reset!", ticks());
-                    tick_origin = ticks() as u32;
                     output_mode = output_mode_glob.get();
                     reset_all_outputs(&midi, leds, notes, ghost_note, &jack, &note_on_glob, &accent_on_glob)
                         .await;
@@ -498,7 +496,6 @@ pub async fn run(
                 }
                 ClockEvent::Start => {
                     // defmt::info!("[{}] Clock start", ticks());
-                    tick_origin = ticks() as u32;
                     generator.reset();
                     // Ensure initial DnB pattern is generated at start of sequence
                     if output_mode == OutputMode::OutputModeDnB {
@@ -514,7 +511,7 @@ pub async fn run(
                         OutputMode::OutputModeDnB => generator.get_dnb_24ppqn_pattern_division(),
                     };
 
-                    let clkn = (ticks() as u32).wrapping_sub(tick_origin);
+                    let clkn = ticks() as u32;
                     // If we have reached the next sequence step, or on the first step
                     if clkn.is_multiple_of(div) {
                         // If output mode has changed since last step, change generator mode and reset the sequence

--- a/faderpunk/src/apps/genseq.rs
+++ b/faderpunk/src/apps/genseq.rs
@@ -202,6 +202,7 @@ pub async fn run(
     let fader = app.use_faders();
     let leds = app.use_leds();
     let mut clock = app.use_clock();
+    let ticks = clock.get_ticker();
     let die = app.use_die();
     let quantizer = app.use_quantizer(Range::_0_10V, vpo, bypass);
     let midi = app.use_midi_output(midi_out, midi_chan, false);
@@ -242,7 +243,6 @@ pub async fn run(
 
     // Clock-driven sequencer loop
     let fut1 = async {
-        let mut clkn: u32 = 0;
         let mut gate_on = false;
         let mut clkn_euclid: u16 = 0;
         let mut beat_reg_length: u8 = storage.query(|s| s.length_tm_length).clamp(1, 16);
@@ -265,7 +265,6 @@ pub async fn run(
             let div = div_glob.get();
             match clock.wait_for_event(ClockDivision::_1).await {
                 ClockEvent::Reset => {
-                    clkn = 0;
                     clkn_euclid = 0;
                     pitch_cycle_step = 0;
                     length_cycle_step = 0;
@@ -280,6 +279,7 @@ pub async fn run(
                     register_pitch = storage.query(|s| s.register_pitch);
                 }
                 ClockEvent::Tick => {
+                    let clkn = ticks() as u32;
                     if clkn.is_multiple_of(div) {
                         clkn_euclid = (clkn_euclid + 1) % euclid_length.max(1) as u16;
                         euclid_step_glob.set(clkn_euclid);
@@ -462,7 +462,6 @@ pub async fn run(
                         }
                     }
 
-                    clkn += 1;
                 }
                 _ => {}
             }

--- a/faderpunk/src/apps/rnd_plus.rs
+++ b/faderpunk/src/apps/rnd_plus.rs
@@ -154,6 +154,7 @@ pub async fn run(
         params.query(|p| (p.bipolar, p.midi_out, p.midi_channel, p.midi_cc, p.nrpn, p.color));
 
     let mut clock = app.use_clock();
+    let ticks = clock.get_ticker();
     let rnd = app.use_die();
     let fader = app.use_faders();
     let buttons = app.use_buttons();
@@ -179,8 +180,6 @@ pub async fn run(
 
     let resolution = [384, 192, 96, 48, 24, 16, 12, 8, 6, 4, 3, 2];
 
-    let mut clkn = 0;
-
     let curve = Curve::Exponential;
     let fader_curve = Curve::Exponential;
 
@@ -200,10 +199,9 @@ pub async fn run(
     let fut1 = async {
         loop {
             match clock.wait_for_event(ClockDivision::_1).await {
-                ClockEvent::Reset => {
-                    clkn = 0;
-                }
+                ClockEvent::Reset => {}
                 ClockEvent::Tick => {
+                    let clkn = ticks() as u16;
                     let muted = storage.query(|s: &Storage| s.mute_save);
 
                     let destination = storage.query(|s| s.dest);
@@ -245,7 +243,6 @@ pub async fn run(
                     {
                         leds.unset(1, Led::Bottom);
                     }
-                    clkn += 1;
                 }
                 _ => {}
             }

--- a/faderpunk/src/apps/rnd_plus.rs
+++ b/faderpunk/src/apps/rnd_plus.rs
@@ -211,7 +211,7 @@ pub async fn run(
                     } else {
                         resolution[(base_speed as usize / 345).clamp(0, resolution.len() - 1)]
                     };
-                    if clkn % div == 0
+                    if clkn.is_multiple_of(div)
                         && !muted
                         && storage.query(|s: &Storage| s.clocked)
                         && destination != 1
@@ -232,7 +232,7 @@ pub async fn run(
                         leds.set(1, Led::Button, rnd_color, Brightness::Mid);
                     }
 
-                    if clkn % div == 0
+                    if clkn.is_multiple_of(div)
                         && storage.query(|s: &Storage| s.clocked)
                         && buttons.is_shift_pressed()
                     {


### PR DESCRIPTION
## Summary

- `euclid.rs` and `fp_grids.rs`: removed the per-app `tick_origin` tracking — apps captured `ticks()` in the `Reset` handler and later did `ticks().wrapping_sub(tick_origin)` to compute `clkn`, but the clock task stores `u64::MAX` into `TICK_COUNTER` *before* publishing `ClockEvent::Reset`, so `tick_origin` captured `0xFFFF_FFFF` instead of the post-reset baseline. The first real tick then wrapped `TICK_COUNTER` to `0`, and `clkn = 0u32.wrapping_sub(0xFFFF_FFFF) = 1` — one step off phase, so both apps skipped step 0 and started one step late on every Play.
- Fix: drop `tick_origin` entirely and read `TICK_COUNTER` (via `ticks()`) directly as `clkn` on each `Tick` event. The clock task already arranges for the counter to wrap to `0` on the first tick after a reset (`TICK_COUNTER.store(u64::MAX, ...)` followed by `fetch_add(1)` on the next tick), so no local offset bookkeeping is needed — `clkn == 0` on the first tick after reset.
- `genseq.rs` and `rnd_plus.rs`: same cleanup — remove local `clkn` counters and read `TICK_COUNTER` directly via `ticks()` on each Tick event, consistent with tb3po/seq8.

## Test plan

- [ ] Start clock (Play): euclid gate fires on the very first downbeat tick, pattern step 0 coincides with beat 1
- [ ] Euclid gate output is in phase with tb3po's gate on the same clock
- [ ] fp_grids pattern starts from step 0 after Play/Reset
- [ ] genseq and rnd_plus step timing unchanged (same behavior, different implementation)