### PR TITLE
feat: custom V/Oct gain calibration curves

### DIFF
--- a/configurator/src/components/ManualTab.tsx
+++ b/configurator/src/components/ManualTab.tsx
@@ -1633,6 +1633,9 @@ export const ManualTab = () => {
                     <Link to="#settings-aux">AUX Jacks</Link>
                   </li>
                   <li>
+                    <Link to="#settings-voct">Custom V/Oct Calibration</Link>
+                  </li>
+                  <li>
                     <Link to="#settings-misc">Miscellaneous</Link>
                   </li>
                   <li>

--- a/configurator/src/components/SettingsTab.tsx
+++ b/configurator/src/components/SettingsTab.tsx
@@ -26,6 +26,7 @@ import { I2cSettings } from "./settings/I2cSettings";
 import { MidiSettings } from "./settings/MidiSettings";
 import { MiscSettings } from "./settings/MiscSettings";
 import { QuantizerSettings } from "./settings/QuantizerSettings";
+import { VoOctCurvesSettings } from "./settings/VoOctCurvesSettings";
 
 interface SettingsFormProps {
   config: GlobalConfig;
@@ -148,19 +149,19 @@ const SettingsForm = ({ config }: SettingsFormProps) => {
   const onSubmit: SubmitHandler<Inputs> = useCallback(
     async (formValues: Inputs) => {
       if (usbDevice && !isSimulator) {
-        const config = transformFormToGlobalConfig(formValues);
-        await setGlobalConfig(usbDevice, config);
-        setConfig(config);
+        const updatedConfig = transformFormToGlobalConfig(formValues, config);
+        await setGlobalConfig(usbDevice, updatedConfig);
+        setConfig(updatedConfig);
       } else if (isSimulator) {
-        const config = transformFormToGlobalConfig(formValues);
-        setConfig(config);
+        const updatedConfig = transformFormToGlobalConfig(formValues, config);
+        setConfig(updatedConfig);
       }
       if (usbDevice || isSimulator) {
         setSaved(true);
         setTimeout(() => setSaved(false), 2000);
       }
     },
-    [usbDevice, isSimulator, setConfig],
+    [usbDevice, isSimulator, setConfig, config],
   );
 
   useEffect(() => {
@@ -180,6 +181,7 @@ const SettingsForm = ({ config }: SettingsFormProps) => {
         <MidiSettings />
         <I2cSettings />
         <MiscSettings />
+        <VoOctCurvesSettings config={config} />
         <SaveLoadSetup />
         <FactoryReset />
         <div className="flex justify-between">
@@ -260,7 +262,10 @@ const buildMidiOutConfig = (
   };
 };
 
-const transformFormToGlobalConfig = (formValues: Inputs): GlobalConfig => {
+const transformFormToGlobalConfig = (
+  formValues: Inputs,
+  currentConfig: GlobalConfig,
+): GlobalConfig => {
   const auxArray = [
     buildAuxJackMode(formValues.auxAtom, formValues.auxAtomDiv),
     buildAuxJackMode(formValues.auxMeteor, formValues.auxMeteorDiv),
@@ -310,5 +315,6 @@ const transformFormToGlobalConfig = (formValues: Inputs): GlobalConfig => {
       tonic: { tag: formValues.quantizerTonic },
     },
     takeover_mode: { tag: formValues.takeoverMode },
+    custom_voct_curves: currentConfig.custom_voct_curves,
   };
 };

--- a/configurator/src/components/input/ParamVoltPerOct.tsx
+++ b/configurator/src/components/input/ParamVoltPerOct.tsx
@@ -15,6 +15,10 @@ type Item = { key: string; value: string };
 const ITEMS: Item[] = [
   { key: "Standard", value: "1V/Oct (Eurorack)" },
   { key: "Buchla", value: "1.2V/Oct (Buchla)" },
+  { key: "Custom:0", value: "Custom 1" },
+  { key: "Custom:1", value: "Custom 2" },
+  { key: "Custom:2", value: "Custom 3" },
+  { key: "Custom:3", value: "Custom 4" },
 ];
 
 export const ParamVoltPerOct = ({

--- a/configurator/src/components/manual/Configurator.tsx
+++ b/configurator/src/components/manual/Configurator.tsx
@@ -312,11 +312,12 @@ export const Configurator = () => (
 
     <H4 id="settings-voct">Custom V/Oct Calibration</H4>
     <p>
-      Faderpunk stores up to <strong>four custom V/Oct calibration curves</strong>{" "}
-      (Custom 1–4). This allows Faderpunk to achieve near-perfect tracking with
-      any V/Oct oscillator, regardless of the calibration of either the target
-      oscillator or the Faderpunk itself. It can even allow oscillators that are
-      not designed to run on 1V/Oct to track with the pitched apps on Faderpunk.
+      Faderpunk stores up to{" "}
+      <strong>four custom V/Oct calibration curves</strong> (Custom 1–4). This
+      allows Faderpunk to achieve near-perfect tracking with any V/Oct
+      oscillator, regardless of the calibration of either the target oscillator
+      or the Faderpunk itself. It can even allow oscillators that are not
+      designed to run on 1V/Oct to track with the pitched apps on Faderpunk.
       Once calibrated, any app that has a <strong>1V/Oct</strong> parameter can
       use one of the custom curves instead of the default standard tracking.
     </p>
@@ -332,7 +333,10 @@ export const Configurator = () => (
         A VCO with a V/Oct input connected to one of the 16 Faderpunk output
         jacks
       </li>
-      <li>A tuner with frequency meter (hardware or software) connected to the VCO audio output</li>
+      <li>
+        A tuner with frequency meter (hardware or software) connected to the VCO
+        audio output
+      </li>
     </List>
     <H5>Calibration wizard</H5>
     <List>

--- a/configurator/src/components/manual/Configurator.tsx
+++ b/configurator/src/components/manual/Configurator.tsx
@@ -310,6 +310,59 @@ export const Configurator = () => (
       <li>4 bars</li>
     </List>
 
+    <H4 id="settings-voct">Custom V/Oct Calibration</H4>
+    <p>
+      Faderpunk stores up to <strong>four custom V/Oct calibration curves</strong>{" "}
+      (Custom 1–4). This allows Faderpunk to achieve near-perfect tracking with
+      any V/Oct oscillator, regardless of the calibration of either the target
+      oscillator or the Faderpunk itself. It can even allow oscillators that are
+      not designed to run on 1V/Oct to track with the pitched apps on Faderpunk.
+      Once calibrated, any app that has a <strong>1V/Oct</strong> parameter can
+      use one of the custom curves instead of the default standard tracking.
+    </p>
+    <p>
+      Each curve shows its measured gain next to the curve name (e.g.,{" "}
+      <em>0.998 V/Oct</em>), or <em>Not calibrated</em> if no measurement has
+      been taken yet. Click <strong>Calibrate</strong> next to a curve to open
+      the calibration wizard.
+    </p>
+    <H5>What you need</H5>
+    <List>
+      <li>
+        A VCO with a V/Oct input connected to one of the 16 Faderpunk output
+        jacks
+      </li>
+      <li>A tuner with frequency meter (hardware or software) connected to the VCO audio output</li>
+    </List>
+    <H5>Calibration wizard</H5>
+    <List>
+      <li>
+        <strong>Setup</strong> — Select the Faderpunk output jack you have
+        connected to the VCO V/Oct input. For best accuracy, use a jack that
+        does not have an app assigned to it. Click <strong>Start</strong>.
+      </li>
+      <li>
+        <strong>Step 1 (1V)</strong> — The firmware outputs 1V on the selected
+        jack. Read the frequency shown by your meter and type it into the field,
+        then click <strong>Next</strong>.
+      </li>
+      <li>
+        <strong>Step 2 (4V)</strong> — The firmware outputs 4V. Read and enter
+        the new frequency, then click <strong>Calculate</strong>.
+      </li>
+      <li>
+        <strong>Result</strong> — The measured V/Oct gain is displayed. Click{" "}
+        <strong>Save</strong> to store the calibration or{" "}
+        <strong>Discard</strong> to cancel.
+      </li>
+    </List>
+    <p>
+      The calibration is saved into the device's global configuration. It
+      survives power cycles and is included when you export a setup file. Apps
+      that use the calibrated curve automatically apply the correction without
+      needing to be reconfigured.
+    </p>
+
     <H4 id="settings-misc">Miscellaneous</H4>
     <List>
       <li>

--- a/configurator/src/components/settings/VoOctCurvesSettings.tsx
+++ b/configurator/src/components/settings/VoOctCurvesSettings.tsx
@@ -1,0 +1,315 @@
+import type { GlobalConfig } from "@atov/fp-config";
+import { useCallback, useState } from "react";
+import { Input } from "@heroui/input";
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/modal";
+import { Select, SelectItem } from "@heroui/select";
+
+import { useStore } from "../../store";
+import { setGlobalConfig } from "../../utils/config";
+import { sendAndReceive } from "../../utils/usb-protocol";
+import { ButtonPrimary, ButtonSecondary } from "../Button";
+
+interface Props {
+  config: GlobalConfig;
+}
+
+const LOW_DAC_COUNTS = 410; // 1V
+const HIGH_DAC_COUNTS = 1638; // 4V
+const OCTAVE_SPAN = 3.0; // 4V - 1V at standard 1V/oct
+
+type WizardStep =
+  | { type: "setup" }
+  | { type: "step1" }
+  | { type: "step2" }
+  | { type: "done"; countsPerOct: number; gain: number }
+  | { type: "error"; message: string };
+
+const CURVE_LABELS = ["Custom 1", "Custom 2", "Custom 3", "Custom 4"] as const;
+
+const JACK_OPTIONS = Array.from({ length: 16 }, (_, i) => ({
+  key: String(i),
+  label: `Jack ${i + 1}`,
+}));
+
+const formatGain = (countsPerOct: number): string =>
+  `${(countsPerOct / 410).toFixed(3)} V/Oct`;
+
+export const VoOctCurvesSettings = ({ config }: Props) => {
+  const { usbDevice, isSimulator, setConfig } = useStore();
+
+  const [openCurveIdx, setOpenCurveIdx] = useState<number | null>(null);
+  const [outputJack, setOutputJack] = useState("0");
+  const [wizardStep, setWizardStep] = useState<WizardStep>({ type: "setup" });
+  const [freqInput, setFreqInput] = useState("");
+  const [f1, setF1] = useState<number | null>(null);
+
+  const releaseOutput = useCallback(
+    (jack: string) => {
+      if (!usbDevice) return;
+      sendAndReceive(usbDevice, {
+        tag: "ReleaseVoOctOutput",
+        value: { output_jack: parseInt(jack, 10) },
+      }).catch(() => {});
+    },
+    [usbDevice],
+  );
+
+  const handleOpenWizard = useCallback((idx: number) => {
+    setOpenCurveIdx(idx);
+    setWizardStep({ type: "setup" });
+    setFreqInput("");
+    setF1(null);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    if (wizardStep.type === "step1" || wizardStep.type === "step2") {
+      releaseOutput(outputJack);
+    }
+    setOpenCurveIdx(null);
+  }, [wizardStep, outputJack, releaseOutput]);
+
+  const handleStart = useCallback(async () => {
+    if (!usbDevice || openCurveIdx === null) return;
+    try {
+      const r = await sendAndReceive(usbDevice, {
+        tag: "SetVoOctOutput",
+        value: {
+          output_jack: parseInt(outputJack, 10),
+          dac_counts: LOW_DAC_COUNTS,
+        },
+      });
+      if (r.tag !== "VoOctOutputSet") {
+        setWizardStep({ type: "error", message: "Failed to set output." });
+        return;
+      }
+      setFreqInput("");
+      setWizardStep({ type: "step1" });
+    } catch (e) {
+      setWizardStep({ type: "error", message: String(e) });
+    }
+  }, [usbDevice, openCurveIdx, outputJack]);
+
+  const handleStep1Next = useCallback(async () => {
+    if (!usbDevice) return;
+    const f1Val = parseFloat(freqInput);
+    if (!Number.isFinite(f1Val) || f1Val <= 0) return;
+
+    try {
+      const r = await sendAndReceive(usbDevice, {
+        tag: "SetVoOctOutput",
+        value: {
+          output_jack: parseInt(outputJack, 10),
+          dac_counts: HIGH_DAC_COUNTS,
+        },
+      });
+      if (r.tag !== "VoOctOutputSet") {
+        setWizardStep({ type: "error", message: "Failed to set output." });
+        return;
+      }
+      setF1(f1Val);
+      setFreqInput("");
+      setWizardStep({ type: "step2" });
+    } catch (e) {
+      setWizardStep({ type: "error", message: String(e) });
+    }
+  }, [usbDevice, freqInput, outputJack]);
+
+  const handleStep2Calculate = useCallback(async () => {
+    if (f1 === null) return;
+    const f2Val = parseFloat(freqInput);
+    if (!Number.isFinite(f2Val) || f2Val <= 0) return;
+
+    releaseOutput(outputJack);
+
+    const gain = OCTAVE_SPAN / Math.log2(f2Val / f1);
+    const countsPerOct = Math.round(gain * 410);
+    setWizardStep({ type: "done", countsPerOct, gain });
+  }, [f1, freqInput, outputJack, releaseOutput]);
+
+  const handleSave = useCallback(async () => {
+    if (openCurveIdx === null || wizardStep.type !== "done") return;
+
+    const updatedCurves = [
+      ...config.custom_voct_curves,
+    ] as unknown as typeof config.custom_voct_curves;
+    updatedCurves[openCurveIdx] = { counts_per_oct: wizardStep.countsPerOct };
+    const updatedConfig: GlobalConfig = {
+      ...config,
+      custom_voct_curves: updatedCurves,
+    };
+
+    if (usbDevice && !isSimulator) {
+      await setGlobalConfig(usbDevice, updatedConfig);
+    }
+    setConfig(updatedConfig);
+    setOpenCurveIdx(null);
+  }, [openCurveIdx, wizardStep, config, usbDevice, isSimulator, setConfig]);
+
+  return (
+    <div className="mb-12">
+      <h2 className="text-yellow-fp mb-4 text-sm font-bold uppercase">
+        Custom V/Oct Curves
+      </h2>
+      <div className="flex flex-col gap-y-4 px-4">
+        {CURVE_LABELS.map((label, idx) => {
+          const cpo = config.custom_voct_curves[idx]?.counts_per_oct ?? 0;
+          return (
+            <div key={idx} className="flex items-center justify-between">
+              <span className="text-sm font-medium">{label}</span>
+              <span className="text-sm text-gray-400">
+                {cpo === 0 ? "Not calibrated" : formatGain(cpo)}
+              </span>
+              <ButtonSecondary
+                size="sm"
+                onPress={() => handleOpenWizard(idx)}
+                isDisabled={!usbDevice || isSimulator}
+              >
+                Calibrate
+              </ButtonSecondary>
+            </div>
+          );
+        })}
+      </div>
+
+      <Modal
+        isOpen={openCurveIdx !== null}
+        onOpenChange={(open) => {
+          if (!open) handleClose();
+        }}
+      >
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader>
+                Calibrate{" "}
+                {openCurveIdx !== null ? CURVE_LABELS[openCurveIdx] : ""}
+              </ModalHeader>
+              <ModalBody>
+                {wizardStep.type === "setup" && (
+                  <div className="flex flex-col gap-y-4">
+                    <p className="text-sm">
+                      Connect an output jack to a VCO V/Oct input, and the VCO
+                      audio output to your frequency meter. Use a jack with no
+                      app assigned for best accuracy.
+                    </p>
+                    <Select
+                      label="Output jack"
+                      selectedKeys={[outputJack]}
+                      onSelectionChange={(keys) =>
+                        setOutputJack([...keys][0] as string)
+                      }
+                      items={JACK_OPTIONS}
+                    >
+                      {(item) => (
+                        <SelectItem key={item.key}>{item.label}</SelectItem>
+                      )}
+                    </Select>
+                  </div>
+                )}
+                {wizardStep.type === "step1" && (
+                  <div className="flex flex-col gap-y-4">
+                    <p className="text-sm">
+                      Outputting 1V. Read the frequency from your meter and
+                      enter it below.
+                    </p>
+                    <Input
+                      label="Measured frequency (Hz)"
+                      type="number"
+                      value={freqInput}
+                      onValueChange={setFreqInput}
+                    />
+                  </div>
+                )}
+                {wizardStep.type === "step2" && (
+                  <div className="flex flex-col gap-y-4">
+                    <p className="text-sm">
+                      Outputting 4V. Read the frequency from your meter and
+                      enter it below.
+                    </p>
+                    <Input
+                      label="Measured frequency (Hz)"
+                      type="number"
+                      value={freqInput}
+                      onValueChange={setFreqInput}
+                    />
+                  </div>
+                )}
+                {wizardStep.type === "done" && (
+                  <div className="flex flex-col gap-y-2">
+                    <p className="text-sm font-medium">
+                      Measured: {formatGain(wizardStep.countsPerOct)}
+                    </p>
+                    <p className="text-xs text-gray-400">
+                      ({wizardStep.countsPerOct} counts/oct)
+                    </p>
+                  </div>
+                )}
+                {wizardStep.type === "error" && (
+                  <p className="text-sm text-red-400">{wizardStep.message}</p>
+                )}
+              </ModalBody>
+              <ModalFooter>
+                {wizardStep.type === "setup" && (
+                  <>
+                    <ButtonPrimary onPress={handleStart}>Start</ButtonPrimary>
+                    <ButtonSecondary onPress={onClose}>Cancel</ButtonSecondary>
+                  </>
+                )}
+                {wizardStep.type === "step1" && (
+                  <>
+                    <ButtonPrimary
+                      onPress={handleStep1Next}
+                      isDisabled={
+                        !Number.isFinite(parseFloat(freqInput)) ||
+                        parseFloat(freqInput) <= 0
+                      }
+                    >
+                      Next
+                    </ButtonPrimary>
+                    <ButtonSecondary onPress={onClose}>Cancel</ButtonSecondary>
+                  </>
+                )}
+                {wizardStep.type === "step2" && (
+                  <>
+                    <ButtonPrimary
+                      onPress={handleStep2Calculate}
+                      isDisabled={
+                        !Number.isFinite(parseFloat(freqInput)) ||
+                        parseFloat(freqInput) <= 0
+                      }
+                    >
+                      Calculate
+                    </ButtonPrimary>
+                    <ButtonSecondary onPress={onClose}>Cancel</ButtonSecondary>
+                  </>
+                )}
+                {wizardStep.type === "done" && (
+                  <>
+                    <ButtonPrimary onPress={handleSave}>Save</ButtonPrimary>
+                    <ButtonSecondary onPress={onClose}>Discard</ButtonSecondary>
+                  </>
+                )}
+                {wizardStep.type === "error" && (
+                  <>
+                    <ButtonPrimary
+                      onPress={() => setWizardStep({ type: "setup" })}
+                    >
+                      Retry
+                    </ButtonPrimary>
+                    <ButtonSecondary onPress={onClose}>Cancel</ButtonSecondary>
+                  </>
+                )}
+              </ModalFooter>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
+    </div>
+  );
+};

--- a/configurator/src/utils/utils.ts
+++ b/configurator/src/utils/utils.ts
@@ -87,7 +87,8 @@ export const getDefaultValue = (val: Value) => {
       return val.value;
     }
     case "VoltPerOct": {
-      return val.value.tag;
+      const vpo = val.value;
+      return vpo.tag === "Custom" ? `Custom:${vpo.value}` : vpo.tag;
     }
   }
 };
@@ -143,8 +144,19 @@ const getParamValue = (
       return { tag: "MidiMode", value: { tag: value as MidiModeTag } };
     case "MidiNrpn":
       return { tag: "MidiNrpn", value: value as boolean };
-    case "VoltPerOct":
-      return { tag: "VoltPerOct", value: { tag: value as VoltPerOct["tag"] } };
+    case "VoltPerOct": {
+      const key = value as string;
+      if (key.startsWith("Custom:")) {
+        return {
+          tag: "VoltPerOct",
+          value: { tag: "Custom", value: parseInt(key.slice(7), 10) },
+        };
+      }
+      return {
+        tag: "VoltPerOct",
+        value: { tag: key as Exclude<VoltPerOct["tag"], "Custom"> },
+      };
+    }
     default:
       return undefined;
   }

--- a/configurator/src/utils/validators.ts
+++ b/configurator/src/utils/validators.ts
@@ -143,7 +143,13 @@ export const getParamSchema = (param: Param) => {
       return z
         .object({
           tag: z.literal("VoltPerOct"),
-          value: z.object({ tag: z.enum(["Standard", "Buchla"]) }),
+          value: z.union([
+            z.object({ tag: z.enum(["Standard", "Buchla"]) }),
+            z.object({
+              tag: z.literal("Custom"),
+              value: z.number().int().min(0).max(3),
+            }),
+          ]),
         })
         .catch({
           tag: "VoltPerOct",
@@ -215,6 +221,12 @@ export const defaultGlobalConfig: GlobalConfig = {
     tonic: { tag: "C" },
   },
   takeover_mode: { tag: "Pickup" },
+  custom_voct_curves: [
+    { counts_per_oct: 0 },
+    { counts_per_oct: 0 },
+    { counts_per_oct: 0 },
+    { counts_per_oct: 0 },
+  ] as GlobalConfig["custom_voct_curves"],
 };
 
 // Lenient schema that validates structure but allows any valid tag values
@@ -280,6 +292,7 @@ export const parseGlobalConfigFromFile = (
     },
     quantizer: validated.quantizer as GlobalConfig["quantizer"],
     takeover_mode: validated.takeover_mode as GlobalConfig["takeover_mode"],
+    custom_voct_curves: defaultGlobalConfig.custom_voct_curves,
   };
 
   return config;

--- a/faderpunk/src/app.rs
+++ b/faderpunk/src/app.rs
@@ -858,3 +858,18 @@ impl<const N: usize> App<N> {
         self.reset().await;
     }
 }
+
+/// Convert a quantized pitch to DAC counts, resolving any Custom V/Oct curve
+/// from the live global config. Prefer this over `Pitch::as_counts_with_curves`
+/// in app code — no need to import or snapshot `get_global_config`.
+pub fn pitch_as_counts(pitch: Pitch, range: Range, vpo: VoltPerOct) -> u16 {
+    let curves = get_global_config().custom_voct_curves;
+    pitch.as_counts_with_curves(range, vpo, &curves)
+}
+
+/// Return DAC counts-per-octave for `vpo`, resolving any Custom V/Oct curve
+/// from the live global config.
+pub fn vpo_counts_per_oct(vpo: VoltPerOct) -> i16 {
+    let curves = get_global_config().custom_voct_curves;
+    vpo.counts_per_oct_with_curves(&curves)
+}

--- a/faderpunk/src/apps/clkturing.rs
+++ b/faderpunk/src/apps/clkturing.rs
@@ -17,7 +17,7 @@ use libfp::{
     Param, Range, Value, VoltPerOct, APP_MAX_PARAMS,
 };
 
-use crate::app::{App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
+use crate::app::{pitch_as_counts, App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
 
 pub const CHANNELS: usize = 2;
 pub const PARAMS: usize = 10;
@@ -245,7 +245,7 @@ pub async fn run(
 
                 let muted = glob_muted.get();
                 if !muted {
-                    output.set_value(out.as_counts(range, vpo));
+                    output.set_value(pitch_as_counts(out, range, vpo));
                     leds.set(
                         0,
                         Led::Top,

--- a/faderpunk/src/apps/genseq.rs
+++ b/faderpunk/src/apps/genseq.rs
@@ -17,7 +17,8 @@ use libfp::{
 use midly::num::u7;
 
 use crate::app::{
-    App, AppParams, AppStorage, ClockEvent, Led, ManagedStorage, ParamStore, SceneEvent,
+    pitch_as_counts, vpo_counts_per_oct, App, AppParams, AppStorage, ClockEvent, Led,
+    ManagedStorage, ParamStore, SceneEvent,
 };
 
 pub const CHANNELS: usize = 3;
@@ -336,7 +337,7 @@ pub async fn run(
                             // bottom of the pitch range maps to C0 rather than clipping
                             // negative DAC values to 0V.
                             let input_floor = ((-octave_offset).max(0) as u16)
-                                .saturating_mul(vpo.counts_per_oct() as u16);
+                                .saturating_mul(vpo_counts_per_oct(vpo) as u16);
                             let quantizer_input =
                                 (att_reg as u32 / 2 + input_floor as u32).min(4095) as u16;
                             let out = quantizer.get_quantized_note(quantizer_input).await;
@@ -356,7 +357,7 @@ pub async fn run(
                             midi_note.set(note);
 
                             if !glob_muted.get() {
-                                cv_out.set_value(shifted.as_counts(Range::_0_10V, vpo));
+                                cv_out.set_value(pitch_as_counts(shifted, Range::_0_10V, vpo));
                             }
                             leds.set(
                                 0,

--- a/faderpunk/src/apps/notefader.rs
+++ b/faderpunk/src/apps/notefader.rs
@@ -13,7 +13,8 @@ use libfp::{
 };
 
 use crate::app::{
-    App, AppParams, AppStorage, ClockEvent, Led, ManagedStorage, ParamStore, SceneEvent,
+    pitch_as_counts, App, AppParams, AppStorage, ClockEvent, Led, ManagedStorage, ParamStore,
+    SceneEvent,
 };
 
 pub const CHANNELS: usize = 1;
@@ -218,7 +219,7 @@ pub async fn run(
 
         let out = quantizer.get_quantized_note(fadval).await;
         if outmode == 0 {
-            jack.set_value(out.as_counts(range, vpo));
+            jack.set_value(pitch_as_counts(out, range, vpo));
         } else {
             jack.set_value(4095)
         }

--- a/faderpunk/src/apps/quantizer.rs
+++ b/faderpunk/src/apps/quantizer.rs
@@ -12,7 +12,10 @@ use serde::{Deserialize, Serialize};
 
 use libfp::{Config, Param, Range, Value};
 
-use crate::app::{App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
+use crate::app::{
+    pitch_as_counts, vpo_counts_per_oct, App, AppParams, AppStorage, Led, ManagedStorage,
+    ParamStore, SceneEvent,
+};
 
 pub const CHANNELS: usize = 2;
 pub const PARAMS: usize = 4;
@@ -138,7 +141,7 @@ pub async fn run(
     leds.set(1, Led::Button, led_color, Brightness::Mid);
 
     let quantizer = app.use_quantizer(range, vpo, bypass);
-    let counts_per_oct = vpo.counts_per_oct();
+    let counts_per_oct = vpo_counts_per_oct(vpo);
     let _input = app.make_in_jack(0, range).await;
     let output = app.make_out_jack(1, range).await;
     for chan in 0..2 {
@@ -173,8 +176,8 @@ pub async fn run(
                 .get_quantized_note((inval + oct + st).clamp(0, 4095) as u16)
                 .await;
 
-            output.set_value(outval.as_counts(range, vpo));
-            let oct_led = split_unsigned_value(outval.as_counts(range, vpo));
+            output.set_value(pitch_as_counts(outval, range, vpo));
+            let oct_led = split_unsigned_value(pitch_as_counts(outval, range, vpo));
             leds.set(1, Led::Top, led_color, Brightness::Custom(oct_led[0]));
             leds.set(1, Led::Bottom, led_color, Brightness::Custom(oct_led[1]));
             leds.set(

--- a/faderpunk/src/apps/seq8.rs
+++ b/faderpunk/src/apps/seq8.rs
@@ -14,8 +14,8 @@ use libfp::{
 };
 
 use crate::app::{
-    App, AppParams, AppStorage, Arr, ClockEvent, Global, Led, ManagedStorage, ParamStore,
-    SceneEvent,
+    pitch_as_counts, vpo_counts_per_oct, App, AppParams, AppStorage, Arr, ClockEvent, Global,
+    Led, ManagedStorage, ParamStore, SceneEvent,
 };
 
 pub const CHANNELS: usize = 8;
@@ -327,7 +327,7 @@ pub async fn run(
     ];
 
     let quantizer = app.use_quantizer(range, vpo, bypass);
-    let counts_per_oct = vpo.counts_per_oct() as u32;
+    let counts_per_oct = vpo_counts_per_oct(vpo) as u32;
 
     let page_glob: Global<usize> = app.make_global(0);
     let prev_page_glob: Global<usize> = app.make_global(0);
@@ -741,7 +741,7 @@ pub async fn run(
                                     // Hand the target CV to slide_handler; slide only if
                                     // the previously played step had legato enabled.
                                     let mut targets = target_cv_glob.get();
-                                    targets[n] = (out.as_counts(range, vpo) as i32
+                                    targets[n] = (pitch_as_counts(out, range, vpo) as i32
                                         + transpo[n] as i32 * counts_per_oct as i32 / 12)
                                         .clamp(0, 4095) as u16;
                                     target_cv_glob.set(targets);

--- a/faderpunk/src/apps/tb3po.rs
+++ b/faderpunk/src/apps/tb3po.rs
@@ -17,7 +17,8 @@ use libfp::{
 };
 
 use crate::app::{
-    App, AppParams, AppStorage, ClockEvent, Global, Led, ManagedStorage, ParamStore, SceneEvent,
+    pitch_as_counts, vpo_counts_per_oct, App, AppParams, AppStorage, ClockEvent, Global, Led,
+    ManagedStorage, ParamStore, SceneEvent,
 };
 use crate::tasks::leds::LedMode;
 
@@ -266,7 +267,7 @@ fn step_is_oct_down(p: &AcidPattern, step: u8) -> bool {
 
 /// Raw pitch CV for a step before quantising (in ±5V counts 0–4095).
 fn raw_pitch_cv(p: &AcidPattern, step: u8, transpose: i16, vpo: VoltPerOct) -> u16 {
-    let oct = vpo.counts_per_oct() as i32;
+    let oct = vpo_counts_per_oct(vpo) as i32;
     let semi = oct / 12;
     let note = p.notes[step as usize] as i32;
     let cv = CENTER_CV as i32
@@ -443,12 +444,12 @@ pub async fn run(
                     if is_slid_prev {
                         // Glide: output_task will interpolate toward new target
                         let out = quantizer.get_quantized_note(target_raw).await;
-                        slide_target_glob.set(out.as_counts(pitch_range, vpo));
+                        slide_target_glob.set(pitch_as_counts(out, pitch_range, vpo));
                         slide_active_glob.set(true);
                     } else if is_gated {
                         // Snap to new pitch
                         let out = quantizer.get_quantized_note(target_raw).await;
-                        let counts = out.as_counts(pitch_range, vpo);
+                        let counts = pitch_as_counts(out, pitch_range, vpo);
                         slide_target_glob.set(counts);
                         slide_active_glob.set(false);
                     }

--- a/faderpunk/src/apps/turing.rs
+++ b/faderpunk/src/apps/turing.rs
@@ -19,7 +19,8 @@ use libfp::{
 };
 
 use crate::app::{
-    App, AppParams, AppStorage, ClockEvent, Led, ManagedStorage, ParamStore, SceneEvent,
+    pitch_as_counts, App, AppParams, AppStorage, ClockEvent, Led, ManagedStorage, ParamStore,
+    SceneEvent,
 };
 
 pub const CHANNELS: usize = 1;
@@ -340,7 +341,7 @@ pub async fn run(
                             let out = quantizer.get_quantized_note(att_reg).await;
                             let muted = glob_muted.get();
                             if !muted {
-                                cv_jack.as_ref().unwrap().set_value(out.as_counts(range, vpo));
+                                cv_jack.as_ref().unwrap().set_value(pitch_as_counts(out, range, vpo));
                                 leds.set(
                                     0,
                                     Led::Top,

--- a/faderpunk/src/storage.rs
+++ b/faderpunk/src/storage.rs
@@ -99,6 +99,7 @@ impl From<GlobalConfigV0> for GlobalConfig {
             midi: old.midi,
             quantizer: old.quantizer,
             takeover_mode: old.takeover_mode,
+            custom_voct_curves: Default::default(),
         }
     }
 }
@@ -132,6 +133,7 @@ impl From<GlobalConfigV170> for GlobalConfig {
             midi: old.midi,
             quantizer: old.quantizer,
             takeover_mode: TakeoverMode::Pickup,
+            custom_voct_curves: Default::default(),
         }
     }
 }

--- a/faderpunk/src/tasks/clock.rs
+++ b/faderpunk/src/tasks/clock.rs
@@ -11,8 +11,9 @@ use embassy_sync::{
     blocking_mutex::raw::{CriticalSectionRawMutex, ThreadModeRawMutex},
     channel::Channel,
     pubsub::{PubSubChannel, Subscriber},
+    signal::Signal,
 };
-use embassy_time::{Duration, Instant, Timer};
+use embassy_time::{with_timeout, Duration, Instant, Timer};
 use heapless::Deque;
 use midly::live::SystemRealtime;
 use portable_atomic::{AtomicBool, AtomicU64, Ordering};
@@ -46,6 +47,13 @@ const METRONOME_HIGH_MS: u64 = 25;
 
 pub static TICK_COUNTER: AtomicU64 = AtomicU64::new(0);
 pub static METRONOME_HIGH: AtomicBool = AtomicBool::new(true);
+
+/// Signals the AUX pin loop to pause clock detection and run a frequency
+/// measurement. Index corresponds to aux pin: 0=Atom, 1=Meteor, 2=Cube.
+pub static VOCT_MEASURE_REQ: [Signal<CriticalSectionRawMutex, ()>; 3] =
+    [const { Signal::new() }; 3];
+/// Result of a V/Oct frequency measurement: Ok(freq_hz) or Err(()) on timeout.
+pub static VOCT_MEASURE_RES: Signal<CriticalSectionRawMutex, Result<u32, ()>> = Signal::new();
 
 type AuxInputs = (
     Peri<'static, PIN_1>,
@@ -206,7 +214,7 @@ pub async fn start_clock(spawner: &Spawner, aux_inputs: AuxInputs) {
     spawner.spawn(metronome()).unwrap();
 }
 
-async fn make_ext_clock_loop(mut pin: Input<'_>, clock_src: ClockSrc) {
+async fn make_ext_clock_loop(pin: &mut Input<'_>, clock_src: ClockSrc) {
     let sender = SYNC_ENGINE_CHANNEL.sender();
     loop {
         pin.wait_for_falling_edge().await;
@@ -217,6 +225,61 @@ async fn make_ext_clock_loop(mut pin: Input<'_>, clock_src: ClockSrc) {
                 timestamp: Instant::now(),
             })
             .await;
+    }
+}
+
+/// Measure the frequency of an incoming signal on `pin` by timing rising edges.
+/// Returns `Ok(freq_hz)` or `Err(())` on timeout (2 s without a valid edge).
+/// Debounces edges closer than 50 µs to handle noisy sine-wave sources.
+async fn measure_frequency(pin: &mut Input<'_>) -> Result<u32, ()> {
+    const SAMPLES: u64 = 8;
+    const DEBOUNCE_US: u64 = 50;
+    const TIMEOUT: Duration = Duration::from_secs(2);
+
+    // Sync to the first rising edge.
+    with_timeout(TIMEOUT, pin.wait_for_rising_edge())
+        .await
+        .map_err(|_| ())?;
+    let mut last_edge = Instant::now();
+
+    let mut total_period_us: u64 = 0;
+    let mut valid: u64 = 0;
+
+    while valid < SAMPLES {
+        with_timeout(TIMEOUT, pin.wait_for_rising_edge())
+            .await
+            .map_err(|_| ())?;
+        let now = Instant::now();
+        let period_us = now.duration_since(last_edge).as_micros();
+        last_edge = now;
+
+        if period_us < DEBOUNCE_US {
+            continue;
+        }
+        total_period_us += period_us;
+        valid += 1;
+    }
+
+    let avg_us = total_period_us / SAMPLES;
+    if avg_us == 0 {
+        return Err(());
+    }
+    Ok((1_000_000 / avg_us) as u32)
+}
+
+/// Runs the clock-detection loop for one AUX pin, breaking out to perform a
+/// frequency measurement whenever `VOCT_MEASURE_REQ[aux_idx]` is signalled.
+async fn aux_pin_loop(mut pin: Input<'_>, src: ClockSrc, aux_idx: usize) {
+    loop {
+        select(
+            make_ext_clock_loop(&mut pin, src),
+            VOCT_MEASURE_REQ[aux_idx].wait(),
+        )
+        .await;
+
+        // Measurement requested: measure and signal result; clock loop restarts.
+        let result = measure_frequency(&mut pin).await;
+        VOCT_MEASURE_RES.signal(result);
     }
 }
 
@@ -832,9 +895,9 @@ async fn run_clock_sources(aux_inputs: AuxInputs) {
     let cube = Input::new(hexagon_pin, Pull::Up);
 
     let engine_fut = run_unified_clock_engine();
-    let atom_fut = make_ext_clock_loop(atom, ClockSrc::Atom);
-    let meteor_fut = make_ext_clock_loop(meteor, ClockSrc::Meteor);
-    let cube_fut = make_ext_clock_loop(cube, ClockSrc::Cube);
+    let atom_fut = aux_pin_loop(atom, ClockSrc::Atom, 0);
+    let meteor_fut = aux_pin_loop(meteor, ClockSrc::Meteor, 1);
+    let cube_fut = aux_pin_loop(cube, ClockSrc::Cube, 2);
 
     join4(engine_fut, atom_fut, meteor_fut, cube_fut).await;
 }

--- a/faderpunk/src/tasks/configure.rs
+++ b/faderpunk/src/tasks/configure.rs
@@ -1,4 +1,5 @@
 use cobs::{decode_in_place, try_encode};
+use embassy_futures::select::{select, Either};
 use embassy_rp::peripherals::USB;
 use embassy_rp::usb::{Driver, Endpoint as UsbEndpoint, In, Out};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
@@ -10,11 +11,15 @@ use heapless::Vec;
 use postcard::{from_bytes, to_vec};
 
 use libfp::{ConfigMsgIn, ConfigMsgOut, Value, APP_MAX_PARAMS, GLOBAL_CHANNELS};
+use max11300::config::{ConfigMode0, ConfigMode5, Mode, Port, DACRANGE};
+use portable_atomic::Ordering;
 
 use crate::apps::{get_channels, get_config, REGISTERED_APP_IDS};
 use crate::layout::LAYOUT_WATCH;
 use crate::storage::factory_reset;
+use crate::tasks::clock::{VOCT_MEASURE_REQ, VOCT_MEASURE_RES};
 use crate::tasks::global_config::{get_global_config, GLOBAL_CONFIG_WATCH};
+use crate::tasks::max::{MaxCmd, MAX_CHANNEL, MAX_VALUES_DAC};
 
 use super::transport::{WebEndpoints, USB_MAX_PACKET_SIZE};
 
@@ -162,8 +167,143 @@ pub async fn start_webusb_loop<'a>(webusb: WebEndpoints<'a, Driver<'a, USB>>) {
             ConfigMsgIn::FactoryReset => {
                 factory_reset().await;
             }
+            ConfigMsgIn::MeasureVoOct {
+                output_jack,
+                aux_input,
+                dac_counts,
+            } => {
+                handle_measure_voct(&mut proto, output_jack, aux_input, dac_counts).await;
+            }
+            ConfigMsgIn::SetVoOctOutput {
+                output_jack,
+                dac_counts,
+            } => {
+                handle_set_voct_output(&mut proto, output_jack, dac_counts).await;
+            }
+            ConfigMsgIn::ReleaseVoOctOutput { output_jack } => {
+                handle_release_voct_output(&mut proto, output_jack).await;
+            }
         }
     }
+}
+
+/// Set the output jack to 0-10V DAC mode, write `dac_counts`, signal the
+/// clock task to measure frequency on the chosen AUX pin, wait for the result,
+/// then release the jack (Mode1 high-Z).
+async fn handle_measure_voct(
+    proto: &mut ConfigProtocol<'_>,
+    output_jack: u8,
+    aux_input: u8,
+    dac_counts: u16,
+) {
+    let aux_idx = aux_input as usize;
+    if aux_idx > 2 || output_jack as usize >= 16 {
+        proto.send_msg(ConfigMsgOut::VoOctCalError).await.unwrap();
+        return;
+    }
+
+    let port = match Port::try_from(output_jack as usize) {
+        Ok(p) => p,
+        Err(_) => {
+            proto.send_msg(ConfigMsgOut::VoOctCalError).await.unwrap();
+            return;
+        }
+    };
+
+    // Configure the output jack to 0-10V DAC mode.
+    MAX_CHANNEL
+        .send(MaxCmd::ConfigurePort {
+            port,
+            mode: Mode::Mode5(ConfigMode5(DACRANGE::Rg0_10v)),
+            gpo_level: None,
+        })
+        .await;
+
+    // Keep re-writing dac_counts every 5 ms so any app running on Core 1
+    // cannot permanently overwrite the calibration voltage. After 300 ms the
+    // VCO has settled; we then trigger the frequency measurement and wait for
+    // the result. The drive loop is cancelled automatically when select()
+    // returns (never() branch wins as soon as drive_and_measure completes).
+    let drive_and_measure = async {
+        MAX_VALUES_DAC[output_jack as usize].store(dac_counts, Ordering::Relaxed);
+        embassy_time::Timer::after_millis(300).await;
+        VOCT_MEASURE_REQ[aux_idx].signal(());
+        with_timeout(Duration::from_secs(10), VOCT_MEASURE_RES.wait()).await
+    };
+    let keep_driving = async {
+        loop {
+            MAX_VALUES_DAC[output_jack as usize].store(dac_counts, Ordering::Relaxed);
+            embassy_time::Timer::after_millis(5).await;
+        }
+    };
+
+    let freq_res = match select(keep_driving, drive_and_measure).await {
+        Either::Second(r) => r,
+        Either::First(_) => unreachable!(),
+    };
+
+    match freq_res {
+        Ok(Ok(freq_hz)) => {
+            proto
+                .send_msg(ConfigMsgOut::VoOctFrequency { freq_hz })
+                .await
+                .unwrap();
+        }
+        _ => {
+            proto.send_msg(ConfigMsgOut::VoOctCalError).await.unwrap();
+        }
+    }
+
+    // Release the output jack to high-Z (Mode 0) so apps can reclaim it.
+    MAX_CHANNEL
+        .send(MaxCmd::ConfigurePort {
+            port,
+            mode: Mode::Mode0(ConfigMode0),
+            gpo_level: None,
+        })
+        .await;
+}
+
+/// Set `output_jack` to 0-10V DAC mode and write `dac_counts`, then hold it
+/// there for the caller to measure manually (e.g. with an external frequency
+/// counter). The value is written once; pick a jack with no app assigned so
+/// nothing else overwrites `MAX_VALUES_DAC`.
+async fn handle_set_voct_output(proto: &mut ConfigProtocol<'_>, output_jack: u8, dac_counts: u16) {
+    let port = match Port::try_from(output_jack as usize) {
+        Ok(p) if (output_jack as usize) < 16 => p,
+        _ => {
+            proto.send_msg(ConfigMsgOut::VoOctOutputSet).await.unwrap();
+            return;
+        }
+    };
+
+    MAX_CHANNEL
+        .send(MaxCmd::ConfigurePort {
+            port,
+            mode: Mode::Mode5(ConfigMode5(DACRANGE::Rg0_10v)),
+            gpo_level: None,
+        })
+        .await;
+    MAX_VALUES_DAC[output_jack as usize].store(dac_counts, Ordering::Relaxed);
+
+    proto.send_msg(ConfigMsgOut::VoOctOutputSet).await.unwrap();
+}
+
+/// Release `output_jack` back to high-Z (Mode 0) so apps can reclaim it.
+async fn handle_release_voct_output(proto: &mut ConfigProtocol<'_>, output_jack: u8) {
+    if let Ok(port) = Port::try_from(output_jack as usize) {
+        if (output_jack as usize) < 16 {
+            MAX_CHANNEL
+                .send(MaxCmd::ConfigurePort {
+                    port,
+                    mode: Mode::Mode0(ConfigMode0),
+                    gpo_level: None,
+                })
+                .await;
+        }
+    }
+
+    proto.send_msg(ConfigMsgOut::VoOctOutputSet).await.unwrap();
 }
 
 struct ConfigProtocol<'a> {

--- a/gen-bindings/Cargo.lock
+++ b/gen-bindings/Cargo.lock
@@ -323,7 +323,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libfp"
-version = "0.10.3-beta.0"
+version = "0.10.3-beta.1"
 dependencies = [
  "embassy-time",
  "enum-ordinalize",

--- a/gen-bindings/src/main.rs
+++ b/gen-bindings/src/main.rs
@@ -23,6 +23,7 @@ fn main() {
             libfp::ConfigMsgIn,
             libfp::ConfigMsgOut,
             libfp::Curve,
+            libfp::CustomVoOctCurve,
             libfp::GlobalConfig,
             libfp::I2cMode,
             libfp::Key,

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -381,12 +381,14 @@ impl Key {
 }
 
 /// Volts-per-octave standard. Selects pitch calibration for quantizer and pitch apps.
-/// `Standard` = 1V/Oct (Eurorack), `Buchla` = 1.2V/Oct.
+/// `Standard` = 1V/Oct (Eurorack), `Buchla` = 1.2V/Oct, `Custom(idx)` = user-calibrated curve.
 #[derive(Clone, Copy, Default, Debug, PartialEq, Serialize, Deserialize, PostcardBindings)]
 pub enum VoltPerOct {
     #[default]
     Standard,
     Buchla,
+    /// Index into `GlobalConfig::custom_voct_curves` (0–3).
+    Custom(u8),
 }
 
 impl VoltPerOct {
@@ -394,6 +396,26 @@ impl VoltPerOct {
         match self {
             VoltPerOct::Standard => 410,
             VoltPerOct::Buchla => 492,
+            VoltPerOct::Custom(_) => 410,
+        }
+    }
+
+    /// Like `counts_per_oct` but resolves custom curves from the stored calibration data.
+    pub fn counts_per_oct_with_curves(self, curves: &[CustomVoOctCurve; 4]) -> i16 {
+        match self {
+            VoltPerOct::Standard => 410,
+            VoltPerOct::Buchla => 492,
+            VoltPerOct::Custom(idx) => {
+                let cpo = curves
+                    .get(idx as usize)
+                    .map(|c| c.counts_per_oct)
+                    .unwrap_or(0);
+                if cpo == 0 {
+                    410
+                } else {
+                    cpo as i16
+                }
+            }
         }
     }
 
@@ -401,6 +423,7 @@ impl VoltPerOct {
         match self {
             VoltPerOct::Standard => 12.0,
             VoltPerOct::Buchla => 10.0,
+            VoltPerOct::Custom(_) => 12.0,
         }
     }
 
@@ -408,8 +431,38 @@ impl VoltPerOct {
         match self {
             VoltPerOct::Standard => 1.0,
             VoltPerOct::Buchla => 1.2,
+            VoltPerOct::Custom(_) => 1.0,
         }
     }
+
+    /// Like `voltage_scale` but resolves custom curves from calibration data.
+    /// Derives scale from `counts_per_oct / 409.5` (the DAC counts for 1V in a 10V range).
+    pub fn voltage_scale_with_curves(self, curves: &[CustomVoOctCurve; 4]) -> f32 {
+        match self {
+            VoltPerOct::Standard => 1.0,
+            VoltPerOct::Buchla => 1.2,
+            VoltPerOct::Custom(idx) => {
+                let cpo = curves
+                    .get(idx as usize)
+                    .map(|c| c.counts_per_oct)
+                    .unwrap_or(0);
+                if cpo == 0 {
+                    1.0
+                } else {
+                    cpo as f32 / 409.5
+                }
+            }
+        }
+    }
+}
+
+/// One user-calibrated V/Oct gain curve stored in `GlobalConfig`.
+/// `counts_per_oct = 0` means uncalibrated; apps fall back to the Standard value (410).
+#[derive(Clone, Copy, Default, Serialize, Deserialize, PostcardBindings, Encode, Decode)]
+pub struct CustomVoOctCurve {
+    #[n(0)]
+    #[cbor(default)]
+    pub counts_per_oct: u16,
 }
 
 impl From<VoltPerOct> for Value {
@@ -661,6 +714,9 @@ pub struct GlobalConfig {
     #[n(6)]
     #[cbor(default)]
     pub takeover_mode: TakeoverMode,
+    #[n(7)]
+    #[cbor(default)]
+    pub custom_voct_curves: [CustomVoOctCurve; 4],
 }
 
 impl Default for GlobalConfig {
@@ -684,6 +740,7 @@ impl GlobalConfig {
             midi: MidiConfig::new(),
             quantizer: QuantizerConfig::new(),
             takeover_mode: TakeoverMode::Pickup,
+            custom_voct_curves: [CustomVoOctCurve { counts_per_oct: 0 }; 4],
         }
     }
 
@@ -1102,6 +1159,27 @@ pub enum ConfigMsgIn {
         values: [Option<Value>; APP_MAX_PARAMS],
     },
     FactoryReset,
+    /// Set `output_jack` to `dac_counts` (0-10V DAC range), then measure the
+    /// frequency on `aux_input` (0=Atom, 1=Meteor, 2=Cube). Responds with
+    /// `VoOctFrequency` or `VoOctCalError`. Call twice with dac_counts=410
+    /// then dac_counts=2460 to get the two reference frequencies.
+    MeasureVoOct {
+        output_jack: u8,
+        aux_input: u8,
+        dac_counts: u16,
+    },
+    /// Set `output_jack` to `dac_counts` (0-10V DAC range) and hold it there.
+    /// Used for manual V/Oct calibration where the user reads the resulting
+    /// frequency off an external meter. Responds with `VoOctOutputSet`.
+    SetVoOctOutput {
+        output_jack: u8,
+        dac_counts: u16,
+    },
+    /// Release `output_jack` back to high-Z so apps can reclaim it. Responds
+    /// with `VoOctOutputSet`.
+    ReleaseVoOctOutput {
+        output_jack: u8,
+    },
 }
 
 #[derive(Clone, Serialize, PostcardBindings)]
@@ -1114,6 +1192,14 @@ pub enum ConfigMsgOut<'a> {
     Layout(Layout),
     AppConfig(u8, usize, ConfigMeta<'a>),
     AppState(u8, &'a [Value]),
+    /// Frequency measured on the selected AUX input during V/Oct calibration.
+    VoOctFrequency {
+        freq_hz: u32,
+    },
+    /// V/Oct calibration measurement failed (no signal or timeout).
+    VoOctCalError,
+    /// Acknowledges `SetVoOctOutput` / `ReleaseVoOctOutput`.
+    VoOctOutputSet,
 }
 
 pub struct Config<const N: usize> {
@@ -1758,6 +1844,7 @@ mod tests {
             midi: decoded_v0.midi,
             quantizer: decoded_v0.quantizer,
             takeover_mode: decoded_v0.takeover_mode,
+            custom_voct_curves: Default::default(),
         };
         assert_eq!(migrated.led_brightness, 111);
 
@@ -1855,6 +1942,7 @@ mod tests {
             midi: decoded_v17.midi,
             quantizer: decoded_v17.quantizer,
             takeover_mode: TakeoverMode::Pickup,
+            custom_voct_curves: Default::default(),
         };
         assert_eq!(migrated.led_brightness, 111);
         assert_eq!(migrated.clock.swing_amount, 0);

--- a/libfp/src/quantizer.rs
+++ b/libfp/src/quantizer.rs
@@ -1,7 +1,7 @@
 // V/oct quantizer, based on the ideas in
 // https://github.com/pichenettes/eurorack/blob/master/braids/quantizer_scales.h
 
-use crate::{Key, MidiNote, Note, Range, VoltPerOct};
+use crate::{CustomVoOctCurve, Key, MidiNote, Note, Range, VoltPerOct};
 use heapless::Vec;
 use libm::roundf;
 
@@ -33,6 +33,26 @@ impl Pitch {
             Range::_Neg5_5V => ((scaled + 5.0) / 10.0) * 4095.0,
         };
 
+        roundf(counts).clamp(0.0, 4095.0) as u16
+    }
+
+    /// Like `as_counts` but resolves custom V/Oct curves from calibration data.
+    pub fn as_counts_with_curves(
+        &self,
+        range: Range,
+        vpo: VoltPerOct,
+        curves: &[CustomVoOctCurve; 4],
+    ) -> u16 {
+        if let Some(raw) = self.raw {
+            return raw;
+        }
+        let voltage = self.as_v_oct();
+        let scaled = voltage * vpo.voltage_scale_with_curves(curves);
+        let counts = match range {
+            Range::_0_10V => (scaled / 10.0) * 4095.0,
+            Range::_0_5V => (scaled / 5.0) * 4095.0,
+            Range::_Neg5_5V => ((scaled + 5.0) / 10.0) * 4095.0,
+        };
         roundf(counts).clamp(0.0, 4095.0) as u16
     }
 


### PR DESCRIPTION
## Summary
- Adds 4 user-calibratable "Custom" V/Oct curves, selectable alongside Standard (1V/oct) and Buchla (1.2V/oct) in output apps (notefader, tb3po, turing, seq8, quantizer, genseq).
- New Settings panel lets the user calibrate a curve via a manual 3-step wizard: firmware outputs 1V then 4V on a chosen jack, user reads the frequency off an external meter and types it in, gain is computed as `3.0 / log2(f2/f1)` and stored as `counts_per_oct`.
- Firmware: new `SetVoOctOutput` / `ReleaseVoOctOutput` WebUSB messages that drive a DAC jack to a fixed voltage and hold/release it. (An earlier auto-measurement approach via AUX GPIO frequency counting, `MeasureVoOct`, is left in place but unused by the UI for now — it proved unreliable and needs further investigation.)

## Test plan
This is a draft for further hardware testing. Checklist:
- [ ] Patch an output jack to a VCO V/Oct input, and the VCO audio out to an external frequency meter
- [ ] Settings → Custom V/Oct Curves → Calibrate on Custom 1
- [ ] Confirm jack outputs 1V (step 1), enter measured frequency, confirm it outputs 4V (step 2), enter measured frequency
- [ ] Confirm computed gain looks plausible (close to 1.0 V/Oct for a well-tracking VCO) and saves
- [ ] Select Custom 1 in a sequencer app's V/Oct param; verify pitch output uses the calibrated curve
- [ ] Power-cycle device; confirm curve persists
- [ ] Cancel mid-wizard (during step 1 or 2); confirm the jack releases back to high-Z rather than getting stuck driving a voltage