### PR TITLE
feat(voct): automated gain calibration wizard with AUX frequency measurement

### DIFF
--- a/configurator/src/components/ManualTab.tsx
+++ b/configurator/src/components/ManualTab.tsx
@@ -1682,6 +1682,9 @@ export const ManualTab = () => {
                     <Link to="#settings-aux">AUX Jacks</Link>
                   </li>
                   <li>
+                    <Link to="#settings-voct">Custom V/Oct Calibration</Link>
+                  </li>
+                  <li>
                     <Link to="#settings-misc">Miscellaneous</Link>
                   </li>
                   <li>

--- a/configurator/src/components/SettingsTab.tsx
+++ b/configurator/src/components/SettingsTab.tsx
@@ -26,6 +26,7 @@ import { I2cSettings } from "./settings/I2cSettings";
 import { MidiSettings } from "./settings/MidiSettings";
 import { MiscSettings } from "./settings/MiscSettings";
 import { QuantizerSettings } from "./settings/QuantizerSettings";
+import { VoOctCurvesSettings } from "./settings/VoOctCurvesSettings";
 
 interface SettingsFormProps {
   config: GlobalConfig;
@@ -150,19 +151,19 @@ const SettingsForm = ({ config }: SettingsFormProps) => {
   const onSubmit: SubmitHandler<Inputs> = useCallback(
     async (formValues: Inputs) => {
       if (device && !isSimulator) {
-        const config = transformFormToGlobalConfig(formValues);
-        await setGlobalConfig(device, config);
-        setConfig(config);
+        const updatedConfig = transformFormToGlobalConfig(formValues, config);
+        await setGlobalConfig(device, updatedConfig);
+        setConfig(updatedConfig);
       } else if (isSimulator) {
-        const config = transformFormToGlobalConfig(formValues);
-        setConfig(config);
+        const updatedConfig = transformFormToGlobalConfig(formValues, config);
+        setConfig(updatedConfig);
       }
       if (device || isSimulator) {
         setSaved(true);
         setTimeout(() => setSaved(false), 2000);
       }
     },
-    [device, isSimulator, setConfig],
+    [device, isSimulator, setConfig, config],
   );
 
   useEffect(() => {
@@ -182,6 +183,7 @@ const SettingsForm = ({ config }: SettingsFormProps) => {
         <MidiSettings />
         <I2cSettings />
         <MiscSettings />
+        <VoOctCurvesSettings config={config} />
         <SaveLoadSetup />
         <FactoryReset />
         <div className="flex justify-between">
@@ -262,7 +264,10 @@ const buildMidiOutConfig = (
   };
 };
 
-const transformFormToGlobalConfig = (formValues: Inputs): GlobalConfig => {
+const transformFormToGlobalConfig = (
+  formValues: Inputs,
+  currentConfig: GlobalConfig,
+): GlobalConfig => {
   const auxArray = [
     buildAuxJackMode(formValues.auxAtom, formValues.auxAtomDiv),
     buildAuxJackMode(formValues.auxMeteor, formValues.auxMeteorDiv),
@@ -312,5 +317,6 @@ const transformFormToGlobalConfig = (formValues: Inputs): GlobalConfig => {
       tonic: { tag: formValues.quantizerTonic },
     },
     takeover_mode: { tag: formValues.takeoverMode },
+    custom_voct_curves: currentConfig.custom_voct_curves,
   };
 };

--- a/configurator/src/components/input/ParamVoltPerOct.tsx
+++ b/configurator/src/components/input/ParamVoltPerOct.tsx
@@ -15,6 +15,10 @@ type Item = { key: string; value: string };
 const ITEMS: Item[] = [
   { key: "Standard", value: "1V/Oct (Eurorack)" },
   { key: "Buchla", value: "1.2V/Oct (Buchla)" },
+  { key: "Custom:0", value: "Custom 1" },
+  { key: "Custom:1", value: "Custom 2" },
+  { key: "Custom:2", value: "Custom 3" },
+  { key: "Custom:3", value: "Custom 4" },
 ];
 
 export const ParamVoltPerOct = ({

--- a/configurator/src/components/manual/Configurator.tsx
+++ b/configurator/src/components/manual/Configurator.tsx
@@ -317,11 +317,12 @@ export const Configurator = () => (
 
     <H4 id="settings-voct">Custom V/Oct Calibration</H4>
     <p>
-      Faderpunk stores up to <strong>four custom V/Oct calibration curves</strong>{" "}
-      (Custom 1–4). This allows Faderpunk to achieve near-perfect tracking with
-      any V/Oct oscillator, regardless of the calibration of either the target
-      oscillator or the Faderpunk itself. It can even allow oscillators that are
-      not designed to run on 1V/Oct to track with the pitched apps on Faderpunk.
+      Faderpunk stores up to{" "}
+      <strong>four custom V/Oct calibration curves</strong> (Custom 1–4). This
+      allows Faderpunk to achieve near-perfect tracking with any V/Oct
+      oscillator, regardless of the calibration of either the target oscillator
+      or the Faderpunk itself. It can even allow oscillators that are not
+      designed to run on 1V/Oct to track with the pitched apps on Faderpunk.
       Once calibrated, any app that has a <strong>1V/Oct</strong> parameter can
       use one of the custom curves instead of the default standard tracking.
     </p>
@@ -337,28 +338,32 @@ export const Configurator = () => (
         A VCO with a V/Oct input connected to one of the 16 Faderpunk output
         jacks
       </li>
-      <li>A tuner with frequency meter (hardware or software) connected to the VCO audio output</li>
+      <li>
+        The VCO audio output connected to one of the three AUX jacks (Atom,
+        Meteor, or Cube) — Faderpunk measures the frequency automatically
+      </li>
     </List>
     <H5>Calibration wizard</H5>
     <List>
       <li>
-        <strong>Setup</strong> — Select the Faderpunk output jack you have
-        connected to the VCO V/Oct input. For best accuracy, use a jack that
-        does not have an app assigned to it. Click <strong>Start</strong>.
+        <strong>Setup</strong> — Select the Faderpunk output jack connected to
+        the VCO V/Oct input and the AUX jack connected to the VCO audio output.
+        For best accuracy, use an output jack that does not have an app assigned
+        to it. Click <strong>Start</strong>.
       </li>
       <li>
-        <strong>Step 1 (1V)</strong> — The firmware outputs 1V on the selected
-        jack. Read the frequency shown by your meter and type it into the field,
-        then click <strong>Next</strong>.
+        <strong>1V measurement</strong> — Faderpunk outputs 1V and measures the
+        frequency on the AUX jack automatically.
       </li>
       <li>
-        <strong>Step 2 (4V)</strong> — The firmware outputs 4V. Read and enter
-        the new frequency, then click <strong>Calculate</strong>.
+        <strong>4V measurement</strong> — Faderpunk outputs 4V and measures
+        again. The V/Oct gain is calculated from the two readings.
       </li>
       <li>
-        <strong>Result</strong> — The measured V/Oct gain is displayed. Click{" "}
-        <strong>Save</strong> to store the calibration or{" "}
-        <strong>Discard</strong> to cancel.
+        <strong>Confirm</strong> — Faderpunk outputs one calibrated octave above
+        1V. Verify that your VCO is at exactly twice the 1V frequency on your
+        meter, then click <strong>Save</strong>. If the result looks off, click{" "}
+        <strong>Recalibrate</strong> to start again.
       </li>
     </List>
     <p>

--- a/configurator/src/components/manual/Configurator.tsx
+++ b/configurator/src/components/manual/Configurator.tsx
@@ -315,6 +315,59 @@ export const Configurator = () => (
       <li>4 bars</li>
     </List>
 
+    <H4 id="settings-voct">Custom V/Oct Calibration</H4>
+    <p>
+      Faderpunk stores up to <strong>four custom V/Oct calibration curves</strong>{" "}
+      (Custom 1–4). This allows Faderpunk to achieve near-perfect tracking with
+      any V/Oct oscillator, regardless of the calibration of either the target
+      oscillator or the Faderpunk itself. It can even allow oscillators that are
+      not designed to run on 1V/Oct to track with the pitched apps on Faderpunk.
+      Once calibrated, any app that has a <strong>1V/Oct</strong> parameter can
+      use one of the custom curves instead of the default standard tracking.
+    </p>
+    <p>
+      Each curve shows its measured gain next to the curve name (e.g.,{" "}
+      <em>0.998 V/Oct</em>), or <em>Not calibrated</em> if no measurement has
+      been taken yet. Click <strong>Calibrate</strong> next to a curve to open
+      the calibration wizard.
+    </p>
+    <H5>What you need</H5>
+    <List>
+      <li>
+        A VCO with a V/Oct input connected to one of the 16 Faderpunk output
+        jacks
+      </li>
+      <li>A tuner with frequency meter (hardware or software) connected to the VCO audio output</li>
+    </List>
+    <H5>Calibration wizard</H5>
+    <List>
+      <li>
+        <strong>Setup</strong> — Select the Faderpunk output jack you have
+        connected to the VCO V/Oct input. For best accuracy, use a jack that
+        does not have an app assigned to it. Click <strong>Start</strong>.
+      </li>
+      <li>
+        <strong>Step 1 (1V)</strong> — The firmware outputs 1V on the selected
+        jack. Read the frequency shown by your meter and type it into the field,
+        then click <strong>Next</strong>.
+      </li>
+      <li>
+        <strong>Step 2 (4V)</strong> — The firmware outputs 4V. Read and enter
+        the new frequency, then click <strong>Calculate</strong>.
+      </li>
+      <li>
+        <strong>Result</strong> — The measured V/Oct gain is displayed. Click{" "}
+        <strong>Save</strong> to store the calibration or{" "}
+        <strong>Discard</strong> to cancel.
+      </li>
+    </List>
+    <p>
+      The calibration is saved into the device's global configuration. It
+      survives power cycles and is included when you export a setup file. Apps
+      that use the calibrated curve automatically apply the correction without
+      needing to be reconfigured.
+    </p>
+
     <H4 id="settings-misc">Miscellaneous</H4>
     <List>
       <li>

--- a/configurator/src/components/manual/Configurator.tsx
+++ b/configurator/src/components/manual/Configurator.tsx
@@ -330,7 +330,10 @@ export const Configurator = () => (
       Each curve shows its measured gain next to the curve name (e.g.,{" "}
       <em>0.998 V/Oct</em>), or <em>Not calibrated</em> if no measurement has
       been taken yet. Click <strong>Calibrate</strong> next to a curve to open
-      the calibration wizard.
+      the calibration wizard. The wizard offers two modes:{" "}
+      <strong>Automated</strong>, where Faderpunk measures the VCO frequency
+      itself via an AUX jack, and <strong>Manual</strong>, where you read the
+      frequency off an external tuner.
     </p>
     <H5>What you need</H5>
     <List>
@@ -339,17 +342,27 @@ export const Configurator = () => (
         jacks
       </li>
       <li>
-        The VCO audio output connected to one of the three AUX jacks (Atom,
-        Meteor, or Cube) — Faderpunk measures the frequency automatically
+        For Automated mode: the VCO audio output connected to one of the three
+        AUX jacks (Atom, Meteor, or Cube) — Faderpunk measures the frequency
+        itself
+      </li>
+      <li>
+        For Manual mode: a tuner with a frequency meter (hardware or software)
+        connected to the VCO audio output
       </li>
     </List>
-    <H5>Calibration wizard</H5>
+    <p>
+      If an app is currently assigned to the output jack you calibrate on,
+      Faderpunk temporarily evicts it for the duration of the calibration and
+      restores it automatically afterward — there's no need to free up the jack
+      first.
+    </p>
+    <H5>Automated calibration wizard</H5>
     <List>
       <li>
-        <strong>Setup</strong> — Select the Faderpunk output jack connected to
-        the VCO V/Oct input and the AUX jack connected to the VCO audio output.
-        For best accuracy, use an output jack that does not have an app assigned
-        to it. Click <strong>Start</strong>.
+        <strong>Setup</strong> — Select <strong>Automated</strong>, the
+        Faderpunk output jack connected to the VCO V/Oct input, and the AUX jack
+        connected to the VCO audio output. Click <strong>Start</strong>.
       </li>
       <li>
         <strong>1V measurement</strong> — Faderpunk outputs 1V and measures the
@@ -361,8 +374,31 @@ export const Configurator = () => (
       </li>
       <li>
         <strong>Confirm</strong> — Faderpunk outputs one calibrated octave above
-        1V. Verify that your VCO is at exactly twice the 1V frequency on your
-        meter, then click <strong>Save</strong>. If the result looks off, click{" "}
+        1V and re-measures automatically, showing the deviation in cents. Click{" "}
+        <strong>Save</strong> if the result looks accurate, or{" "}
+        <strong>Recalibrate</strong> to start again.
+      </li>
+    </List>
+    <H5>Manual calibration wizard</H5>
+    <List>
+      <li>
+        <strong>Setup</strong> — Select <strong>Manual</strong> and the
+        Faderpunk output jack connected to the VCO V/Oct input. Click{" "}
+        <strong>Start</strong>.
+      </li>
+      <li>
+        <strong>1V measurement</strong> — Faderpunk outputs 1V. Read the
+        frequency from your tuner and enter it, then click <strong>Next</strong>
+        .
+      </li>
+      <li>
+        <strong>4V measurement</strong> — Faderpunk outputs 4V. Read the new
+        frequency from your tuner and enter it, then click{" "}
+        <strong>Calculate</strong>.
+      </li>
+      <li>
+        <strong>Confirm</strong> — The calculated V/Oct gain is displayed. Click{" "}
+        <strong>Save</strong> to store the calibration, or{" "}
         <strong>Recalibrate</strong> to start again.
       </li>
     </List>

--- a/configurator/src/components/settings/VoOctCurvesSettings.tsx
+++ b/configurator/src/components/settings/VoOctCurvesSettings.tsx
@@ -28,6 +28,11 @@ const OCTAVE_SPAN = 3.0; // 4V - 1V at standard 1V/oct
 const MAX_PLAUSIBLE_COUNTS_PER_OCT = 2000;
 // MAX11300 DAC resolution (12-bit).
 const MAX_DAC_COUNTS = 4095;
+// MeasureVoOct's own worst case on the firmware is a 30s measurement window
+// (see with_timeout(Duration::from_secs(30), ...) in tasks/voct_freq.rs) plus
+// a 300ms pre-settle delay — comfortably below the default 2s protocol
+// timeout used for fast request/response commands, so it needs its own.
+const MEASURE_TIMEOUT_MS = 32_000;
 
 type WizardMode = "auto" | "manual";
 
@@ -135,14 +140,18 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
       setWizardStep({ type: "measuring1" });
       let r1;
       try {
-        r1 = await sendAndReceive(device, {
-          tag: "MeasureVoOct",
-          value: {
-            output_jack: jack,
-            aux_input: aux,
-            dac_counts: LOW_DAC_COUNTS,
+        r1 = await sendAndReceive(
+          device,
+          {
+            tag: "MeasureVoOct",
+            value: {
+              output_jack: jack,
+              aux_input: aux,
+              dac_counts: LOW_DAC_COUNTS,
+            },
           },
-        });
+          MEASURE_TIMEOUT_MS,
+        );
       } catch (e) {
         setWizardStep({ type: "error", message: String(e) });
         return;
@@ -160,14 +169,18 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
       setWizardStep({ type: "measuring2", f1 });
       let r2;
       try {
-        r2 = await sendAndReceive(device, {
-          tag: "MeasureVoOct",
-          value: {
-            output_jack: jack,
-            aux_input: aux,
-            dac_counts: HIGH_DAC_COUNTS,
+        r2 = await sendAndReceive(
+          device,
+          {
+            tag: "MeasureVoOct",
+            value: {
+              output_jack: jack,
+              aux_input: aux,
+              dac_counts: HIGH_DAC_COUNTS,
+            },
           },
-        });
+          MEASURE_TIMEOUT_MS,
+        );
       } catch (e) {
         setWizardStep({ type: "error", message: String(e) });
         return;
@@ -223,14 +236,18 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
 
       let rConfirm;
       try {
-        rConfirm = await sendAndReceive(device, {
-          tag: "MeasureVoOct",
-          value: {
-            output_jack: jack,
-            aux_input: aux,
-            dac_counts: confirmDacCounts,
+        rConfirm = await sendAndReceive(
+          device,
+          {
+            tag: "MeasureVoOct",
+            value: {
+              output_jack: jack,
+              aux_input: aux,
+              dac_counts: confirmDacCounts,
+            },
           },
-        });
+          MEASURE_TIMEOUT_MS,
+        );
       } catch (e) {
         setWizardStep({ type: "error", message: String(e) });
         return;

--- a/configurator/src/components/settings/VoOctCurvesSettings.tsx
+++ b/configurator/src/components/settings/VoOctCurvesSettings.tsx
@@ -1,0 +1,315 @@
+import type { GlobalConfig } from "@atov/fp-config";
+import { useCallback, useState } from "react";
+import { Input } from "@heroui/input";
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/modal";
+import { Select, SelectItem } from "@heroui/select";
+
+import { useStore } from "../../store";
+import { setGlobalConfig } from "../../utils/config";
+import { sendAndReceive } from "../../utils/usb-protocol";
+import { ButtonPrimary, ButtonSecondary } from "../Button";
+
+interface Props {
+  config: GlobalConfig;
+}
+
+const LOW_DAC_COUNTS = 410; // 1V
+const HIGH_DAC_COUNTS = 1638; // 4V
+const OCTAVE_SPAN = 3.0; // 4V - 1V at standard 1V/oct
+
+type WizardStep =
+  | { type: "setup" }
+  | { type: "step1" }
+  | { type: "step2" }
+  | { type: "done"; countsPerOct: number; gain: number }
+  | { type: "error"; message: string };
+
+const CURVE_LABELS = ["Custom 1", "Custom 2", "Custom 3", "Custom 4"] as const;
+
+const JACK_OPTIONS = Array.from({ length: 16 }, (_, i) => ({
+  key: String(i),
+  label: `Jack ${i + 1}`,
+}));
+
+const formatGain = (countsPerOct: number): string =>
+  `${(countsPerOct / 410).toFixed(3)} V/Oct`;
+
+export const VoOctCurvesSettings = ({ config }: Props) => {
+  const { usbDevice, isSimulator, setConfig } = useStore();
+
+  const [openCurveIdx, setOpenCurveIdx] = useState<number | null>(null);
+  const [outputJack, setOutputJack] = useState("0");
+  const [wizardStep, setWizardStep] = useState<WizardStep>({ type: "setup" });
+  const [freqInput, setFreqInput] = useState("");
+  const [f1, setF1] = useState<number | null>(null);
+
+  const releaseOutput = useCallback(
+    (jack: string) => {
+      if (!usbDevice) return;
+      sendAndReceive(usbDevice, {
+        tag: "ReleaseVoOctOutput",
+        value: { output_jack: parseInt(jack, 10) },
+      }).catch(() => {});
+    },
+    [usbDevice],
+  );
+
+  const handleOpenWizard = useCallback((idx: number) => {
+    setOpenCurveIdx(idx);
+    setWizardStep({ type: "setup" });
+    setFreqInput("");
+    setF1(null);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    if (wizardStep.type === "step1" || wizardStep.type === "step2") {
+      releaseOutput(outputJack);
+    }
+    setOpenCurveIdx(null);
+  }, [wizardStep, outputJack, releaseOutput]);
+
+  const handleStart = useCallback(async () => {
+    if (!usbDevice || openCurveIdx === null) return;
+    try {
+      const r = await sendAndReceive(usbDevice, {
+        tag: "SetVoOctOutput",
+        value: {
+          output_jack: parseInt(outputJack, 10),
+          dac_counts: LOW_DAC_COUNTS,
+        },
+      });
+      if (r.tag !== "VoOctOutputSet") {
+        setWizardStep({ type: "error", message: "Failed to set output." });
+        return;
+      }
+      setFreqInput("");
+      setWizardStep({ type: "step1" });
+    } catch (e) {
+      setWizardStep({ type: "error", message: String(e) });
+    }
+  }, [usbDevice, openCurveIdx, outputJack]);
+
+  const handleStep1Next = useCallback(async () => {
+    if (!usbDevice) return;
+    const f1Val = parseFloat(freqInput);
+    if (!Number.isFinite(f1Val) || f1Val <= 0) return;
+
+    try {
+      const r = await sendAndReceive(usbDevice, {
+        tag: "SetVoOctOutput",
+        value: {
+          output_jack: parseInt(outputJack, 10),
+          dac_counts: HIGH_DAC_COUNTS,
+        },
+      });
+      if (r.tag !== "VoOctOutputSet") {
+        setWizardStep({ type: "error", message: "Failed to set output." });
+        return;
+      }
+      setF1(f1Val);
+      setFreqInput("");
+      setWizardStep({ type: "step2" });
+    } catch (e) {
+      setWizardStep({ type: "error", message: String(e) });
+    }
+  }, [usbDevice, freqInput, outputJack]);
+
+  const handleStep2Calculate = useCallback(async () => {
+    if (f1 === null) return;
+    const f2Val = parseFloat(freqInput);
+    if (!Number.isFinite(f2Val) || f2Val <= 0) return;
+
+    releaseOutput(outputJack);
+
+    const gain = OCTAVE_SPAN / Math.log2(f2Val / f1);
+    const countsPerOct = Math.round(gain * 410);
+    setWizardStep({ type: "done", countsPerOct, gain });
+  }, [f1, freqInput, outputJack, releaseOutput]);
+
+  const handleSave = useCallback(async () => {
+    if (openCurveIdx === null || wizardStep.type !== "done") return;
+
+    const updatedCurves = [
+      ...config.custom_voct_curves,
+    ] as unknown as typeof config.custom_voct_curves;
+    updatedCurves[openCurveIdx] = { counts_per_oct: wizardStep.countsPerOct };
+    const updatedConfig: GlobalConfig = {
+      ...config,
+      custom_voct_curves: updatedCurves,
+    };
+
+    if (usbDevice && !isSimulator) {
+      await setGlobalConfig(usbDevice, updatedConfig);
+    }
+    setConfig(updatedConfig);
+    setOpenCurveIdx(null);
+  }, [openCurveIdx, wizardStep, config, usbDevice, isSimulator, setConfig]);
+
+  return (
+    <div className="mb-12">
+      <h2 className="text-yellow-fp mb-4 text-sm font-bold uppercase">
+        Custom V/Oct Curves
+      </h2>
+      <div className="flex flex-col gap-y-4 px-4">
+        {CURVE_LABELS.map((label, idx) => {
+          const cpo = config.custom_voct_curves[idx]?.counts_per_oct ?? 0;
+          return (
+            <div key={idx} className="flex items-center justify-between">
+              <span className="text-sm font-medium">{label}</span>
+              <span className="text-sm text-gray-400">
+                {cpo === 0 ? "Not calibrated" : formatGain(cpo)}
+              </span>
+              <ButtonSecondary
+                size="sm"
+                onPress={() => handleOpenWizard(idx)}
+                isDisabled={!usbDevice || isSimulator}
+              >
+                Calibrate
+              </ButtonSecondary>
+            </div>
+          );
+        })}
+      </div>
+
+      <Modal
+        isOpen={openCurveIdx !== null}
+        onOpenChange={(open) => {
+          if (!open) handleClose();
+        }}
+      >
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader>
+                Calibrate{" "}
+                {openCurveIdx !== null ? CURVE_LABELS[openCurveIdx] : ""}
+              </ModalHeader>
+              <ModalBody>
+                {wizardStep.type === "setup" && (
+                  <div className="flex flex-col gap-y-4">
+                    <p className="text-sm">
+                      Connect an output jack to a VCO V/Oct input, and the VCO
+                      audio output to your frequency meter. Use a jack with no
+                      app assigned for best accuracy.
+                    </p>
+                    <Select
+                      label="Output jack"
+                      selectedKeys={[outputJack]}
+                      onSelectionChange={(keys) =>
+                        setOutputJack([...keys][0] as string)
+                      }
+                      items={JACK_OPTIONS}
+                    >
+                      {(item) => (
+                        <SelectItem key={item.key}>{item.label}</SelectItem>
+                      )}
+                    </Select>
+                  </div>
+                )}
+                {wizardStep.type === "step1" && (
+                  <div className="flex flex-col gap-y-4">
+                    <p className="text-sm">
+                      Outputting 1V. Read the frequency from your meter and
+                      enter it below.
+                    </p>
+                    <Input
+                      label="Measured frequency (Hz)"
+                      type="number"
+                      value={freqInput}
+                      onValueChange={setFreqInput}
+                    />
+                  </div>
+                )}
+                {wizardStep.type === "step2" && (
+                  <div className="flex flex-col gap-y-4">
+                    <p className="text-sm">
+                      Outputting 4V. Read the frequency from your meter and
+                      enter it below.
+                    </p>
+                    <Input
+                      label="Measured frequency (Hz)"
+                      type="number"
+                      value={freqInput}
+                      onValueChange={setFreqInput}
+                    />
+                  </div>
+                )}
+                {wizardStep.type === "done" && (
+                  <div className="flex flex-col gap-y-2">
+                    <p className="text-sm font-medium">
+                      Measured: {formatGain(wizardStep.countsPerOct)}
+                    </p>
+                    <p className="text-xs text-gray-400">
+                      ({wizardStep.countsPerOct} counts/oct)
+                    </p>
+                  </div>
+                )}
+                {wizardStep.type === "error" && (
+                  <p className="text-sm text-red-400">{wizardStep.message}</p>
+                )}
+              </ModalBody>
+              <ModalFooter>
+                {wizardStep.type === "setup" && (
+                  <>
+                    <ButtonPrimary onPress={handleStart}>Start</ButtonPrimary>
+                    <ButtonSecondary onPress={onClose}>Cancel</ButtonSecondary>
+                  </>
+                )}
+                {wizardStep.type === "step1" && (
+                  <>
+                    <ButtonPrimary
+                      onPress={handleStep1Next}
+                      isDisabled={
+                        !Number.isFinite(parseFloat(freqInput)) ||
+                        parseFloat(freqInput) <= 0
+                      }
+                    >
+                      Next
+                    </ButtonPrimary>
+                    <ButtonSecondary onPress={onClose}>Cancel</ButtonSecondary>
+                  </>
+                )}
+                {wizardStep.type === "step2" && (
+                  <>
+                    <ButtonPrimary
+                      onPress={handleStep2Calculate}
+                      isDisabled={
+                        !Number.isFinite(parseFloat(freqInput)) ||
+                        parseFloat(freqInput) <= 0
+                      }
+                    >
+                      Calculate
+                    </ButtonPrimary>
+                    <ButtonSecondary onPress={onClose}>Cancel</ButtonSecondary>
+                  </>
+                )}
+                {wizardStep.type === "done" && (
+                  <>
+                    <ButtonPrimary onPress={handleSave}>Save</ButtonPrimary>
+                    <ButtonSecondary onPress={onClose}>Discard</ButtonSecondary>
+                  </>
+                )}
+                {wizardStep.type === "error" && (
+                  <>
+                    <ButtonPrimary
+                      onPress={() => setWizardStep({ type: "setup" })}
+                    >
+                      Retry
+                    </ButtonPrimary>
+                    <ButtonSecondary onPress={onClose}>Cancel</ButtonSecondary>
+                  </>
+                )}
+              </ModalFooter>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
+    </div>
+  );
+};

--- a/configurator/src/components/settings/VoOctCurvesSettings.tsx
+++ b/configurator/src/components/settings/VoOctCurvesSettings.tsx
@@ -68,7 +68,7 @@ const parseFreq = (s: string): number | null => {
 };
 
 export const VoOctCurvesSettings = ({ config }: Props) => {
-  const { device, isSimulator, setConfig } = useStore();
+  const { device, isSimulator, setConfig, setSuspendHealthCheck } = useStore();
 
   const [openCurveIdx, setOpenCurveIdx] = useState<number | null>(null);
   const [wizardMode, setWizardMode] = useState<WizardMode>("auto");
@@ -126,123 +126,134 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
     const aux = parseInt(auxInput, 10);
     if (!Number.isFinite(jack) || !Number.isFinite(aux)) return;
 
-    setWizardStep({ type: "measuring1" });
-    let r1;
+    // MeasureVoOct blocks the firmware's single-threaded config loop for as
+    // long as the measurement takes (up to 30s). Suspend the connection
+    // health check for the duration so it doesn't mistake the resulting slow
+    // response for a dropped connection and force-navigate away mid-wizard.
+    setSuspendHealthCheck(true);
     try {
-      r1 = await sendAndReceive(device, {
-        tag: "MeasureVoOct",
-        value: {
-          output_jack: jack,
-          aux_input: aux,
-          dac_counts: LOW_DAC_COUNTS,
-        },
-      });
-    } catch (e) {
-      setWizardStep({ type: "error", message: String(e) });
-      return;
-    }
-    if (r1.tag !== "VoOctFrequency") {
+      setWizardStep({ type: "measuring1" });
+      let r1;
+      try {
+        r1 = await sendAndReceive(device, {
+          tag: "MeasureVoOct",
+          value: {
+            output_jack: jack,
+            aux_input: aux,
+            dac_counts: LOW_DAC_COUNTS,
+          },
+        });
+      } catch (e) {
+        setWizardStep({ type: "error", message: String(e) });
+        return;
+      }
+      if (r1.tag !== "VoOctFrequency") {
+        setWizardStep({
+          type: "error",
+          message:
+            "No signal detected at 1V. Check AUX jack and VCO connections.",
+        });
+        return;
+      }
+      const f1 = r1.value.freq_hz;
+
+      setWizardStep({ type: "measuring2", f1 });
+      let r2;
+      try {
+        r2 = await sendAndReceive(device, {
+          tag: "MeasureVoOct",
+          value: {
+            output_jack: jack,
+            aux_input: aux,
+            dac_counts: HIGH_DAC_COUNTS,
+          },
+        });
+      } catch (e) {
+        setWizardStep({ type: "error", message: String(e) });
+        return;
+      }
+      if (r2.tag !== "VoOctFrequency") {
+        setWizardStep({
+          type: "error",
+          message:
+            "No signal detected at 4V. Check AUX jack and VCO connections.",
+        });
+        return;
+      }
+      const f2 = r2.value.freq_hz;
+
+      const countsPerOct = Math.round((OCTAVE_SPAN / Math.log2(f2 / f1)) * 410);
+
+      if (countsPerOct <= 0 || countsPerOct > MAX_PLAUSIBLE_COUNTS_PER_OCT) {
+        setWizardStep({
+          type: "error",
+          message:
+            countsPerOct <= 0
+              ? `VCO frequency went down from 1V to 4V (${f1.toFixed(1)} Hz → ${f2.toFixed(1)} Hz). Check output jack and VCO V/Oct wiring.`
+              : `Calculated gain (${countsPerOct} counts/oct) is out of range. Check connections.`,
+        });
+        return;
+      }
+
+      // Confirm by outputting one countsPerOct above LOW (1V), staying within
+      // the 1–4V calibration range. Pre-set the output now via
+      // SetVoOctOutput so the VCO can settle downward from 4V during the
+      // 800 ms UI wait, before the firmware's own settle window starts.
+      const confirmDacCounts = LOW_DAC_COUNTS + countsPerOct;
+      if (confirmDacCounts > MAX_DAC_COUNTS) {
+        setWizardStep({ type: "confirm", countsPerOct, f1, fConfirm: null });
+        return;
+      }
+
+      setWizardStep({ type: "measuring_confirm", countsPerOct, f1 });
+
+      // Pre-settle: bring the output to confirmDacCounts now. Errors are
+      // ignored; MeasureVoOct will reconfigure the port regardless.
+      try {
+        await sendAndReceive(device, {
+          tag: "SetVoOctOutput",
+          value: { output_jack: jack, dac_counts: confirmDacCounts },
+        });
+      } catch {
+        // ignore — MeasureVoOct below will configure the port itself
+      }
+      // Give the VCO extra time to settle downward before the firmware
+      // window.
+      await new Promise<void>((r) => setTimeout(r, 800));
+
+      let rConfirm;
+      try {
+        rConfirm = await sendAndReceive(device, {
+          tag: "MeasureVoOct",
+          value: {
+            output_jack: jack,
+            aux_input: aux,
+            dac_counts: confirmDacCounts,
+          },
+        });
+      } catch (e) {
+        setWizardStep({ type: "error", message: String(e) });
+        return;
+      }
+      if (rConfirm.tag !== "VoOctFrequency") {
+        setWizardStep({
+          type: "error",
+          message:
+            "Verification measurement failed. Check AUX jack connection.",
+        });
+        return;
+      }
+
       setWizardStep({
-        type: "error",
-        message:
-          "No signal detected at 1V. Check AUX jack and VCO connections.",
+        type: "confirm",
+        countsPerOct,
+        f1,
+        fConfirm: rConfirm.value.freq_hz,
       });
-      return;
+    } finally {
+      setSuspendHealthCheck(false);
     }
-    const f1 = r1.value.freq_hz;
-
-    setWizardStep({ type: "measuring2", f1 });
-    let r2;
-    try {
-      r2 = await sendAndReceive(device, {
-        tag: "MeasureVoOct",
-        value: {
-          output_jack: jack,
-          aux_input: aux,
-          dac_counts: HIGH_DAC_COUNTS,
-        },
-      });
-    } catch (e) {
-      setWizardStep({ type: "error", message: String(e) });
-      return;
-    }
-    if (r2.tag !== "VoOctFrequency") {
-      setWizardStep({
-        type: "error",
-        message:
-          "No signal detected at 4V. Check AUX jack and VCO connections.",
-      });
-      return;
-    }
-    const f2 = r2.value.freq_hz;
-
-    const countsPerOct = Math.round((OCTAVE_SPAN / Math.log2(f2 / f1)) * 410);
-
-    if (countsPerOct <= 0 || countsPerOct > MAX_PLAUSIBLE_COUNTS_PER_OCT) {
-      setWizardStep({
-        type: "error",
-        message:
-          countsPerOct <= 0
-            ? `VCO frequency went down from 1V to 4V (${f1.toFixed(1)} Hz → ${f2.toFixed(1)} Hz). Check output jack and VCO V/Oct wiring.`
-            : `Calculated gain (${countsPerOct} counts/oct) is out of range. Check connections.`,
-      });
-      return;
-    }
-
-    // Confirm by outputting one countsPerOct above LOW (1V), staying within the
-    // 1–4V calibration range. Pre-set the output now via SetVoOctOutput so the
-    // VCO can settle downward from 4V during the 800 ms UI wait, before the
-    // firmware's own settle window starts.
-    const confirmDacCounts = LOW_DAC_COUNTS + countsPerOct;
-    if (confirmDacCounts > MAX_DAC_COUNTS) {
-      setWizardStep({ type: "confirm", countsPerOct, f1, fConfirm: null });
-      return;
-    }
-
-    setWizardStep({ type: "measuring_confirm", countsPerOct, f1 });
-
-    // Pre-settle: bring the output to confirmDacCounts now. Errors are ignored;
-    // MeasureVoOct will reconfigure the port regardless.
-    try {
-      await sendAndReceive(device, {
-        tag: "SetVoOctOutput",
-        value: { output_jack: jack, dac_counts: confirmDacCounts },
-      });
-    } catch {
-      // ignore — MeasureVoOct below will configure the port itself
-    }
-    // Give the VCO extra time to settle downward before the firmware window.
-    await new Promise<void>((r) => setTimeout(r, 800));
-
-    let rConfirm;
-    try {
-      rConfirm = await sendAndReceive(device, {
-        tag: "MeasureVoOct",
-        value: {
-          output_jack: jack,
-          aux_input: aux,
-          dac_counts: confirmDacCounts,
-        },
-      });
-    } catch (e) {
-      setWizardStep({ type: "error", message: String(e) });
-      return;
-    }
-    if (rConfirm.tag !== "VoOctFrequency") {
-      setWizardStep({
-        type: "error",
-        message: "Verification measurement failed. Check AUX jack connection.",
-      });
-      return;
-    }
-
-    setWizardStep({
-      type: "confirm",
-      countsPerOct,
-      f1,
-      fConfirm: rConfirm.value.freq_hz,
-    });
-  }, [device, openCurveIdx, outputJack, auxInput]);
+  }, [device, openCurveIdx, outputJack, auxInput, setSuspendHealthCheck]);
 
   // --- Manual flow ---
 

--- a/configurator/src/components/settings/VoOctCurvesSettings.tsx
+++ b/configurator/src/components/settings/VoOctCurvesSettings.tsx
@@ -398,6 +398,9 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
 
       <Modal
         isOpen={openCurveIdx !== null}
+        isDismissable={!isMeasuring}
+        isKeyboardDismissDisabled={isMeasuring}
+        hideCloseButton={isMeasuring}
         onOpenChange={(open) => {
           if (!open) handleClose();
         }}
@@ -413,6 +416,11 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
                 <span className="text-xs font-normal text-gray-400">
                   Don&apos;t refresh or close this page while calibrating.
                 </span>
+                {isMeasuring && (
+                  <span className="text-xs font-normal text-gray-400">
+                    This step finishes on its own within about 30 seconds.
+                  </span>
+                )}
               </ModalHeader>
 
               <ModalBody>
@@ -648,10 +656,6 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
                     </ButtonPrimary>
                     <ButtonSecondary onPress={onClose}>Cancel</ButtonSecondary>
                   </>
-                )}
-
-                {isMeasuring && (
-                  <ButtonSecondary onPress={onClose}>Cancel</ButtonSecondary>
                 )}
 
                 {wizardStep.type === "manual_enter1" && (

--- a/configurator/src/components/settings/VoOctCurvesSettings.tsx
+++ b/configurator/src/components/settings/VoOctCurvesSettings.tsx
@@ -12,7 +12,7 @@ import { Select, SelectItem } from "@heroui/select";
 
 import { useStore } from "../../store";
 import { setGlobalConfig } from "../../utils/config";
-import { sendAndReceive } from "../../utils/usb-protocol";
+import { sendAndReceive } from "../../utils/midi-protocol";
 import { ButtonPrimary, ButtonSecondary } from "../Button";
 
 interface Props {
@@ -68,7 +68,7 @@ const parseFreq = (s: string): number | null => {
 };
 
 export const VoOctCurvesSettings = ({ config }: Props) => {
-  const { usbDevice, isSimulator, setConfig } = useStore();
+  const { device, isSimulator, setConfig } = useStore();
 
   const [openCurveIdx, setOpenCurveIdx] = useState<number | null>(null);
   const [wizardMode, setWizardMode] = useState<WizardMode>("auto");
@@ -78,7 +78,7 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
   const [manualF1, setManualF1] = useState("");
   const [manualF2, setManualF2] = useState("");
 
-  // Refreshing/closing the tab mid-calibration drops the WebUSB connection,
+  // Refreshing/closing the tab mid-calibration drops the MIDI connection,
   // which can leave the jack's app evicted until the device is rebooted (the
   // firmware has no way to detect a clean session end vs. a dropped
   // connection). Warn before the browser navigates away while the wizard is
@@ -107,20 +107,20 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
     if (
       (wizardStep.type === "manual_enter1" ||
         wizardStep.type === "manual_enter2") &&
-      usbDevice
+      device
     ) {
-      void sendAndReceive(usbDevice, {
+      void sendAndReceive(device, {
         tag: "ReleaseVoOctOutput",
         value: { output_jack: parseInt(outputJack, 10) },
       }).catch(() => {});
     }
     setOpenCurveIdx(null);
-  }, [wizardStep, usbDevice, outputJack]);
+  }, [wizardStep, device, outputJack]);
 
   // --- Automated flow ---
 
   const handleStartAuto = useCallback(async () => {
-    if (!usbDevice || openCurveIdx === null) return;
+    if (!device || openCurveIdx === null) return;
 
     const jack = parseInt(outputJack, 10);
     const aux = parseInt(auxInput, 10);
@@ -129,7 +129,7 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
     setWizardStep({ type: "measuring1" });
     let r1;
     try {
-      r1 = await sendAndReceive(usbDevice, {
+      r1 = await sendAndReceive(device, {
         tag: "MeasureVoOct",
         value: {
           output_jack: jack,
@@ -154,7 +154,7 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
     setWizardStep({ type: "measuring2", f1 });
     let r2;
     try {
-      r2 = await sendAndReceive(usbDevice, {
+      r2 = await sendAndReceive(device, {
         tag: "MeasureVoOct",
         value: {
           output_jack: jack,
@@ -204,7 +204,7 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
     // Pre-settle: bring the output to confirmDacCounts now. Errors are ignored;
     // MeasureVoOct will reconfigure the port regardless.
     try {
-      await sendAndReceive(usbDevice, {
+      await sendAndReceive(device, {
         tag: "SetVoOctOutput",
         value: { output_jack: jack, dac_counts: confirmDacCounts },
       });
@@ -216,7 +216,7 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
 
     let rConfirm;
     try {
-      rConfirm = await sendAndReceive(usbDevice, {
+      rConfirm = await sendAndReceive(device, {
         tag: "MeasureVoOct",
         value: {
           output_jack: jack,
@@ -242,16 +242,16 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
       f1,
       fConfirm: rConfirm.value.freq_hz,
     });
-  }, [usbDevice, openCurveIdx, outputJack, auxInput]);
+  }, [device, openCurveIdx, outputJack, auxInput]);
 
   // --- Manual flow ---
 
   const handleStartManual = useCallback(async () => {
-    if (!usbDevice || openCurveIdx === null) return;
+    if (!device || openCurveIdx === null) return;
 
     const jack = parseInt(outputJack, 10);
     try {
-      const r = await sendAndReceive(usbDevice, {
+      const r = await sendAndReceive(device, {
         tag: "SetVoOctOutput",
         value: { output_jack: jack, dac_counts: LOW_DAC_COUNTS },
       });
@@ -262,16 +262,16 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
     }
     setManualF1("");
     setWizardStep({ type: "manual_enter1" });
-  }, [usbDevice, openCurveIdx, outputJack]);
+  }, [device, openCurveIdx, outputJack]);
 
   const handleManualNext = useCallback(async () => {
-    if (!usbDevice) return;
+    if (!device) return;
     const f1 = parseFreq(manualF1);
     if (f1 === null) return;
 
     const jack = parseInt(outputJack, 10);
     try {
-      const r = await sendAndReceive(usbDevice, {
+      const r = await sendAndReceive(device, {
         tag: "SetVoOctOutput",
         value: { output_jack: jack, dac_counts: HIGH_DAC_COUNTS },
       });
@@ -282,16 +282,16 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
     }
     setManualF2("");
     setWizardStep({ type: "manual_enter2", f1 });
-  }, [usbDevice, outputJack, manualF1]);
+  }, [device, outputJack, manualF1]);
 
   const handleManualCalculate = useCallback(async () => {
-    if (!usbDevice || wizardStep.type !== "manual_enter2") return;
+    if (!device || wizardStep.type !== "manual_enter2") return;
     const f2 = parseFreq(manualF2);
     if (f2 === null) return;
 
     const { f1 } = wizardStep;
     try {
-      await sendAndReceive(usbDevice, {
+      await sendAndReceive(device, {
         tag: "ReleaseVoOctOutput",
         value: { output_jack: parseInt(outputJack, 10) },
       });
@@ -312,7 +312,7 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
       return;
     }
     setWizardStep({ type: "confirm", countsPerOct, f1, fConfirm: null });
-  }, [usbDevice, wizardStep, manualF2, outputJack]);
+  }, [device, wizardStep, manualF2, outputJack]);
 
   // --- Save ---
 
@@ -328,12 +328,12 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
       custom_voct_curves: updatedCurves,
     };
 
-    if (usbDevice && !isSimulator) {
-      await setGlobalConfig(usbDevice, updatedConfig);
+    if (device && !isSimulator) {
+      await setGlobalConfig(device, updatedConfig);
     }
     setConfig(updatedConfig);
     setOpenCurveIdx(null);
-  }, [openCurveIdx, wizardStep, config, usbDevice, isSimulator, setConfig]);
+  }, [openCurveIdx, wizardStep, config, device, isSimulator, setConfig]);
 
   // -------------------- render --------------------
 
@@ -359,7 +359,7 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
               <ButtonSecondary
                 size="sm"
                 onPress={() => handleOpenWizard(idx)}
-                isDisabled={!usbDevice || isSimulator}
+                isDisabled={!device || isSimulator}
               >
                 Calibrate
               </ButtonSecondary>

--- a/configurator/src/components/settings/VoOctCurvesSettings.tsx
+++ b/configurator/src/components/settings/VoOctCurvesSettings.tsx
@@ -22,6 +22,12 @@ interface Props {
 const LOW_DAC_COUNTS = 410; // 1V
 const HIGH_DAC_COUNTS = 1638; // 4V
 const OCTAVE_SPAN = 3.0; // 4V - 1V at standard 1V/oct
+// Matches the firmware's plausibility clamp (libfp's resolve_custom_cpo) so a
+// bad calibration is rejected here with a clear error instead of silently
+// falling back to the Standard gain later.
+const MAX_PLAUSIBLE_COUNTS_PER_OCT = 2000;
+// MAX11300 DAC resolution (12-bit).
+const MAX_DAC_COUNTS = 4095;
 
 type WizardMode = "auto" | "manual";
 
@@ -172,7 +178,7 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
 
     const countsPerOct = Math.round((OCTAVE_SPAN / Math.log2(f2 / f1)) * 410);
 
-    if (countsPerOct <= 0 || countsPerOct > 60000) {
+    if (countsPerOct <= 0 || countsPerOct > MAX_PLAUSIBLE_COUNTS_PER_OCT) {
       setWizardStep({
         type: "error",
         message:
@@ -188,7 +194,7 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
     // VCO can settle downward from 4V during the 800 ms UI wait, before the
     // firmware's own settle window starts.
     const confirmDacCounts = LOW_DAC_COUNTS + countsPerOct;
-    if (confirmDacCounts > 65535) {
+    if (confirmDacCounts > MAX_DAC_COUNTS) {
       setWizardStep({ type: "confirm", countsPerOct, f1, fConfirm: null });
       return;
     }
@@ -295,6 +301,16 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
     }
 
     const countsPerOct = Math.round((OCTAVE_SPAN / Math.log2(f2 / f1)) * 410);
+    if (countsPerOct <= 0 || countsPerOct > MAX_PLAUSIBLE_COUNTS_PER_OCT) {
+      setWizardStep({
+        type: "error",
+        message:
+          countsPerOct <= 0
+            ? `VCO frequency went down from 1V to 4V. Check output jack and VCO V/Oct wiring.`
+            : `Calculated gain (${countsPerOct} counts/oct) is out of range. Check connections.`,
+      });
+      return;
+    }
     setWizardStep({ type: "confirm", countsPerOct, f1, fConfirm: null });
   }, [usbDevice, wizardStep, manualF2, outputJack]);
 

--- a/configurator/src/components/settings/VoOctCurvesSettings.tsx
+++ b/configurator/src/components/settings/VoOctCurvesSettings.tsx
@@ -1,6 +1,5 @@
 import type { GlobalConfig } from "@atov/fp-config";
 import { useCallback, useState } from "react";
-import { Input } from "@heroui/input";
 import {
   Modal,
   ModalBody,
@@ -8,6 +7,7 @@ import {
   ModalFooter,
   ModalHeader,
 } from "@heroui/modal";
+import { Input } from "@heroui/input";
 import { Select, SelectItem } from "@heroui/select";
 
 import { useStore } from "../../store";
@@ -23,11 +23,21 @@ const LOW_DAC_COUNTS = 410; // 1V
 const HIGH_DAC_COUNTS = 1638; // 4V
 const OCTAVE_SPAN = 3.0; // 4V - 1V at standard 1V/oct
 
+type WizardMode = "auto" | "manual";
+
 type WizardStep =
   | { type: "setup" }
-  | { type: "step1" }
-  | { type: "step2" }
-  | { type: "done"; countsPerOct: number; gain: number }
+  | { type: "measuring1" }
+  | { type: "measuring2"; f1: number }
+  | { type: "measuring_confirm"; countsPerOct: number; f1: number }
+  | { type: "manual_enter1" }
+  | { type: "manual_enter2"; f1: number }
+  | {
+      type: "confirm";
+      countsPerOct: number;
+      f1: number;
+      fConfirm: number | null;
+    }
   | { type: "error"; message: string };
 
 const CURVE_LABELS = ["Custom 1", "Custom 2", "Custom 3", "Custom 4"] as const;
@@ -37,103 +47,246 @@ const JACK_OPTIONS = Array.from({ length: 16 }, (_, i) => ({
   label: `Jack ${i + 1}`,
 }));
 
+const AUX_OPTIONS = [
+  { key: "0", label: "Atom" },
+  { key: "1", label: "Meteor" },
+  { key: "2", label: "Cube" },
+];
+
 const formatGain = (countsPerOct: number): string =>
   `${(countsPerOct / 410).toFixed(3)} V/Oct`;
+
+const parseFreq = (s: string): number | null => {
+  const n = parseFloat(s);
+  return isFinite(n) && n >= 10 && n <= 20000 ? n : null;
+};
 
 export const VoOctCurvesSettings = ({ config }: Props) => {
   const { usbDevice, isSimulator, setConfig } = useStore();
 
   const [openCurveIdx, setOpenCurveIdx] = useState<number | null>(null);
+  const [wizardMode, setWizardMode] = useState<WizardMode>("auto");
   const [outputJack, setOutputJack] = useState("0");
+  const [auxInput, setAuxInput] = useState("0");
   const [wizardStep, setWizardStep] = useState<WizardStep>({ type: "setup" });
-  const [freqInput, setFreqInput] = useState("");
-  const [f1, setF1] = useState<number | null>(null);
-
-  const releaseOutput = useCallback(
-    (jack: string) => {
-      if (!usbDevice) return;
-      sendAndReceive(usbDevice, {
-        tag: "ReleaseVoOctOutput",
-        value: { output_jack: parseInt(jack, 10) },
-      }).catch(() => {});
-    },
-    [usbDevice],
-  );
+  const [manualF1, setManualF1] = useState("");
+  const [manualF2, setManualF2] = useState("");
 
   const handleOpenWizard = useCallback((idx: number) => {
     setOpenCurveIdx(idx);
     setWizardStep({ type: "setup" });
-    setFreqInput("");
-    setF1(null);
+    setWizardMode("auto");
+    setManualF1("");
+    setManualF2("");
   }, []);
 
   const handleClose = useCallback(() => {
-    if (wizardStep.type === "step1" || wizardStep.type === "step2") {
-      releaseOutput(outputJack);
+    // Release output jack if manual mode is holding a voltage. Fire-and-forget
+    // so the modal closes immediately while cleanup runs in the background.
+    if (
+      (wizardStep.type === "manual_enter1" ||
+        wizardStep.type === "manual_enter2") &&
+      usbDevice
+    ) {
+      void sendAndReceive(usbDevice, {
+        tag: "ReleaseVoOctOutput",
+        value: { output_jack: parseInt(outputJack, 10) },
+      }).catch(() => {});
     }
     setOpenCurveIdx(null);
-  }, [wizardStep, outputJack, releaseOutput]);
+  }, [wizardStep, usbDevice, outputJack]);
 
-  const handleStart = useCallback(async () => {
+  // --- Automated flow ---
+
+  const handleStartAuto = useCallback(async () => {
     if (!usbDevice || openCurveIdx === null) return;
+
+    const jack = parseInt(outputJack, 10);
+    const aux = parseInt(auxInput, 10);
+    if (!Number.isFinite(jack) || !Number.isFinite(aux)) return;
+
+    setWizardStep({ type: "measuring1" });
+    let r1;
     try {
-      const r = await sendAndReceive(usbDevice, {
-        tag: "SetVoOctOutput",
+      r1 = await sendAndReceive(usbDevice, {
+        tag: "MeasureVoOct",
         value: {
-          output_jack: parseInt(outputJack, 10),
+          output_jack: jack,
+          aux_input: aux,
           dac_counts: LOW_DAC_COUNTS,
         },
       });
-      if (r.tag !== "VoOctOutputSet") {
-        setWizardStep({ type: "error", message: "Failed to set output." });
-        return;
-      }
-      setFreqInput("");
-      setWizardStep({ type: "step1" });
     } catch (e) {
       setWizardStep({ type: "error", message: String(e) });
+      return;
     }
-  }, [usbDevice, openCurveIdx, outputJack]);
+    if (r1.tag !== "VoOctFrequency") {
+      setWizardStep({
+        type: "error",
+        message:
+          "No signal detected at 1V. Check AUX jack and VCO connections.",
+      });
+      return;
+    }
+    const f1 = r1.value.freq_hz;
 
-  const handleStep1Next = useCallback(async () => {
-    if (!usbDevice) return;
-    const f1Val = parseFloat(freqInput);
-    if (!Number.isFinite(f1Val) || f1Val <= 0) return;
-
+    setWizardStep({ type: "measuring2", f1 });
+    let r2;
     try {
-      const r = await sendAndReceive(usbDevice, {
-        tag: "SetVoOctOutput",
+      r2 = await sendAndReceive(usbDevice, {
+        tag: "MeasureVoOct",
         value: {
-          output_jack: parseInt(outputJack, 10),
+          output_jack: jack,
+          aux_input: aux,
           dac_counts: HIGH_DAC_COUNTS,
         },
       });
-      if (r.tag !== "VoOctOutputSet") {
-        setWizardStep({ type: "error", message: "Failed to set output." });
-        return;
-      }
-      setF1(f1Val);
-      setFreqInput("");
-      setWizardStep({ type: "step2" });
     } catch (e) {
       setWizardStep({ type: "error", message: String(e) });
+      return;
     }
-  }, [usbDevice, freqInput, outputJack]);
+    if (r2.tag !== "VoOctFrequency") {
+      setWizardStep({
+        type: "error",
+        message:
+          "No signal detected at 4V. Check AUX jack and VCO connections.",
+      });
+      return;
+    }
+    const f2 = r2.value.freq_hz;
 
-  const handleStep2Calculate = useCallback(async () => {
+    const countsPerOct = Math.round((OCTAVE_SPAN / Math.log2(f2 / f1)) * 410);
+
+    if (countsPerOct <= 0 || countsPerOct > 60000) {
+      setWizardStep({
+        type: "error",
+        message:
+          countsPerOct <= 0
+            ? `VCO frequency went down from 1V to 4V (${f1.toFixed(1)} Hz → ${f2.toFixed(1)} Hz). Check output jack and VCO V/Oct wiring.`
+            : `Calculated gain (${countsPerOct} counts/oct) is out of range. Check connections.`,
+      });
+      return;
+    }
+
+    // Confirm by outputting one countsPerOct above LOW (1V), staying within the
+    // 1–4V calibration range. Pre-set the output now via SetVoOctOutput so the
+    // VCO can settle downward from 4V during the 800 ms UI wait, before the
+    // firmware's own settle window starts.
+    const confirmDacCounts = LOW_DAC_COUNTS + countsPerOct;
+    if (confirmDacCounts > 65535) {
+      setWizardStep({ type: "confirm", countsPerOct, f1, fConfirm: null });
+      return;
+    }
+
+    setWizardStep({ type: "measuring_confirm", countsPerOct, f1 });
+
+    // Pre-settle: bring the output to confirmDacCounts now. Errors are ignored;
+    // MeasureVoOct will reconfigure the port regardless.
+    try {
+      await sendAndReceive(usbDevice, {
+        tag: "SetVoOctOutput",
+        value: { output_jack: jack, dac_counts: confirmDacCounts },
+      });
+    } catch {
+      // ignore — MeasureVoOct below will configure the port itself
+    }
+    // Give the VCO extra time to settle downward before the firmware window.
+    await new Promise<void>((r) => setTimeout(r, 800));
+
+    let rConfirm;
+    try {
+      rConfirm = await sendAndReceive(usbDevice, {
+        tag: "MeasureVoOct",
+        value: {
+          output_jack: jack,
+          aux_input: aux,
+          dac_counts: confirmDacCounts,
+        },
+      });
+    } catch (e) {
+      setWizardStep({ type: "error", message: String(e) });
+      return;
+    }
+    if (rConfirm.tag !== "VoOctFrequency") {
+      setWizardStep({
+        type: "error",
+        message: "Verification measurement failed. Check AUX jack connection.",
+      });
+      return;
+    }
+
+    setWizardStep({
+      type: "confirm",
+      countsPerOct,
+      f1,
+      fConfirm: rConfirm.value.freq_hz,
+    });
+  }, [usbDevice, openCurveIdx, outputJack, auxInput]);
+
+  // --- Manual flow ---
+
+  const handleStartManual = useCallback(async () => {
+    if (!usbDevice || openCurveIdx === null) return;
+
+    const jack = parseInt(outputJack, 10);
+    try {
+      const r = await sendAndReceive(usbDevice, {
+        tag: "SetVoOctOutput",
+        value: { output_jack: jack, dac_counts: LOW_DAC_COUNTS },
+      });
+      if (r.tag !== "VoOctOutputSet") throw new Error("unexpected response");
+    } catch (e) {
+      setWizardStep({ type: "error", message: String(e) });
+      return;
+    }
+    setManualF1("");
+    setWizardStep({ type: "manual_enter1" });
+  }, [usbDevice, openCurveIdx, outputJack]);
+
+  const handleManualNext = useCallback(async () => {
+    if (!usbDevice) return;
+    const f1 = parseFreq(manualF1);
     if (f1 === null) return;
-    const f2Val = parseFloat(freqInput);
-    if (!Number.isFinite(f2Val) || f2Val <= 0) return;
 
-    releaseOutput(outputJack);
+    const jack = parseInt(outputJack, 10);
+    try {
+      const r = await sendAndReceive(usbDevice, {
+        tag: "SetVoOctOutput",
+        value: { output_jack: jack, dac_counts: HIGH_DAC_COUNTS },
+      });
+      if (r.tag !== "VoOctOutputSet") throw new Error("unexpected response");
+    } catch (e) {
+      setWizardStep({ type: "error", message: String(e) });
+      return;
+    }
+    setManualF2("");
+    setWizardStep({ type: "manual_enter2", f1 });
+  }, [usbDevice, outputJack, manualF1]);
 
-    const gain = OCTAVE_SPAN / Math.log2(f2Val / f1);
-    const countsPerOct = Math.round(gain * 410);
-    setWizardStep({ type: "done", countsPerOct, gain });
-  }, [f1, freqInput, outputJack, releaseOutput]);
+  const handleManualCalculate = useCallback(async () => {
+    if (!usbDevice || wizardStep.type !== "manual_enter2") return;
+    const f2 = parseFreq(manualF2);
+    if (f2 === null) return;
+
+    const { f1 } = wizardStep;
+    try {
+      await sendAndReceive(usbDevice, {
+        tag: "ReleaseVoOctOutput",
+        value: { output_jack: parseInt(outputJack, 10) },
+      });
+    } catch (e) {
+      setWizardStep({ type: "error", message: String(e) });
+      return;
+    }
+
+    const countsPerOct = Math.round((OCTAVE_SPAN / Math.log2(f2 / f1)) * 410);
+    setWizardStep({ type: "confirm", countsPerOct, f1, fConfirm: null });
+  }, [usbDevice, wizardStep, manualF2, outputJack]);
+
+  // --- Save ---
 
   const handleSave = useCallback(async () => {
-    if (openCurveIdx === null || wizardStep.type !== "done") return;
+    if (openCurveIdx === null || wizardStep.type !== "confirm") return;
 
     const updatedCurves = [
       ...config.custom_voct_curves,
@@ -150,6 +303,13 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
     setConfig(updatedConfig);
     setOpenCurveIdx(null);
   }, [openCurveIdx, wizardStep, config, usbDevice, isSimulator, setConfig]);
+
+  // -------------------- render --------------------
+
+  const isMeasuring =
+    wizardStep.type === "measuring1" ||
+    wizardStep.type === "measuring2" ||
+    wizardStep.type === "measuring_confirm";
 
   return (
     <div className="mb-12">
@@ -190,111 +350,285 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
                 Calibrate{" "}
                 {openCurveIdx !== null ? CURVE_LABELS[openCurveIdx] : ""}
               </ModalHeader>
+
               <ModalBody>
                 {wizardStep.type === "setup" && (
                   <div className="flex flex-col gap-y-4">
-                    <p className="text-sm">
-                      Connect an output jack to a VCO V/Oct input, and the VCO
-                      audio output to your frequency meter. Use a jack with no
-                      app assigned for best accuracy.
-                    </p>
+                    <div className="flex overflow-hidden rounded-lg border border-gray-700">
+                      <button
+                        type="button"
+                        onClick={() => setWizardMode("auto")}
+                        className={`flex-1 py-1.5 text-sm font-medium transition-colors ${
+                          wizardMode === "auto"
+                            ? "bg-yellow-fp text-black"
+                            : "text-gray-400 hover:text-white"
+                        }`}
+                      >
+                        Automated
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setWizardMode("manual")}
+                        className={`flex-1 py-1.5 text-sm font-medium transition-colors ${
+                          wizardMode === "manual"
+                            ? "bg-yellow-fp text-black"
+                            : "text-gray-400 hover:text-white"
+                        }`}
+                      >
+                        Manual
+                      </button>
+                    </div>
+
                     <Select
-                      label="Output jack"
+                      label="Output jack (to VCO V/Oct)"
                       selectedKeys={[outputJack]}
-                      onSelectionChange={(keys) =>
-                        setOutputJack([...keys][0] as string)
-                      }
+                      disallowEmptySelection
+                      onSelectionChange={(keys) => {
+                        const first = [...keys][0];
+                        if (
+                          typeof first === "string" ||
+                          typeof first === "number"
+                        )
+                          setOutputJack(String(first));
+                      }}
                       items={JACK_OPTIONS}
                     >
                       {(item) => (
                         <SelectItem key={item.key}>{item.label}</SelectItem>
                       )}
                     </Select>
+
+                    {wizardMode === "auto" ? (
+                      <>
+                        <Select
+                          label="AUX input (from VCO audio out)"
+                          selectedKeys={[auxInput]}
+                          disallowEmptySelection
+                          onSelectionChange={(keys) => {
+                            const first = [...keys][0];
+                            if (
+                              typeof first === "string" ||
+                              typeof first === "number"
+                            )
+                              setAuxInput(String(first));
+                          }}
+                          items={AUX_OPTIONS}
+                        >
+                          {(item) => (
+                            <SelectItem key={item.key}>{item.label}</SelectItem>
+                          )}
+                        </Select>
+                        <p className="text-xs text-gray-400">
+                          Faderpunk will output 1V and 4V and measure the VCO
+                          frequency automatically via the AUX jack.
+                        </p>
+                      </>
+                    ) : (
+                      <p className="text-xs text-gray-400">
+                        Faderpunk will output 1V and 4V. Read the frequency from
+                        an external tuner and enter it manually.
+                      </p>
+                    )}
                   </div>
                 )}
-                {wizardStep.type === "step1" && (
-                  <div className="flex flex-col gap-y-4">
-                    <p className="text-sm">
-                      Outputting 1V. Read the frequency from your meter and
-                      enter it below.
-                    </p>
-                    <Input
-                      label="Measured frequency (Hz)"
-                      type="number"
-                      value={freqInput}
-                      onValueChange={setFreqInput}
-                    />
-                  </div>
-                )}
-                {wizardStep.type === "step2" && (
-                  <div className="flex flex-col gap-y-4">
-                    <p className="text-sm">
-                      Outputting 4V. Read the frequency from your meter and
-                      enter it below.
-                    </p>
-                    <Input
-                      label="Measured frequency (Hz)"
-                      type="number"
-                      value={freqInput}
-                      onValueChange={setFreqInput}
-                    />
-                  </div>
-                )}
-                {wizardStep.type === "done" && (
+
+                {wizardStep.type === "measuring1" && (
                   <div className="flex flex-col gap-y-2">
-                    <p className="text-sm font-medium">
-                      Measured: {formatGain(wizardStep.countsPerOct)}
+                    <p className="animate-pulse text-sm">
+                      Outputting 1V — measuring frequency…
                     </p>
                     <p className="text-xs text-gray-400">
-                      ({wizardStep.countsPerOct} counts/oct)
+                      Make sure your VCO is producing audio on the selected AUX
+                      jack.
                     </p>
                   </div>
                 )}
+
+                {wizardStep.type === "measuring2" && (
+                  <div className="flex flex-col gap-y-2">
+                    <p className="text-sm text-gray-400">
+                      1V: {wizardStep.f1.toFixed(1)} Hz ✓
+                    </p>
+                    <p className="animate-pulse text-sm">
+                      Outputting 4V — measuring frequency…
+                    </p>
+                  </div>
+                )}
+
+                {wizardStep.type === "measuring_confirm" && (
+                  <div className="flex flex-col gap-y-2">
+                    <p className="text-sm text-gray-400">
+                      1V: {wizardStep.f1.toFixed(1)} Hz ✓
+                    </p>
+                    <p className="text-sm text-gray-400">
+                      Gain: {formatGain(wizardStep.countsPerOct)} ✓
+                    </p>
+                    <p className="animate-pulse text-sm">
+                      Verifying 1 octave above 1V…
+                    </p>
+                  </div>
+                )}
+
+                {wizardStep.type === "manual_enter1" && (
+                  <div className="flex flex-col gap-y-4">
+                    <p className="text-sm">
+                      Outputting 1V on Jack {parseInt(outputJack, 10) + 1}. Read
+                      the frequency from your tuner and enter it below.
+                    </p>
+                    <Input
+                      type="number"
+                      label="Frequency at 1V (Hz)"
+                      placeholder="e.g. 261.6"
+                      value={manualF1}
+                      onValueChange={setManualF1}
+                      min={10}
+                      max={20000}
+                      step={0.1}
+                    />
+                  </div>
+                )}
+
+                {wizardStep.type === "manual_enter2" && (
+                  <div className="flex flex-col gap-y-4">
+                    <p className="text-sm text-gray-400">
+                      1V: {wizardStep.f1.toFixed(1)} Hz ✓
+                    </p>
+                    <p className="text-sm">
+                      Now outputting 4V. Read the new frequency from your tuner
+                      and enter it below.
+                    </p>
+                    <Input
+                      type="number"
+                      label="Frequency at 4V (Hz)"
+                      placeholder="e.g. 2093.0"
+                      value={manualF2}
+                      onValueChange={setManualF2}
+                      min={10}
+                      max={20000}
+                      step={0.1}
+                    />
+                  </div>
+                )}
+
+                {wizardStep.type === "confirm" &&
+                  (() => {
+                    const { countsPerOct, f1, fConfirm } = wizardStep;
+                    return (
+                      <div className="flex flex-col gap-y-3">
+                        <div className="flex flex-col gap-y-1">
+                          <p className="text-sm font-medium">
+                            Gain: {formatGain(countsPerOct)}
+                          </p>
+                          <p className="text-xs text-gray-400">
+                            ({countsPerOct} counts/oct)
+                          </p>
+                        </div>
+                        {fConfirm !== null &&
+                          (() => {
+                            const expected = f1 * 2;
+                            const cents = Math.round(
+                              1200 * Math.log2(fConfirm / expected),
+                            );
+                            const absCents = Math.abs(cents);
+                            const sign = cents >= 0 ? "+" : "";
+                            const quality =
+                              absCents < 5
+                                ? { label: "accurate", color: "text-green-400" }
+                                : absCents < 20
+                                  ? {
+                                      label: "acceptable",
+                                      color: "text-yellow-400",
+                                    }
+                                  : {
+                                      label: "off — consider recalibrating",
+                                      color: "text-red-400",
+                                    };
+                            return (
+                              <div className="flex flex-col gap-y-1">
+                                <p className="text-xs text-gray-400">
+                                  Expected 1 octave above 1V:{" "}
+                                  {expected.toFixed(1)} Hz
+                                </p>
+                                <p className="text-xs text-gray-400">
+                                  Measured: {fConfirm.toFixed(1)} Hz
+                                </p>
+                                <p
+                                  className={`text-sm font-medium ${quality.color}`}
+                                >
+                                  {sign}
+                                  {cents} cents — {quality.label}
+                                </p>
+                              </div>
+                            );
+                          })()}
+                      </div>
+                    );
+                  })()}
+
                 {wizardStep.type === "error" && (
                   <p className="text-sm text-red-400">{wizardStep.message}</p>
                 )}
               </ModalBody>
+
               <ModalFooter>
                 {wizardStep.type === "setup" && (
                   <>
-                    <ButtonPrimary onPress={handleStart}>Start</ButtonPrimary>
+                    <ButtonPrimary
+                      onPress={
+                        wizardMode === "auto"
+                          ? handleStartAuto
+                          : handleStartManual
+                      }
+                    >
+                      Start
+                    </ButtonPrimary>
                     <ButtonSecondary onPress={onClose}>Cancel</ButtonSecondary>
                   </>
                 )}
-                {wizardStep.type === "step1" && (
+
+                {isMeasuring && (
+                  <ButtonSecondary onPress={onClose}>Cancel</ButtonSecondary>
+                )}
+
+                {wizardStep.type === "manual_enter1" && (
                   <>
                     <ButtonPrimary
-                      onPress={handleStep1Next}
-                      isDisabled={
-                        !Number.isFinite(parseFloat(freqInput)) ||
-                        parseFloat(freqInput) <= 0
-                      }
+                      onPress={handleManualNext}
+                      isDisabled={parseFreq(manualF1) === null}
                     >
                       Next
                     </ButtonPrimary>
-                    <ButtonSecondary onPress={onClose}>Cancel</ButtonSecondary>
+                    <ButtonSecondary onPress={handleClose}>
+                      Cancel
+                    </ButtonSecondary>
                   </>
                 )}
-                {wizardStep.type === "step2" && (
+
+                {wizardStep.type === "manual_enter2" && (
                   <>
                     <ButtonPrimary
-                      onPress={handleStep2Calculate}
-                      isDisabled={
-                        !Number.isFinite(parseFloat(freqInput)) ||
-                        parseFloat(freqInput) <= 0
-                      }
+                      onPress={handleManualCalculate}
+                      isDisabled={parseFreq(manualF2) === null}
                     >
                       Calculate
                     </ButtonPrimary>
-                    <ButtonSecondary onPress={onClose}>Cancel</ButtonSecondary>
+                    <ButtonSecondary onPress={handleClose}>
+                      Cancel
+                    </ButtonSecondary>
                   </>
                 )}
-                {wizardStep.type === "done" && (
+
+                {wizardStep.type === "confirm" && (
                   <>
                     <ButtonPrimary onPress={handleSave}>Save</ButtonPrimary>
-                    <ButtonSecondary onPress={onClose}>Discard</ButtonSecondary>
+                    <ButtonSecondary
+                      onPress={() => setWizardStep({ type: "setup" })}
+                    >
+                      Recalibrate
+                    </ButtonSecondary>
                   </>
                 )}
+
                 {wizardStep.type === "error" && (
                   <>
                     <ButtonPrimary

--- a/configurator/src/components/settings/VoOctCurvesSettings.tsx
+++ b/configurator/src/components/settings/VoOctCurvesSettings.tsx
@@ -1,5 +1,5 @@
 import type { GlobalConfig } from "@atov/fp-config";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   Modal,
   ModalBody,
@@ -71,6 +71,21 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
   const [wizardStep, setWizardStep] = useState<WizardStep>({ type: "setup" });
   const [manualF1, setManualF1] = useState("");
   const [manualF2, setManualF2] = useState("");
+
+  // Refreshing/closing the tab mid-calibration drops the WebUSB connection,
+  // which can leave the jack's app evicted until the device is rebooted (the
+  // firmware has no way to detect a clean session end vs. a dropped
+  // connection). Warn before the browser navigates away while the wizard is
+  // open.
+  useEffect(() => {
+    if (openCurveIdx === null) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [openCurveIdx]);
 
   const handleOpenWizard = useCallback((idx: number) => {
     setOpenCurveIdx(idx);
@@ -346,9 +361,14 @@ export const VoOctCurvesSettings = ({ config }: Props) => {
         <ModalContent>
           {(onClose) => (
             <>
-              <ModalHeader>
-                Calibrate{" "}
-                {openCurveIdx !== null ? CURVE_LABELS[openCurveIdx] : ""}
+              <ModalHeader className="flex flex-col items-start gap-y-1">
+                <span>
+                  Calibrate{" "}
+                  {openCurveIdx !== null ? CURVE_LABELS[openCurveIdx] : ""}
+                </span>
+                <span className="text-xs font-normal text-gray-400">
+                  Don&apos;t refresh or close this page while calibrating.
+                </span>
               </ModalHeader>
 
               <ModalBody>

--- a/configurator/src/hooks/useConnectionHealthCheck.ts
+++ b/configurator/src/hooks/useConnectionHealthCheck.ts
@@ -13,7 +13,7 @@ export const useConnectionHealthCheck = () => {
     if (!device || isSimulator) return;
 
     const interval = setInterval(async () => {
-      if (pollingRef.current) return;
+      if (pollingRef.current || useStore.getState().suspendHealthCheck) return;
       pollingRef.current = true;
 
       try {

--- a/configurator/src/store.ts
+++ b/configurator/src/store.ts
@@ -77,6 +77,12 @@ interface State {
   setParams: (id: number, newParams: Value[]) => void;
   setAllParams: (newParams: ParamValues) => void;
   device: FpMidiDevice | undefined;
+  // Set while a long-running, single-in-flight device operation (e.g. V/Oct
+  // calibration) is blocking the firmware's config loop, so
+  // useConnectionHealthCheck doesn't mistake the resulting slow/absent
+  // response for a dropped connection and force-navigate away.
+  suspendHealthCheck: boolean;
+  setSuspendHealthCheck: (suspendHealthCheck: boolean) => void;
 }
 
 const initialState = {
@@ -87,6 +93,7 @@ const initialState = {
   layout: undefined,
   params: undefined,
   device: undefined,
+  suspendHealthCheck: false,
 };
 
 export const useStore = create<State>((set, get) => ({
@@ -182,4 +189,5 @@ export const useStore = create<State>((set, get) => ({
     if (isSimulator && layout && config)
       persistSimulatorState(layout, newParams, config);
   },
+  setSuspendHealthCheck: (suspendHealthCheck) => set({ suspendHealthCheck }),
 }));

--- a/configurator/src/utils/midi-protocol.ts
+++ b/configurator/src/utils/midi-protocol.ts
@@ -227,16 +227,18 @@ export async function sendMessage(
 
 export async function receiveMessage(
   device: FpMidiDevice,
+  timeoutMs: number = RECEIVE_TIMEOUT_MS,
 ): Promise<ConfigMsgOut> {
-  return receiveFromRx(device.rx, RECEIVE_TIMEOUT_MS);
+  return receiveFromRx(device.rx, timeoutMs);
 }
 
 export async function sendAndReceive(
   device: FpMidiDevice,
   msg: ConfigMsgIn,
+  timeoutMs?: number,
 ): Promise<ConfigMsgOut> {
   await sendMessage(device, msg);
-  return receiveMessage(device);
+  return receiveMessage(device, timeoutMs);
 }
 
 export async function receiveBatchMessages(

--- a/configurator/src/utils/utils.ts
+++ b/configurator/src/utils/utils.ts
@@ -87,7 +87,8 @@ export const getDefaultValue = (val: Value) => {
       return val.value;
     }
     case "VoltPerOct": {
-      return val.value.tag;
+      const vpo = val.value;
+      return vpo.tag === "Custom" ? `Custom:${vpo.value}` : vpo.tag;
     }
   }
 };
@@ -143,8 +144,19 @@ const getParamValue = (
       return { tag: "MidiMode", value: { tag: value as MidiModeTag } };
     case "MidiNrpn":
       return { tag: "MidiNrpn", value: value as boolean };
-    case "VoltPerOct":
-      return { tag: "VoltPerOct", value: { tag: value as VoltPerOct["tag"] } };
+    case "VoltPerOct": {
+      const key = value as string;
+      if (key.startsWith("Custom:")) {
+        return {
+          tag: "VoltPerOct",
+          value: { tag: "Custom", value: parseInt(key.slice(7), 10) },
+        };
+      }
+      return {
+        tag: "VoltPerOct",
+        value: { tag: key as Exclude<VoltPerOct["tag"], "Custom"> },
+      };
+    }
     default:
       return undefined;
   }

--- a/configurator/src/utils/validators.ts
+++ b/configurator/src/utils/validators.ts
@@ -266,6 +266,17 @@ const globalConfigSchema = z.object({
     tonic: taggedObjectSchema,
   }),
   takeover_mode: taggedObjectSchema,
+  // Absent in setup files saved before Custom V/Oct curves existed — default
+  // to uncalibrated rather than failing the whole file.
+  custom_voct_curves: z
+    .array(z.object({ counts_per_oct: z.number().int().min(0).max(65535) }))
+    .length(4)
+    .default([
+      { counts_per_oct: 0 },
+      { counts_per_oct: 0 },
+      { counts_per_oct: 0 },
+      { counts_per_oct: 0 },
+    ]),
 });
 
 export const parseGlobalConfigFromFile = (
@@ -299,7 +310,12 @@ export const parseGlobalConfigFromFile = (
     },
     quantizer: validated.quantizer as GlobalConfig["quantizer"],
     takeover_mode: validated.takeover_mode as GlobalConfig["takeover_mode"],
-    custom_voct_curves: defaultGlobalConfig.custom_voct_curves,
+    custom_voct_curves: [
+      validated.custom_voct_curves[0],
+      validated.custom_voct_curves[1],
+      validated.custom_voct_curves[2],
+      validated.custom_voct_curves[3],
+    ] as GlobalConfig["custom_voct_curves"],
   };
 
   return config;

--- a/configurator/src/utils/validators.ts
+++ b/configurator/src/utils/validators.ts
@@ -143,7 +143,13 @@ export const getParamSchema = (param: Param) => {
       return z
         .object({
           tag: z.literal("VoltPerOct"),
-          value: z.object({ tag: z.enum(["Standard", "Buchla"]) }),
+          value: z.union([
+            z.object({ tag: z.enum(["Standard", "Buchla"]) }),
+            z.object({
+              tag: z.literal("Custom"),
+              value: z.number().int().min(0).max(3),
+            }),
+          ]),
         })
         .catch({
           tag: "VoltPerOct",
@@ -215,6 +221,12 @@ export const defaultGlobalConfig: GlobalConfig = {
     tonic: { tag: "C" },
   },
   takeover_mode: { tag: "Pickup" },
+  custom_voct_curves: [
+    { counts_per_oct: 0 },
+    { counts_per_oct: 0 },
+    { counts_per_oct: 0 },
+    { counts_per_oct: 0 },
+  ] as GlobalConfig["custom_voct_curves"],
 };
 
 // Lenient schema that validates structure but allows any valid tag values
@@ -287,6 +299,7 @@ export const parseGlobalConfigFromFile = (
     },
     quantizer: validated.quantizer as GlobalConfig["quantizer"],
     takeover_mode: validated.takeover_mode as GlobalConfig["takeover_mode"],
+    custom_voct_curves: defaultGlobalConfig.custom_voct_curves,
   };
 
   return config;

--- a/faderpunk/src/app.rs
+++ b/faderpunk/src/app.rs
@@ -859,16 +859,14 @@ impl<const N: usize> App<N> {
 }
 
 /// Convert a quantized pitch to DAC counts, resolving any Custom V/Oct curve
-/// from the live global config. Prefer this over `Pitch::as_counts_with_curves`
+/// from the live global config. Prefer this over `GlobalConfig::pitch_as_counts`
 /// in app code — no need to import or snapshot `get_global_config`.
 pub fn pitch_as_counts(pitch: Pitch, range: Range, vpo: VoltPerOct) -> u16 {
-    let curves = get_global_config().custom_voct_curves;
-    pitch.as_counts_with_curves(range, vpo, &curves)
+    get_global_config().pitch_as_counts(pitch, range, vpo)
 }
 
 /// Return DAC counts-per-octave for `vpo`, resolving any Custom V/Oct curve
 /// from the live global config.
 pub fn vpo_counts_per_oct(vpo: VoltPerOct) -> i16 {
-    let curves = get_global_config().custom_voct_curves;
-    vpo.counts_per_oct_with_curves(&curves)
+    get_global_config().vpo_counts_per_oct(vpo)
 }

--- a/faderpunk/src/app.rs
+++ b/faderpunk/src/app.rs
@@ -857,3 +857,18 @@ impl<const N: usize> App<N> {
         self.reset().await;
     }
 }
+
+/// Convert a quantized pitch to DAC counts, resolving any Custom V/Oct curve
+/// from the live global config. Prefer this over `Pitch::as_counts_with_curves`
+/// in app code — no need to import or snapshot `get_global_config`.
+pub fn pitch_as_counts(pitch: Pitch, range: Range, vpo: VoltPerOct) -> u16 {
+    let curves = get_global_config().custom_voct_curves;
+    pitch.as_counts_with_curves(range, vpo, &curves)
+}
+
+/// Return DAC counts-per-octave for `vpo`, resolving any Custom V/Oct curve
+/// from the live global config.
+pub fn vpo_counts_per_oct(vpo: VoltPerOct) -> i16 {
+    let curves = get_global_config().custom_voct_curves;
+    vpo.counts_per_oct_with_curves(&curves)
+}

--- a/faderpunk/src/apps/clkturing.rs
+++ b/faderpunk/src/apps/clkturing.rs
@@ -17,7 +17,7 @@ use libfp::{
     Param, Range, Value, VoltPerOct, APP_MAX_PARAMS,
 };
 
-use crate::app::{App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
+use crate::app::{pitch_as_counts, App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
 
 pub const CHANNELS: usize = 2;
 pub const PARAMS: usize = 10;
@@ -245,7 +245,7 @@ pub async fn run(
 
                 let muted = glob_muted.get();
                 if !muted {
-                    output.set_value(out.as_counts(range, vpo));
+                    output.set_value(pitch_as_counts(out, range, vpo));
                     leds.set(
                         0,
                         Led::Top,

--- a/faderpunk/src/apps/genseq.rs
+++ b/faderpunk/src/apps/genseq.rs
@@ -17,7 +17,8 @@ use libfp::{
 use midly::num::u7;
 
 use crate::app::{
-    App, AppParams, AppStorage, ClockEvent, Led, ManagedStorage, ParamStore, SceneEvent,
+    pitch_as_counts, vpo_counts_per_oct, App, AppParams, AppStorage, ClockEvent, Led,
+    ManagedStorage, ParamStore, SceneEvent,
 };
 
 pub const CHANNELS: usize = 3;
@@ -349,7 +350,7 @@ pub async fn run(
                             // bottom of the pitch range maps to C0 rather than clipping
                             // negative DAC values to 0V.
                             let input_floor = ((-octave_offset).max(0) as u16)
-                                .saturating_mul(vpo.counts_per_oct() as u16);
+                                .saturating_mul(vpo_counts_per_oct(vpo) as u16);
                             let quantizer_input =
                                 (att_reg as u32 / 2 + input_floor as u32).min(4095) as u16;
                             let out = quantizer.get_quantized_note(quantizer_input).await;
@@ -369,7 +370,7 @@ pub async fn run(
                             midi_note.set(note);
 
                             if !glob_muted.get() {
-                                cv_out.set_value(shifted.as_counts(Range::_0_10V, vpo));
+                                cv_out.set_value(pitch_as_counts(shifted, Range::_0_10V, vpo));
                             }
                             leds.set(
                                 0,

--- a/faderpunk/src/apps/genseq.rs
+++ b/faderpunk/src/apps/genseq.rs
@@ -17,8 +17,8 @@ use libfp::{
 use midly::num::u7;
 
 use crate::app::{
-    pitch_as_counts, vpo_counts_per_oct, App, AppParams, AppStorage, ClockEvent, Led,
-    ManagedStorage, ParamStore, SceneEvent,
+    pitch_as_counts, App, AppParams, AppStorage, ClockEvent, Led, ManagedStorage, ParamStore,
+    SceneEvent,
 };
 
 pub const CHANNELS: usize = 3;
@@ -342,7 +342,7 @@ pub async fn run(
 
                             let register_scaled = scale_to_12bit(register_pitch, length as u8);
                             let raw_att = storage.query(|s| s.pitch_att);
-                            let att_reg = attenuate(register_scaled, raw_att);
+                            let att_reg: u16 = attenuate(register_scaled, raw_att);
                             let octave_offset =
                                 (storage.query(|s| s.octave_shift) / 819).min(4) as i32 - 2;
 
@@ -350,7 +350,7 @@ pub async fn run(
                             // bottom of the pitch range maps to C0 rather than clipping
                             // negative DAC values to 0V.
                             let input_floor = ((-octave_offset).max(0) as u16)
-                                .saturating_mul(vpo_counts_per_oct(vpo) as u16);
+                                .saturating_mul(vpo.counts_per_oct() as u16);
                             let quantizer_input =
                                 (att_reg as u32 / 2 + input_floor as u32).min(4095) as u16;
                             let out = quantizer.get_quantized_note(quantizer_input).await;

--- a/faderpunk/src/apps/notefader.rs
+++ b/faderpunk/src/apps/notefader.rs
@@ -13,7 +13,8 @@ use libfp::{
 };
 
 use crate::app::{
-    App, AppParams, AppStorage, ClockEvent, Led, ManagedStorage, ParamStore, SceneEvent,
+    pitch_as_counts, App, AppParams, AppStorage, ClockEvent, Led, ManagedStorage, ParamStore,
+    SceneEvent,
 };
 
 pub const CHANNELS: usize = 1;
@@ -217,7 +218,7 @@ pub async fn run(
 
         let out = quantizer.get_quantized_note(fadval).await;
         if outmode == 0 {
-            jack.set_value(out.as_counts(range, vpo));
+            jack.set_value(pitch_as_counts(out, range, vpo));
         } else {
             jack.set_value(4095)
         }

--- a/faderpunk/src/apps/quantizer.rs
+++ b/faderpunk/src/apps/quantizer.rs
@@ -12,7 +12,10 @@ use serde::{Deserialize, Serialize};
 
 use libfp::{Config, Param, Range, Value};
 
-use crate::app::{App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
+use crate::app::{
+    pitch_as_counts, vpo_counts_per_oct, App, AppParams, AppStorage, Led, ManagedStorage,
+    ParamStore, SceneEvent,
+};
 
 pub const CHANNELS: usize = 2;
 pub const PARAMS: usize = 4;
@@ -138,7 +141,7 @@ pub async fn run(
     leds.set(1, Led::Button, led_color, Brightness::Mid);
 
     let quantizer = app.use_quantizer(range, vpo, bypass);
-    let counts_per_oct = vpo.counts_per_oct();
+    let counts_per_oct = vpo_counts_per_oct(vpo);
     let _input = app.make_in_jack(0, range).await;
     let output = app.make_out_jack(1, range).await;
     for chan in 0..2 {
@@ -173,8 +176,8 @@ pub async fn run(
                 .get_quantized_note((inval + oct + st).clamp(0, 4095) as u16)
                 .await;
 
-            output.set_value(outval.as_counts(range, vpo));
-            let oct_led = split_unsigned_value(outval.as_counts(range, vpo));
+            output.set_value(pitch_as_counts(outval, range, vpo));
+            let oct_led = split_unsigned_value(pitch_as_counts(outval, range, vpo));
             leds.set(1, Led::Top, led_color, Brightness::Custom(oct_led[0]));
             leds.set(1, Led::Bottom, led_color, Brightness::Custom(oct_led[1]));
             leds.set(

--- a/faderpunk/src/apps/quantizer.rs
+++ b/faderpunk/src/apps/quantizer.rs
@@ -13,8 +13,7 @@ use serde::{Deserialize, Serialize};
 use libfp::{Config, Param, Range, Value};
 
 use crate::app::{
-    pitch_as_counts, vpo_counts_per_oct, App, AppParams, AppStorage, Led, ManagedStorage,
-    ParamStore, SceneEvent,
+    pitch_as_counts, App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent,
 };
 
 pub const CHANNELS: usize = 2;
@@ -141,7 +140,7 @@ pub async fn run(
     leds.set(1, Led::Button, led_color, Brightness::Mid);
 
     let quantizer = app.use_quantizer(range, vpo, bypass);
-    let counts_per_oct = vpo_counts_per_oct(vpo);
+    let counts_per_oct = vpo.counts_per_oct();
     let _input = app.make_in_jack(0, range).await;
     let output = app.make_out_jack(1, range).await;
     for chan in 0..2 {

--- a/faderpunk/src/apps/seq8.rs
+++ b/faderpunk/src/apps/seq8.rs
@@ -14,8 +14,8 @@ use libfp::{
 };
 
 use crate::app::{
-    App, AppParams, AppStorage, Arr, ClockEvent, Global, Led, ManagedStorage, ParamStore,
-    SceneEvent,
+    pitch_as_counts, vpo_counts_per_oct, App, AppParams, AppStorage, Arr, ClockEvent, Global,
+    Led, ManagedStorage, ParamStore, SceneEvent,
 };
 
 pub const CHANNELS: usize = 8;
@@ -326,7 +326,7 @@ pub async fn run(
     ];
 
     let quantizer = app.use_quantizer(range, vpo, bypass);
-    let counts_per_oct = vpo.counts_per_oct() as u32;
+    let counts_per_oct = vpo_counts_per_oct(vpo) as u32;
 
     let page_glob: Global<usize> = app.make_global(0);
     let prev_page_glob: Global<usize> = app.make_global(0);
@@ -743,7 +743,7 @@ pub async fn run(
                                     // Hand the target CV to slide_handler; slide only if
                                     // the previously played step had legato enabled.
                                     let mut targets = target_cv_glob.get();
-                                    targets[n] = (out.as_counts(range, vpo) as i32
+                                    targets[n] = (pitch_as_counts(out, range, vpo) as i32
                                         + transpo[n] as i32 * counts_per_oct as i32 / 12)
                                         .clamp(0, 4095) as u16;
                                     target_cv_glob.set(targets);

--- a/faderpunk/src/apps/seq8.rs
+++ b/faderpunk/src/apps/seq8.rs
@@ -326,7 +326,10 @@ pub async fn run(
     ];
 
     let quantizer = app.use_quantizer(range, vpo, bypass);
-    let counts_per_oct = vpo_counts_per_oct(vpo) as u32;
+    // Nominal scale for pre-quantize offsets (matches the quantizer's internal decode).
+    let counts_per_oct = vpo.counts_per_oct() as u32;
+    // Calibrated scale for the post-quantize transpose add (real DAC-counts domain).
+    let calibrated_counts_per_oct = vpo_counts_per_oct(vpo) as u32;
 
     let page_glob: Global<usize> = app.make_global(0);
     let prev_page_glob: Global<usize> = app.make_global(0);
@@ -744,7 +747,8 @@ pub async fn run(
                                     // the previously played step had legato enabled.
                                     let mut targets = target_cv_glob.get();
                                     targets[n] = (pitch_as_counts(out, range, vpo) as i32
-                                        + transpo[n] as i32 * counts_per_oct as i32 / 12)
+                                        + transpo[n] as i32 * calibrated_counts_per_oct as i32
+                                            / 12)
                                         .clamp(0, 4095) as u16;
                                     target_cv_glob.set(targets);
                                     let mut slid = sliding_glob.get();

--- a/faderpunk/src/apps/tb3po.rs
+++ b/faderpunk/src/apps/tb3po.rs
@@ -16,8 +16,8 @@ use libfp::{
 };
 
 use crate::app::{
-    pitch_as_counts, vpo_counts_per_oct, App, AppParams, AppStorage, ClockEvent, Global, Led,
-    ManagedStorage, ParamStore, SceneEvent,
+    pitch_as_counts, App, AppParams, AppStorage, ClockEvent, Global, Led, ManagedStorage,
+    ParamStore, SceneEvent,
 };
 use crate::tasks::leds::LedMode;
 
@@ -266,7 +266,7 @@ fn step_is_oct_down(p: &AcidPattern, step: u8) -> bool {
 
 /// Raw pitch CV for a step before quantising (in ±5V counts 0–4095).
 fn raw_pitch_cv(p: &AcidPattern, step: u8, transpose: i16, vpo: VoltPerOct) -> u16 {
-    let oct = vpo_counts_per_oct(vpo) as i32;
+    let oct = vpo.counts_per_oct() as i32;
     let semi = oct / 12;
     let note = p.notes[step as usize] as i32;
     let cv = CENTER_CV as i32

--- a/faderpunk/src/apps/tb3po.rs
+++ b/faderpunk/src/apps/tb3po.rs
@@ -16,7 +16,8 @@ use libfp::{
 };
 
 use crate::app::{
-    App, AppParams, AppStorage, ClockEvent, Global, Led, ManagedStorage, ParamStore, SceneEvent,
+    pitch_as_counts, vpo_counts_per_oct, App, AppParams, AppStorage, ClockEvent, Global, Led,
+    ManagedStorage, ParamStore, SceneEvent,
 };
 use crate::tasks::leds::LedMode;
 
@@ -265,7 +266,7 @@ fn step_is_oct_down(p: &AcidPattern, step: u8) -> bool {
 
 /// Raw pitch CV for a step before quantising (in ±5V counts 0–4095).
 fn raw_pitch_cv(p: &AcidPattern, step: u8, transpose: i16, vpo: VoltPerOct) -> u16 {
-    let oct = vpo.counts_per_oct() as i32;
+    let oct = vpo_counts_per_oct(vpo) as i32;
     let semi = oct / 12;
     let note = p.notes[step as usize] as i32;
     let cv = CENTER_CV as i32
@@ -453,12 +454,12 @@ pub async fn run(
                     if is_slid_prev {
                         // Glide: output_task will interpolate toward new target
                         let out = quantizer.get_quantized_note(target_raw).await;
-                        slide_target_glob.set(out.as_counts(pitch_range, vpo));
+                        slide_target_glob.set(pitch_as_counts(out, pitch_range, vpo));
                         slide_active_glob.set(true);
                     } else if is_gated {
                         // Snap to new pitch
                         let out = quantizer.get_quantized_note(target_raw).await;
-                        let counts = out.as_counts(pitch_range, vpo);
+                        let counts = pitch_as_counts(out, pitch_range, vpo);
                         slide_target_glob.set(counts);
                         slide_active_glob.set(false);
                     }

--- a/faderpunk/src/apps/turing.rs
+++ b/faderpunk/src/apps/turing.rs
@@ -19,7 +19,8 @@ use libfp::{
 };
 
 use crate::app::{
-    App, AppParams, AppStorage, ClockEvent, Led, ManagedStorage, ParamStore, SceneEvent,
+    pitch_as_counts, App, AppParams, AppStorage, ClockEvent, Led, ManagedStorage, ParamStore,
+    SceneEvent,
 };
 
 pub const CHANNELS: usize = 1;
@@ -339,7 +340,7 @@ pub async fn run(
                             let out = quantizer.get_quantized_note(att_reg).await;
                             let muted = glob_muted.get();
                             if !muted {
-                                cv_jack.as_ref().unwrap().set_value(out.as_counts(range, vpo));
+                                cv_jack.as_ref().unwrap().set_value(pitch_as_counts(out, range, vpo));
                                 leds.set(
                                     0,
                                     Led::Top,

--- a/faderpunk/src/layout.rs
+++ b/faderpunk/src/layout.rs
@@ -21,11 +21,29 @@ pub static LAYOUT_WATCH: Watch<CriticalSectionRawMutex, Layout, LAYOUT_WATCH_SUB
 /// Signal to force respawn all apps
 pub static FORCE_RESPAWN_SIGNAL: Signal<CriticalSectionRawMutex, ()> = Signal::new();
 
+/// A scoped, non-persisting request to evict or restore a single channel's
+/// app, used by the V/Oct calibration wizard to temporarily free a jack an
+/// app is using without touching the persisted layout.
+pub enum EvictionCmd {
+    /// Exit whatever app is running on this start_channel, if any.
+    Evict(usize),
+    /// Respawn (app_id, channels, layout_id) on this start_channel.
+    Restore(usize, u8, usize, u8),
+}
+
+pub static LAYOUT_EVICTION_REQ: Signal<CriticalSectionRawMutex, EvictionCmd> = Signal::new();
+pub static LAYOUT_EVICTION_RES: Signal<CriticalSectionRawMutex, ()> = Signal::new();
+
 pub static LAYOUT_MANAGER: StaticCell<LayoutManager> = StaticCell::new();
 
 pub struct LayoutManager {
     exit_signals: [Signal<NoopRawMutex, bool>; GLOBAL_CHANNELS],
     layout: Mutex<NoopRawMutex, InnerLayout>,
+    /// Channels currently on loan for V/Oct calibration (see `EvictionCmd`).
+    /// `spawn_layout`'s reconciliation pass must not spawn into a held
+    /// channel even if the persisted layout wants an app there, since a
+    /// held channel is mid-calibration and not actually free.
+    held: Mutex<NoopRawMutex, [bool; GLOBAL_CHANNELS]>,
     spawner: Spawner,
 }
 
@@ -34,11 +52,19 @@ impl LayoutManager {
         Self {
             exit_signals: [const { Signal::new() }; GLOBAL_CHANNELS],
             layout: Mutex::new([None; GLOBAL_CHANNELS]),
+            held: Mutex::new([false; GLOBAL_CHANNELS]),
             spawner,
         }
     }
 
-    async fn exit_app(&self, start_channel: usize) {
+    /// Mark `start_channel` as held (or release it) for a temporary V/Oct
+    /// calibration eviction, so ordinary layout reconciliation leaves it
+    /// alone until it's released.
+    pub(crate) async fn set_held(&self, start_channel: usize, held: bool) {
+        self.held.lock().await[start_channel] = held;
+    }
+
+    pub(crate) async fn exit_app(&self, start_channel: usize) {
         let mut layout = self.layout.lock().await;
         if layout[start_channel].is_some() {
             layout[start_channel] = None;
@@ -58,6 +84,30 @@ impl LayoutManager {
 
         // Now spawn the desired layout
         self.spawn_layout(layout).await;
+    }
+
+    /// Spawn a single (app_id, channels, layout_id) onto `start_channel` if
+    /// nothing is currently running there. Used to restore an app that was
+    /// temporarily evicted (e.g. for V/Oct calibration) without touching the
+    /// persisted layout.
+    pub(crate) async fn spawn_one(
+        &'static self,
+        start_channel: usize,
+        app_id: u8,
+        channels: usize,
+        layout_id: u8,
+    ) {
+        let mut current_layout = self.layout.lock().await;
+        if current_layout[start_channel].is_none() {
+            spawn_app_by_id(
+                app_id,
+                start_channel,
+                layout_id,
+                self.spawner,
+                &self.exit_signals,
+            );
+            current_layout[start_channel] = Some((app_id, channels, layout_id));
+        }
     }
 
     pub async fn spawn_layout(&'static self, layout: &Layout) -> bool {
@@ -92,8 +142,9 @@ impl LayoutManager {
                     let current_layout = self.layout.lock().await;
                     current_layout[start_channel].is_none()
                 };
+                let held = self.held.lock().await[start_channel];
 
-                if should_spawn {
+                if should_spawn && !held {
                     spawn_app_by_id(
                         app_id,
                         start_channel,

--- a/faderpunk/src/main.rs
+++ b/faderpunk/src/main.rs
@@ -43,7 +43,10 @@ use {defmt_rtt as _, panic_probe as _};
 
 use crate::storage::{factory_reset, store_layout};
 
-use layout::{LayoutManager, FORCE_RESPAWN_SIGNAL, LAYOUT_MANAGER, LAYOUT_WATCH};
+use layout::{
+    EvictionCmd, LayoutManager, FORCE_RESPAWN_SIGNAL, LAYOUT_EVICTION_REQ, LAYOUT_EVICTION_RES,
+    LAYOUT_MANAGER, LAYOUT_WATCH,
+};
 use storage::{load_calibration_data, load_global_config, load_layout, migrate_fram};
 use tasks::{
     buttons::{is_channel_button_pressed, is_scene_button_pressed},
@@ -91,24 +94,48 @@ pub static QUANTIZER: LazyLock<Mutex<CriticalSectionRawMutex, Quantizer>> =
 
 #[embassy_executor::task]
 async fn main_core1(spawner: Spawner) {
-    use embassy_futures::select::{select, Either};
+    use embassy_futures::select::{select3, Either3};
 
     spawner.spawn(midi_distributor()).unwrap();
     let lm = LAYOUT_MANAGER.init(LayoutManager::new(spawner));
     let mut receiver = LAYOUT_WATCH.receiver().unwrap();
     loop {
-        match select(receiver.changed(), FORCE_RESPAWN_SIGNAL.wait()).await {
-            Either::First(layout) => {
+        match select3(
+            receiver.changed(),
+            FORCE_RESPAWN_SIGNAL.wait(),
+            LAYOUT_EVICTION_REQ.wait(),
+        )
+        .await
+        {
+            Either3::First(layout) => {
                 // Normal layout change
                 if lm.spawn_layout(&layout).await {
                     // Store new layout if it changed
                     store_layout(&layout).await;
                 }
             }
-            Either::Second(_) => {
+            Either3::Second(_) => {
                 // Force respawn requested
                 let layout = receiver.get().await;
                 lm.respawn_all(&layout).await;
+            }
+            Either3::Third(cmd) => {
+                // Scoped, non-persisting eviction/restore for calibration.
+                // The channel is held for the whole evict..restore window so
+                // an unrelated SetLayout/FORCE_RESPAWN_SIGNAL reconciliation
+                // can't spawn an app back into it while calibration holds it.
+                match cmd {
+                    EvictionCmd::Evict(start_channel) => {
+                        lm.set_held(start_channel, true).await;
+                        lm.exit_app(start_channel).await;
+                    }
+                    EvictionCmd::Restore(start_channel, app_id, channels, layout_id) => {
+                        lm.spawn_one(start_channel, app_id, channels, layout_id)
+                            .await;
+                        lm.set_held(start_channel, false).await;
+                    }
+                }
+                LAYOUT_EVICTION_RES.signal(());
             }
         }
     }

--- a/faderpunk/src/storage.rs
+++ b/faderpunk/src/storage.rs
@@ -99,6 +99,7 @@ impl From<GlobalConfigV0> for GlobalConfig {
             midi: old.midi,
             quantizer: old.quantizer,
             takeover_mode: old.takeover_mode,
+            custom_voct_curves: Default::default(),
         }
     }
 }
@@ -132,6 +133,7 @@ impl From<GlobalConfigV170> for GlobalConfig {
             midi: old.midi,
             quantizer: old.quantizer,
             takeover_mode: TakeoverMode::Pickup,
+            custom_voct_curves: Default::default(),
         }
     }
 }

--- a/faderpunk/src/tasks/clock.rs
+++ b/faderpunk/src/tasks/clock.rs
@@ -11,8 +11,9 @@ use embassy_sync::{
     blocking_mutex::raw::{CriticalSectionRawMutex, ThreadModeRawMutex},
     channel::Channel,
     pubsub::{PubSubChannel, Subscriber},
+    signal::Signal,
 };
-use embassy_time::{Duration, Instant, Timer};
+use embassy_time::{with_timeout, Duration, Instant, Timer};
 use heapless::Deque;
 use midly::live::SystemRealtime;
 use portable_atomic::{AtomicBool, Ordering};
@@ -45,6 +46,13 @@ const INTERNAL_PPQN: u8 = 24;
 const METRONOME_HIGH_MS: u64 = 25;
 
 pub static METRONOME_HIGH: AtomicBool = AtomicBool::new(true);
+
+/// Signals the AUX pin loop to pause clock detection and run a frequency
+/// measurement. Index corresponds to aux pin: 0=Atom, 1=Meteor, 2=Cube.
+pub static VOCT_MEASURE_REQ: [Signal<CriticalSectionRawMutex, ()>; 3] =
+    [const { Signal::new() }; 3];
+/// Result of a V/Oct frequency measurement: Ok(freq_hz) or Err(()) on timeout.
+pub static VOCT_MEASURE_RES: Signal<CriticalSectionRawMutex, Result<u32, ()>> = Signal::new();
 
 type AuxInputs = (
     Peri<'static, PIN_1>,
@@ -246,7 +254,7 @@ pub async fn start_clock(spawner: &Spawner, aux_inputs: AuxInputs) {
     spawner.spawn(metronome()).unwrap();
 }
 
-async fn make_ext_clock_loop(mut pin: Input<'_>, clock_src: ClockSrc) {
+async fn make_ext_clock_loop(pin: &mut Input<'_>, clock_src: ClockSrc) {
     let sender = SYNC_ENGINE_CHANNEL.sender();
     loop {
         pin.wait_for_falling_edge().await;
@@ -257,6 +265,61 @@ async fn make_ext_clock_loop(mut pin: Input<'_>, clock_src: ClockSrc) {
                 timestamp: Instant::now(),
             })
             .await;
+    }
+}
+
+/// Measure the frequency of an incoming signal on `pin` by timing rising edges.
+/// Returns `Ok(freq_hz)` or `Err(())` on timeout (2 s without a valid edge).
+/// Debounces edges closer than 50 µs to handle noisy sine-wave sources.
+async fn measure_frequency(pin: &mut Input<'_>) -> Result<u32, ()> {
+    const SAMPLES: u64 = 8;
+    const DEBOUNCE_US: u64 = 50;
+    const TIMEOUT: Duration = Duration::from_secs(2);
+
+    // Sync to the first rising edge.
+    with_timeout(TIMEOUT, pin.wait_for_rising_edge())
+        .await
+        .map_err(|_| ())?;
+    let mut last_edge = Instant::now();
+
+    let mut total_period_us: u64 = 0;
+    let mut valid: u64 = 0;
+
+    while valid < SAMPLES {
+        with_timeout(TIMEOUT, pin.wait_for_rising_edge())
+            .await
+            .map_err(|_| ())?;
+        let now = Instant::now();
+        let period_us = now.duration_since(last_edge).as_micros();
+        last_edge = now;
+
+        if period_us < DEBOUNCE_US {
+            continue;
+        }
+        total_period_us += period_us;
+        valid += 1;
+    }
+
+    let avg_us = total_period_us / SAMPLES;
+    if avg_us == 0 {
+        return Err(());
+    }
+    Ok((1_000_000 / avg_us) as u32)
+}
+
+/// Runs the clock-detection loop for one AUX pin, breaking out to perform a
+/// frequency measurement whenever `VOCT_MEASURE_REQ[aux_idx]` is signalled.
+async fn aux_pin_loop(mut pin: Input<'_>, src: ClockSrc, aux_idx: usize) {
+    loop {
+        select(
+            make_ext_clock_loop(&mut pin, src),
+            VOCT_MEASURE_REQ[aux_idx].wait(),
+        )
+        .await;
+
+        // Measurement requested: measure and signal result; clock loop restarts.
+        let result = measure_frequency(&mut pin).await;
+        VOCT_MEASURE_RES.signal(result);
     }
 }
 
@@ -987,9 +1050,9 @@ async fn run_clock_sources(aux_inputs: AuxInputs) {
     let cube = Input::new(hexagon_pin, Pull::Up);
 
     let engine_fut = run_unified_clock_engine();
-    let atom_fut = make_ext_clock_loop(atom, ClockSrc::Atom);
-    let meteor_fut = make_ext_clock_loop(meteor, ClockSrc::Meteor);
-    let cube_fut = make_ext_clock_loop(cube, ClockSrc::Cube);
+    let atom_fut = aux_pin_loop(atom, ClockSrc::Atom, 0);
+    let meteor_fut = aux_pin_loop(meteor, ClockSrc::Meteor, 1);
+    let cube_fut = aux_pin_loop(cube, ClockSrc::Cube, 2);
 
     join4(engine_fut, atom_fut, meteor_fut, cube_fut).await;
 }

--- a/faderpunk/src/tasks/clock.rs
+++ b/faderpunk/src/tasks/clock.rs
@@ -52,7 +52,7 @@ pub static METRONOME_HIGH: AtomicBool = AtomicBool::new(true);
 pub static VOCT_MEASURE_REQ: [Signal<CriticalSectionRawMutex, ()>; 3] =
     [const { Signal::new() }; 3];
 /// Result of a V/Oct frequency measurement: Ok(freq_hz) or Err(()) on timeout.
-pub static VOCT_MEASURE_RES: Signal<CriticalSectionRawMutex, Result<u32, ()>> = Signal::new();
+pub static VOCT_MEASURE_RES: Signal<CriticalSectionRawMutex, Result<f32, ()>> = Signal::new();
 
 type AuxInputs = (
     Peri<'static, PIN_1>,
@@ -289,7 +289,7 @@ async fn sync_to_rising_edge(pin: &mut Input<'_>, timeout: Duration) -> Result<I
     }
 }
 
-async fn measure_frequency(pin: &mut Input<'_>) -> Result<u32, ()> {
+async fn measure_frequency(pin: &mut Input<'_>) -> Result<f32, ()> {
     const ROUGH_SAMPLES: u64 = 8;
     const FINE_SAMPLES: u64 = 256;
     const MIN_PERIOD_US: u64 = 100; // 10 kHz upper limit
@@ -357,7 +357,7 @@ async fn measure_frequency(pin: &mut Input<'_>) -> Result<u32, ()> {
     if total_period_us == 0 {
         return Err(());
     }
-    Ok((FINE_SAMPLES * 1_000_000 / total_period_us) as u32)
+    Ok(FINE_SAMPLES as f32 * 1_000_000.0 / total_period_us as f32)
 }
 
 /// Runs the clock-detection loop for one AUX pin, breaking out to perform a

--- a/faderpunk/src/tasks/clock.rs
+++ b/faderpunk/src/tasks/clock.rs
@@ -270,41 +270,94 @@ async fn make_ext_clock_loop(pin: &mut Input<'_>, clock_src: ClockSrc) {
 
 /// Measure the frequency of an incoming signal on `pin` by timing rising edges.
 /// Returns `Ok(freq_hz)` or `Err(())` on timeout (2 s without a valid edge).
-/// Debounces edges closer than 50 µs to handle noisy sine-wave sources.
-async fn measure_frequency(pin: &mut Input<'_>) -> Result<u32, ()> {
-    const SAMPLES: u64 = 8;
-    const DEBOUNCE_US: u64 = 50;
-    const TIMEOUT: Duration = Duration::from_secs(2);
-
-    // Sync to the first rising edge.
-    with_timeout(TIMEOUT, pin.wait_for_rising_edge())
-        .await
-        .map_err(|_| ())?;
-    let mut last_edge = Instant::now();
-
-    let mut total_period_us: u64 = 0;
-    let mut valid: u64 = 0;
-
-    while valid < SAMPLES {
-        with_timeout(TIMEOUT, pin.wait_for_rising_edge())
+/// Accepts only signals in the 10 Hz – 10 kHz band; edges outside this range
+/// are discarded without corrupting the period accumulator.
+///
+/// 256 samples span ~580 ms at 440 Hz, keeping endpoint jitter below 0.01%.
+async fn sync_to_rising_edge(pin: &mut Input<'_>, timeout: Duration) -> Result<Instant, ()> {
+    loop {
+        with_timeout(timeout, pin.wait_for_rising_edge())
             .await
             .map_err(|_| ())?;
         let now = Instant::now();
-        let period_us = now.duration_since(last_edge).as_micros();
-        last_edge = now;
+        // Level-check: if pin is already LOW the edge was a narrow glitch that
+        // resolved before Embassy scheduled us. Skip it without advancing the
+        // anchor — mirrors little-helper's ISR-level pin re-read.
+        if pin.is_high() {
+            return Ok(now);
+        }
+    }
+}
 
-        if period_us < DEBOUNCE_US {
+async fn measure_frequency(pin: &mut Input<'_>) -> Result<u32, ()> {
+    const ROUGH_SAMPLES: u64 = 8;
+    const FINE_SAMPLES: u64 = 256;
+    const MIN_PERIOD_US: u64 = 100; // 10 kHz upper limit
+    const MAX_PERIOD_US: u64 = 100_000; // 10 Hz lower limit
+    const TIMEOUT: Duration = Duration::from_secs(2);
+
+    // --- Phase 1: rough period estimate (wide gate, few samples) ---
+    let mut last_edge = sync_to_rising_edge(pin, TIMEOUT).await?;
+    let mut rough_total_us: u64 = 0;
+    let mut rough_valid: u64 = 0;
+
+    while rough_valid < ROUGH_SAMPLES {
+        let now = sync_to_rising_edge(pin, TIMEOUT).await?;
+        let period_us = now.duration_since(last_edge).as_micros();
+
+        if period_us < MIN_PERIOD_US {
             continue;
         }
+        if period_us > MAX_PERIOD_US {
+            last_edge = now;
+            continue;
+        }
+        last_edge = now;
+        rough_total_us += period_us;
+        rough_valid += 1;
+    }
+
+    if rough_total_us == 0 {
+        return Err(());
+    }
+    let rough_period_us = rough_total_us / rough_valid;
+
+    // --- Phase 2: fine measurement with adaptive gate ---
+    // Gate rejects any interval outside [60%, 150%] of the rough period.
+    // A spurious edge mid-cycle creates a sub-fundamental interval that sits
+    // below the 60% floor and is rejected without advancing the anchor.
+    let lo = rough_period_us * 6 / 10;
+    let hi = rough_period_us * 15 / 10;
+
+    last_edge = sync_to_rising_edge(pin, TIMEOUT).await?;
+    let mut total_period_us: u64 = 0;
+    let mut valid: u64 = 0;
+
+    while valid < FINE_SAMPLES {
+        let now = sync_to_rising_edge(pin, TIMEOUT).await?;
+        let period_us = now.duration_since(last_edge).as_micros();
+
+        if period_us < lo {
+            // Short interval: spurious edge — keep current anchor.
+            continue;
+        }
+        if period_us > hi {
+            if period_us > MAX_PERIOD_US {
+                // Gap / sub-10 Hz: reset anchor.
+                last_edge = now;
+            }
+            continue;
+        }
+
+        last_edge = now;
         total_period_us += period_us;
         valid += 1;
     }
 
-    let avg_us = total_period_us / SAMPLES;
-    if avg_us == 0 {
+    if total_period_us == 0 {
         return Err(());
     }
-    Ok((1_000_000 / avg_us) as u32)
+    Ok((FINE_SAMPLES * 1_000_000 / total_period_us) as u32)
 }
 
 /// Runs the clock-detection loop for one AUX pin, breaking out to perform a
@@ -1038,6 +1091,64 @@ async fn run_unified_clock_engine() {
                     }
                 }
             }
+        }
+    }
+}
+
+/// Debug helper: continuously measures frequency on `pin` and logs each result.
+/// First pass also logs raw per-edge periods to diagnose spurious edges.
+/// Swap into `run_clock_sources` in place of `aux_pin_loop` for field testing.
+#[allow(dead_code)]
+async fn debug_freq_loop(mut pin: Input<'_>) {
+    const TIMEOUT: Duration = Duration::from_secs(2);
+    const MIN_PERIOD_US: u64 = 100;
+    const MAX_PERIOD_US: u64 = 100_000;
+
+    defmt::info!("ATOM debug: logging raw periods for first 20 edges");
+    let Ok(mut last_edge) = sync_to_rising_edge(&mut pin, TIMEOUT).await else {
+        defmt::warn!("ATOM debug: no signal on startup");
+        return;
+    };
+    let mut rejected: u32 = 0;
+    let mut accepted: u32 = 0;
+    let mut min_us: u64 = u64::MAX;
+    let mut max_us: u64 = 0;
+
+    while accepted < 20 {
+        let Ok(now) = sync_to_rising_edge(&mut pin, TIMEOUT).await else {
+            defmt::warn!("ATOM debug: timeout during raw period log");
+            break;
+        };
+        let period_us = now.duration_since(last_edge).as_micros();
+        if !(MIN_PERIOD_US..=MAX_PERIOD_US).contains(&period_us) {
+            rejected += 1;
+            last_edge = now;
+            continue;
+        }
+        defmt::info!("ATOM raw period: {} us", period_us);
+        if period_us < min_us {
+            min_us = period_us;
+        }
+        if period_us > max_us {
+            max_us = period_us;
+        }
+        last_edge = now;
+        accepted += 1;
+    }
+    defmt::info!(
+        "ATOM raw: {} accepted, {} rejected, min={} us, max={} us",
+        accepted,
+        rejected,
+        min_us,
+        max_us
+    );
+
+    defmt::info!("ATOM debug: starting continuous frequency measurement");
+    loop {
+        defmt::info!("ATOM debug: waiting for signal...");
+        match measure_frequency(&mut pin).await {
+            Ok(hz) => defmt::info!("ATOM freq: {} Hz", hz),
+            Err(()) => defmt::warn!("ATOM: no signal (timeout after 2s)"),
         }
     }
 }

--- a/faderpunk/src/tasks/clock.rs
+++ b/faderpunk/src/tasks/clock.rs
@@ -11,9 +11,8 @@ use embassy_sync::{
     blocking_mutex::raw::{CriticalSectionRawMutex, ThreadModeRawMutex},
     channel::Channel,
     pubsub::{PubSubChannel, Subscriber},
-    signal::Signal,
 };
-use embassy_time::{with_timeout, Duration, Instant, Timer};
+use embassy_time::{Duration, Instant, Timer};
 use heapless::Deque;
 use midly::live::SystemRealtime;
 use portable_atomic::{AtomicBool, Ordering};
@@ -46,13 +45,6 @@ const INTERNAL_PPQN: u8 = 24;
 const METRONOME_HIGH_MS: u64 = 25;
 
 pub static METRONOME_HIGH: AtomicBool = AtomicBool::new(true);
-
-/// Signals the AUX pin loop to pause clock detection and run a frequency
-/// measurement. Index corresponds to aux pin: 0=Atom, 1=Meteor, 2=Cube.
-pub static VOCT_MEASURE_REQ: [Signal<CriticalSectionRawMutex, ()>; 3] =
-    [const { Signal::new() }; 3];
-/// Result of a V/Oct frequency measurement: Ok(freq_hz) or Err(()) on timeout.
-pub static VOCT_MEASURE_RES: Signal<CriticalSectionRawMutex, Result<f32, ()>> = Signal::new();
 
 type AuxInputs = (
     Peri<'static, PIN_1>,
@@ -254,7 +246,7 @@ pub async fn start_clock(spawner: &Spawner, aux_inputs: AuxInputs) {
     spawner.spawn(metronome()).unwrap();
 }
 
-async fn make_ext_clock_loop(pin: &mut Input<'_>, clock_src: ClockSrc) {
+pub(crate) async fn make_ext_clock_loop(pin: &mut Input<'_>, clock_src: ClockSrc) {
     let sender = SYNC_ENGINE_CHANNEL.sender();
     loop {
         pin.wait_for_falling_edge().await;
@@ -265,114 +257,6 @@ async fn make_ext_clock_loop(pin: &mut Input<'_>, clock_src: ClockSrc) {
                 timestamp: Instant::now(),
             })
             .await;
-    }
-}
-
-/// Measure the frequency of an incoming signal on `pin` by timing rising edges.
-/// Returns `Ok(freq_hz)` or `Err(())` on timeout (2 s without a valid edge).
-/// Accepts only signals in the 10 Hz – 10 kHz band; edges outside this range
-/// are discarded without corrupting the period accumulator.
-///
-/// 256 samples span ~580 ms at 440 Hz, keeping endpoint jitter below 0.01%.
-async fn sync_to_rising_edge(pin: &mut Input<'_>, timeout: Duration) -> Result<Instant, ()> {
-    loop {
-        with_timeout(timeout, pin.wait_for_rising_edge())
-            .await
-            .map_err(|_| ())?;
-        let now = Instant::now();
-        // Level-check: if pin is already LOW the edge was a narrow glitch that
-        // resolved before Embassy scheduled us. Skip it without advancing the
-        // anchor — mirrors little-helper's ISR-level pin re-read.
-        if pin.is_high() {
-            return Ok(now);
-        }
-    }
-}
-
-async fn measure_frequency(pin: &mut Input<'_>) -> Result<f32, ()> {
-    const ROUGH_SAMPLES: u64 = 8;
-    const FINE_SAMPLES: u64 = 256;
-    const MIN_PERIOD_US: u64 = 100; // 10 kHz upper limit
-    const MAX_PERIOD_US: u64 = 100_000; // 10 Hz lower limit
-    const TIMEOUT: Duration = Duration::from_secs(2);
-
-    // --- Phase 1: rough period estimate (wide gate, few samples) ---
-    let mut last_edge = sync_to_rising_edge(pin, TIMEOUT).await?;
-    let mut rough_total_us: u64 = 0;
-    let mut rough_valid: u64 = 0;
-
-    while rough_valid < ROUGH_SAMPLES {
-        let now = sync_to_rising_edge(pin, TIMEOUT).await?;
-        let period_us = now.duration_since(last_edge).as_micros();
-
-        if period_us < MIN_PERIOD_US {
-            continue;
-        }
-        if period_us > MAX_PERIOD_US {
-            last_edge = now;
-            continue;
-        }
-        last_edge = now;
-        rough_total_us += period_us;
-        rough_valid += 1;
-    }
-
-    if rough_total_us == 0 {
-        return Err(());
-    }
-    let rough_period_us = rough_total_us / rough_valid;
-
-    // --- Phase 2: fine measurement with adaptive gate ---
-    // Gate rejects any interval outside [60%, 150%] of the rough period.
-    // A spurious edge mid-cycle creates a sub-fundamental interval that sits
-    // below the 60% floor and is rejected without advancing the anchor.
-    let lo = rough_period_us * 6 / 10;
-    let hi = rough_period_us * 15 / 10;
-
-    last_edge = sync_to_rising_edge(pin, TIMEOUT).await?;
-    let mut total_period_us: u64 = 0;
-    let mut valid: u64 = 0;
-
-    while valid < FINE_SAMPLES {
-        let now = sync_to_rising_edge(pin, TIMEOUT).await?;
-        let period_us = now.duration_since(last_edge).as_micros();
-
-        if period_us < lo {
-            // Short interval: spurious edge — keep current anchor.
-            continue;
-        }
-        if period_us > hi {
-            if period_us > MAX_PERIOD_US {
-                // Gap / sub-10 Hz: reset anchor.
-                last_edge = now;
-            }
-            continue;
-        }
-
-        last_edge = now;
-        total_period_us += period_us;
-        valid += 1;
-    }
-
-    if total_period_us == 0 {
-        return Err(());
-    }
-    Ok(FINE_SAMPLES as f32 * 1_000_000.0 / total_period_us as f32)
-}
-
-/// Runs the clock-detection loop for one AUX pin, breaking out to perform a
-/// frequency measurement whenever `VOCT_MEASURE_REQ[aux_idx]` is signalled.
-async fn aux_pin_loop(mut pin: Input<'_>, src: ClockSrc, aux_idx: usize) {
-    loop {
-        select(
-            make_ext_clock_loop(&mut pin, src),
-            VOCT_MEASURE_REQ[aux_idx].wait(),
-        )
-        .await;
-
-        // Measurement requested: measure and signal result; clock loop restarts.
-        let result = measure_frequency(&mut pin).await;
-        VOCT_MEASURE_RES.signal(result);
     }
 }
 
@@ -1095,64 +979,6 @@ async fn run_unified_clock_engine() {
     }
 }
 
-/// Debug helper: continuously measures frequency on `pin` and logs each result.
-/// First pass also logs raw per-edge periods to diagnose spurious edges.
-/// Swap into `run_clock_sources` in place of `aux_pin_loop` for field testing.
-#[allow(dead_code)]
-async fn debug_freq_loop(mut pin: Input<'_>) {
-    const TIMEOUT: Duration = Duration::from_secs(2);
-    const MIN_PERIOD_US: u64 = 100;
-    const MAX_PERIOD_US: u64 = 100_000;
-
-    defmt::info!("ATOM debug: logging raw periods for first 20 edges");
-    let Ok(mut last_edge) = sync_to_rising_edge(&mut pin, TIMEOUT).await else {
-        defmt::warn!("ATOM debug: no signal on startup");
-        return;
-    };
-    let mut rejected: u32 = 0;
-    let mut accepted: u32 = 0;
-    let mut min_us: u64 = u64::MAX;
-    let mut max_us: u64 = 0;
-
-    while accepted < 20 {
-        let Ok(now) = sync_to_rising_edge(&mut pin, TIMEOUT).await else {
-            defmt::warn!("ATOM debug: timeout during raw period log");
-            break;
-        };
-        let period_us = now.duration_since(last_edge).as_micros();
-        if !(MIN_PERIOD_US..=MAX_PERIOD_US).contains(&period_us) {
-            rejected += 1;
-            last_edge = now;
-            continue;
-        }
-        defmt::info!("ATOM raw period: {} us", period_us);
-        if period_us < min_us {
-            min_us = period_us;
-        }
-        if period_us > max_us {
-            max_us = period_us;
-        }
-        last_edge = now;
-        accepted += 1;
-    }
-    defmt::info!(
-        "ATOM raw: {} accepted, {} rejected, min={} us, max={} us",
-        accepted,
-        rejected,
-        min_us,
-        max_us
-    );
-
-    defmt::info!("ATOM debug: starting continuous frequency measurement");
-    loop {
-        defmt::info!("ATOM debug: waiting for signal...");
-        match measure_frequency(&mut pin).await {
-            Ok(hz) => defmt::info!("ATOM freq: {} Hz", hz),
-            Err(()) => defmt::warn!("ATOM: no signal (timeout after 2s)"),
-        }
-    }
-}
-
 #[embassy_executor::task]
 async fn run_clock_sources(aux_inputs: AuxInputs) {
     let (atom_pin, meteor_pin, hexagon_pin) = aux_inputs;
@@ -1161,9 +987,9 @@ async fn run_clock_sources(aux_inputs: AuxInputs) {
     let cube = Input::new(hexagon_pin, Pull::Up);
 
     let engine_fut = run_unified_clock_engine();
-    let atom_fut = aux_pin_loop(atom, ClockSrc::Atom, 0);
-    let meteor_fut = aux_pin_loop(meteor, ClockSrc::Meteor, 1);
-    let cube_fut = aux_pin_loop(cube, ClockSrc::Cube, 2);
+    let atom_fut = super::voct_freq::aux_pin_loop(atom, ClockSrc::Atom, 0);
+    let meteor_fut = super::voct_freq::aux_pin_loop(meteor, ClockSrc::Meteor, 1);
+    let cube_fut = super::voct_freq::aux_pin_loop(cube, ClockSrc::Cube, 2);
 
     join4(engine_fut, atom_fut, meteor_fut, cube_fut).await;
 }

--- a/faderpunk/src/tasks/configure.rs
+++ b/faderpunk/src/tasks/configure.rs
@@ -1,3 +1,4 @@
+use embassy_futures::select::{select, Either};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::channel::Channel;
 use embassy_sync::signal::Signal;
@@ -10,11 +11,15 @@ use libfp::sysex::{
     pack_7bit, unpack_7bit, MAX_PLAIN_SIZE, MAX_SYSEX_FRAME, SYSEX_EOX, SYSEX_HEADER, SYSEX_START,
 };
 use libfp::{ConfigMsgIn, ConfigMsgOut, Value, APP_MAX_PARAMS, GLOBAL_CHANNELS};
+use max11300::config::{ConfigMode0, ConfigMode5, Mode, Port, DACRANGE};
+use portable_atomic::Ordering;
 
 use crate::apps::{get_channels, get_config, REGISTERED_APP_IDS};
 use crate::layout::LAYOUT_WATCH;
 use crate::storage::factory_reset;
+use crate::tasks::clock::{VOCT_MEASURE_REQ, VOCT_MEASURE_RES};
 use crate::tasks::global_config::{get_global_config, GLOBAL_CONFIG_WATCH};
+use crate::tasks::max::{MaxCmd, MAX_CHANNEL, MAX_VALUES_DAC};
 use crate::tasks::midi::{SharedUsbSender, CONFIG_CABLE};
 use crate::version::FIRMWARE_VERSION;
 
@@ -193,6 +198,18 @@ pub async fn start_config_loop<'a>(usb_tx: &'a SharedUsbSender<'a>) {
                 factory_reset().await;
                 Ok(())
             }
+            ConfigMsgIn::MeasureVoOct {
+                output_jack,
+                aux_input,
+                dac_counts,
+            } => handle_measure_voct(&mut proto, output_jack, aux_input, dac_counts).await,
+            ConfigMsgIn::SetVoOctOutput {
+                output_jack,
+                dac_counts,
+            } => handle_set_voct_output(&mut proto, output_jack, dac_counts).await,
+            ConfigMsgIn::ReleaseVoOctOutput { output_jack } => {
+                handle_release_voct_output(&mut proto, output_jack).await
+            }
         };
         if let Err(err) = res {
             defmt::warn!("Failed to send config response: {}", err);
@@ -207,6 +224,124 @@ struct ConfigTransport<'a> {
     usb_tx: &'a SharedUsbSender<'a>,
     plain_buf: [u8; MAX_PLAIN_SIZE],
     frame_buf: [u8; MAX_SYSEX_FRAME],
+}
+
+/// Set the output jack to 0-10V DAC mode, write `dac_counts`, signal the
+/// clock task to measure frequency on the chosen AUX pin, wait for the result,
+/// then release the jack (Mode1 high-Z).
+async fn handle_measure_voct(
+    proto: &mut ConfigTransport<'_>,
+    output_jack: u8,
+    aux_input: u8,
+    dac_counts: u16,
+) -> Result<(), ProtocolError> {
+    let aux_idx = aux_input as usize;
+    if aux_idx > 2 || output_jack as usize >= 16 {
+        return proto.send_msg(ConfigMsgOut::VoOctCalError).await;
+    }
+
+    let port = match Port::try_from(output_jack as usize) {
+        Ok(p) => p,
+        Err(_) => {
+            return proto.send_msg(ConfigMsgOut::VoOctCalError).await;
+        }
+    };
+
+    // Configure the output jack to 0-10V DAC mode.
+    MAX_CHANNEL
+        .send(MaxCmd::ConfigurePort {
+            port,
+            mode: Mode::Mode5(ConfigMode5(DACRANGE::Rg0_10v)),
+            gpo_level: None,
+        })
+        .await;
+
+    // Keep re-writing dac_counts every 5 ms so any app running on Core 1
+    // cannot permanently overwrite the calibration voltage. After 300 ms the
+    // VCO has settled; we then trigger the frequency measurement and wait for
+    // the result. The drive loop is cancelled automatically when select()
+    // returns (never() branch wins as soon as drive_and_measure completes).
+    let drive_and_measure = async {
+        MAX_VALUES_DAC[output_jack as usize].store(dac_counts, Ordering::Relaxed);
+        embassy_time::Timer::after_millis(300).await;
+        VOCT_MEASURE_REQ[aux_idx].signal(());
+        with_timeout(Duration::from_secs(10), VOCT_MEASURE_RES.wait()).await
+    };
+    let keep_driving = async {
+        loop {
+            MAX_VALUES_DAC[output_jack as usize].store(dac_counts, Ordering::Relaxed);
+            embassy_time::Timer::after_millis(5).await;
+        }
+    };
+
+    let freq_res = match select(keep_driving, drive_and_measure).await {
+        Either::Second(r) => r,
+        Either::First(_) => unreachable!(),
+    };
+
+    let res = match freq_res {
+        Ok(Ok(freq_hz)) => proto.send_msg(ConfigMsgOut::VoOctFrequency { freq_hz }).await,
+        _ => proto.send_msg(ConfigMsgOut::VoOctCalError).await,
+    };
+
+    // Release the output jack to high-Z (Mode 0) so apps can reclaim it.
+    MAX_CHANNEL
+        .send(MaxCmd::ConfigurePort {
+            port,
+            mode: Mode::Mode0(ConfigMode0),
+            gpo_level: None,
+        })
+        .await;
+
+    res
+}
+
+/// Set `output_jack` to 0-10V DAC mode and write `dac_counts`, then hold it
+/// there for the caller to measure manually (e.g. with an external frequency
+/// counter). The value is written once; pick a jack with no app assigned so
+/// nothing else overwrites `MAX_VALUES_DAC`.
+async fn handle_set_voct_output(
+    proto: &mut ConfigTransport<'_>,
+    output_jack: u8,
+    dac_counts: u16,
+) -> Result<(), ProtocolError> {
+    let port = match Port::try_from(output_jack as usize) {
+        Ok(p) if (output_jack as usize) < 16 => p,
+        _ => {
+            return proto.send_msg(ConfigMsgOut::VoOctOutputSet).await;
+        }
+    };
+
+    MAX_CHANNEL
+        .send(MaxCmd::ConfigurePort {
+            port,
+            mode: Mode::Mode5(ConfigMode5(DACRANGE::Rg0_10v)),
+            gpo_level: None,
+        })
+        .await;
+    MAX_VALUES_DAC[output_jack as usize].store(dac_counts, Ordering::Relaxed);
+
+    proto.send_msg(ConfigMsgOut::VoOctOutputSet).await
+}
+
+/// Release `output_jack` back to high-Z (Mode 0) so apps can reclaim it.
+async fn handle_release_voct_output(
+    proto: &mut ConfigTransport<'_>,
+    output_jack: u8,
+) -> Result<(), ProtocolError> {
+    if let Ok(port) = Port::try_from(output_jack as usize) {
+        if (output_jack as usize) < 16 {
+            MAX_CHANNEL
+                .send(MaxCmd::ConfigurePort {
+                    port,
+                    mode: Mode::Mode0(ConfigMode0),
+                    gpo_level: None,
+                })
+                .await;
+        }
+    }
+
+    proto.send_msg(ConfigMsgOut::VoOctOutputSet).await
 }
 
 impl<'a> ConfigTransport<'a> {

--- a/faderpunk/src/tasks/configure.rs
+++ b/faderpunk/src/tasks/configure.rs
@@ -10,8 +10,8 @@ use postcard::{from_bytes, to_slice};
 use libfp::sysex::{
     pack_7bit, unpack_7bit, MAX_PLAIN_SIZE, MAX_SYSEX_FRAME, SYSEX_EOX, SYSEX_HEADER, SYSEX_START,
 };
-use libfp::{ConfigMsgIn, ConfigMsgOut, Value, APP_MAX_PARAMS, GLOBAL_CHANNELS};
-use max11300::config::{ConfigMode0, ConfigMode5, Mode, Port, DACRANGE};
+use libfp::{AuxJackMode, ConfigMsgIn, ConfigMsgOut, Value, APP_MAX_PARAMS, GLOBAL_CHANNELS};
+use max11300::config::{ConfigMode0, ConfigMode3, ConfigMode5, Mode, Port, DACRANGE};
 use portable_atomic::Ordering;
 
 use crate::apps::{get_channels, get_config, REGISTERED_APP_IDS};
@@ -247,6 +247,25 @@ async fn handle_measure_voct(
         }
     };
 
+    // If the AUX jack is configured as ClockOut or ResetOut its MAX11300 port
+    // (17 + aux_idx) is in Mode3 (GPO) and will drive the jack voltage, which
+    // would corrupt frequency measurements. Force it to Mode0 (high-Z) for the
+    // duration of the measurement, then restore it afterwards.
+    let aux_port = Port::try_from(17 + aux_idx).unwrap();
+    let aux_was_active = matches!(
+        get_global_config().aux[aux_idx],
+        AuxJackMode::ClockOut(_) | AuxJackMode::ResetOut
+    );
+    if aux_was_active {
+        MAX_CHANNEL
+            .send(MaxCmd::ConfigurePort {
+                port: aux_port,
+                mode: Mode::Mode0(ConfigMode0),
+                gpo_level: None,
+            })
+            .await;
+    }
+
     // Configure the output jack to 0-10V DAC mode.
     MAX_CHANNEL
         .send(MaxCmd::ConfigurePort {
@@ -265,7 +284,7 @@ async fn handle_measure_voct(
         MAX_VALUES_DAC[output_jack as usize].store(dac_counts, Ordering::Relaxed);
         embassy_time::Timer::after_millis(300).await;
         VOCT_MEASURE_REQ[aux_idx].signal(());
-        with_timeout(Duration::from_secs(10), VOCT_MEASURE_RES.wait()).await
+        with_timeout(Duration::from_secs(30), VOCT_MEASURE_RES.wait()).await
     };
     let keep_driving = async {
         loop {
@@ -292,6 +311,17 @@ async fn handle_measure_voct(
             gpo_level: None,
         })
         .await;
+
+    // Restore the AUX port to GPO mode if it was active before measurement.
+    if aux_was_active {
+        MAX_CHANNEL
+            .send(MaxCmd::ConfigurePort {
+                port: aux_port,
+                mode: Mode::Mode3(ConfigMode3),
+                gpo_level: Some(2048),
+            })
+            .await;
+    }
 
     res
 }

--- a/faderpunk/src/tasks/configure.rs
+++ b/faderpunk/src/tasks/configure.rs
@@ -10,12 +10,14 @@ use postcard::{from_bytes, to_slice};
 use libfp::sysex::{
     pack_7bit, unpack_7bit, MAX_PLAIN_SIZE, MAX_SYSEX_FRAME, SYSEX_EOX, SYSEX_HEADER, SYSEX_START,
 };
-use libfp::{AuxJackMode, ConfigMsgIn, ConfigMsgOut, Value, APP_MAX_PARAMS, GLOBAL_CHANNELS};
+use libfp::{
+    AuxJackMode, ConfigMsgIn, ConfigMsgOut, Layout, Value, APP_MAX_PARAMS, GLOBAL_CHANNELS,
+};
 use max11300::config::{ConfigMode0, ConfigMode3, ConfigMode5, Mode, Port, DACRANGE};
 use portable_atomic::Ordering;
 
 use crate::apps::{get_channels, get_config, REGISTERED_APP_IDS};
-use crate::layout::LAYOUT_WATCH;
+use crate::layout::{EvictionCmd, LAYOUT_EVICTION_REQ, LAYOUT_EVICTION_RES, LAYOUT_WATCH};
 use crate::storage::factory_reset;
 use crate::tasks::clock::{VOCT_MEASURE_REQ, VOCT_MEASURE_RES};
 use crate::tasks::global_config::{get_global_config, GLOBAL_CONFIG_WATCH};
@@ -73,6 +75,7 @@ pub async fn start_config_loop<'a>(usb_tx: &'a SharedUsbSender<'a>) {
     let mut proto = ConfigTransport::new(usb_tx);
     let mut layout_receiver = LAYOUT_WATCH.receiver().unwrap();
     let mut layout = layout_receiver.get().await;
+    let mut pending_voct_eviction: Option<(u8, EvictedApp)> = None;
     loop {
         let msg = match proto.read_msg().await {
             Ok(msg) => msg,
@@ -202,13 +205,33 @@ pub async fn start_config_loop<'a>(usb_tx: &'a SharedUsbSender<'a>) {
                 output_jack,
                 aux_input,
                 dac_counts,
-            } => handle_measure_voct(&mut proto, output_jack, aux_input, dac_counts).await,
+            } => {
+                handle_measure_voct(
+                    &mut proto,
+                    &layout,
+                    &mut pending_voct_eviction,
+                    output_jack,
+                    aux_input,
+                    dac_counts,
+                )
+                .await
+            }
             ConfigMsgIn::SetVoOctOutput {
                 output_jack,
                 dac_counts,
-            } => handle_set_voct_output(&mut proto, output_jack, dac_counts).await,
+            } => {
+                handle_set_voct_output(
+                    &mut proto,
+                    &layout,
+                    &mut pending_voct_eviction,
+                    output_jack,
+                    dac_counts,
+                )
+                .await
+            }
             ConfigMsgIn::ReleaseVoOctOutput { output_jack } => {
-                handle_release_voct_output(&mut proto, output_jack).await
+                handle_release_voct_output(&mut proto, &mut pending_voct_eviction, output_jack)
+                    .await
             }
         };
         if let Err(err) = res {
@@ -226,11 +249,54 @@ struct ConfigTransport<'a> {
     frame_buf: [u8; MAX_SYSEX_FRAME],
 }
 
+/// (app_id, start_channel, channels, layout_id) of an app temporarily evicted
+/// from its jack for V/Oct calibration.
+type EvictedApp = (u8, usize, usize, u8);
+
+/// Find the app (if any) currently occupying `jack`.
+fn find_jack_owner(layout: &Layout, jack: u8) -> Option<EvictedApp> {
+    let jack = jack as usize;
+    layout.iter().find(|&(_, start_channel, channels, _)| {
+        jack >= start_channel && jack < start_channel + channels
+    })
+}
+
+/// If `jack` is occupied by a running app, temporarily evict it (a scoped,
+/// non-persisting despawn that doesn't touch the persisted layout) and return
+/// its identity so it can be restored with `restore_jack_owner` once
+/// calibration is done. Returns `None` (no-op) if the jack is unassigned.
+async fn evict_jack_owner(layout: &Layout, jack: u8) -> Option<EvictedApp> {
+    let owner = find_jack_owner(layout, jack)?;
+    let (_, start_channel, _, _) = owner;
+    LAYOUT_EVICTION_REQ.signal(EvictionCmd::Evict(start_channel));
+    LAYOUT_EVICTION_RES.wait().await;
+    Some(owner)
+}
+
+/// Respawn a previously-evicted app back onto its original channel(s).
+async fn restore_jack_owner(evicted: EvictedApp) {
+    let (app_id, start_channel, channels, layout_id) = evicted;
+    LAYOUT_EVICTION_REQ.signal(EvictionCmd::Restore(
+        start_channel,
+        app_id,
+        channels,
+        layout_id,
+    ));
+    LAYOUT_EVICTION_RES.wait().await;
+}
+
 /// Set the output jack to 0-10V DAC mode, write `dac_counts`, signal the
 /// clock task to measure frequency on the chosen AUX pin, wait for the result,
-/// then release the jack (Mode1 high-Z).
+/// then release the jack (Mode1 high-Z). If an app is running on `output_jack`,
+/// it is temporarily evicted and respawned afterward so calibration never
+/// leaves it stranded in high-Z. Shares `pending_eviction` with
+/// `handle_set_voct_output`/`handle_release_voct_output` (rather than
+/// tracking its own eviction locally) so the two flows can never disagree
+/// about whether a jack is currently evicted.
 async fn handle_measure_voct(
     proto: &mut ConfigTransport<'_>,
+    layout: &Layout,
+    pending_eviction: &mut Option<(u8, EvictedApp)>,
     output_jack: u8,
     aux_input: u8,
     dac_counts: u16,
@@ -246,6 +312,15 @@ async fn handle_measure_voct(
             return proto.send_msg(ConfigMsgOut::VoOctCalError).await;
         }
     };
+
+    // This handler always fully resolves its own eviction before returning,
+    // so start from a clean slate: settle any eviction left pending by the
+    // manual flow first (this handler doesn't reuse it, since it always
+    // restores at the end regardless).
+    if let Some((_, evicted)) = pending_eviction.take() {
+        restore_jack_owner(evicted).await;
+    }
+    let evicted = evict_jack_owner(layout, output_jack).await;
 
     // If the AUX jack is configured as ClockOut or ResetOut its MAX11300 port
     // (17 + aux_idx) is in Mode3 (GPO) and will drive the jack voltage, which
@@ -275,11 +350,12 @@ async fn handle_measure_voct(
         })
         .await;
 
-    // Keep re-writing dac_counts every 5 ms so any app running on Core 1
-    // cannot permanently overwrite the calibration voltage. After 300 ms the
-    // VCO has settled; we then trigger the frequency measurement and wait for
-    // the result. The drive loop is cancelled automatically when select()
-    // returns (never() branch wins as soon as drive_and_measure completes).
+    // Keep re-writing dac_counts every 5 ms as a defensive guard (in case
+    // eviction above was a no-op, e.g. a future caller skips it). After
+    // 300 ms the VCO has settled; we then trigger the frequency measurement
+    // and wait for the result. The drive loop is cancelled automatically
+    // when select() returns (never() branch wins as soon as
+    // drive_and_measure completes).
     let drive_and_measure = async {
         MAX_VALUES_DAC[output_jack as usize].store(dac_counts, Ordering::Relaxed);
         embassy_time::Timer::after_millis(300).await;
@@ -323,15 +399,29 @@ async fn handle_measure_voct(
             .await;
     }
 
+    if let Some(evicted) = evicted {
+        restore_jack_owner(evicted).await;
+    }
+    // Always fully resolved by now, regardless of what pending_eviction held
+    // on entry.
+    *pending_eviction = None;
+
     res
 }
 
 /// Set `output_jack` to 0-10V DAC mode and write `dac_counts`, then hold it
 /// there for the caller to measure manually (e.g. with an external frequency
-/// counter). The value is written once; pick a jack with no app assigned so
-/// nothing else overwrites `MAX_VALUES_DAC`.
+/// counter). If an app is running on `output_jack`, it is temporarily
+/// evicted; `pending_eviction` remembers it (jack, evicted app) across the
+/// paired `ReleaseVoOctOutput` call, since the caller measures externally
+/// with an arbitrary delay in between. Only one eviction is tracked at a
+/// time, matching the configurator's manual flow (which only ever targets
+/// one jack per session) — if a different jack is already pending, it is
+/// restored first.
 async fn handle_set_voct_output(
     proto: &mut ConfigTransport<'_>,
+    layout: &Layout,
+    pending_eviction: &mut Option<(u8, EvictedApp)>,
     output_jack: u8,
     dac_counts: u16,
 ) -> Result<(), ProtocolError> {
@@ -341,6 +431,19 @@ async fn handle_set_voct_output(
             return proto.send_msg(ConfigMsgOut::VoOctOutputSet).await;
         }
     };
+
+    if let Some((jack, evicted)) = pending_eviction.take() {
+        if jack == output_jack {
+            *pending_eviction = Some((jack, evicted));
+        } else {
+            restore_jack_owner(evicted).await;
+        }
+    }
+    if pending_eviction.is_none() {
+        if let Some(evicted) = evict_jack_owner(layout, output_jack).await {
+            *pending_eviction = Some((output_jack, evicted));
+        }
+    }
 
     MAX_CHANNEL
         .send(MaxCmd::ConfigurePort {
@@ -354,9 +457,11 @@ async fn handle_set_voct_output(
     proto.send_msg(ConfigMsgOut::VoOctOutputSet).await
 }
 
-/// Release `output_jack` back to high-Z (Mode 0) so apps can reclaim it.
+/// Release `output_jack` back to high-Z (Mode 0) so apps can reclaim it,
+/// restoring whatever app `handle_set_voct_output` evicted for this jack.
 async fn handle_release_voct_output(
     proto: &mut ConfigTransport<'_>,
+    pending_eviction: &mut Option<(u8, EvictedApp)>,
     output_jack: u8,
 ) -> Result<(), ProtocolError> {
     if let Ok(port) = Port::try_from(output_jack as usize) {
@@ -368,6 +473,14 @@ async fn handle_release_voct_output(
                     gpo_level: None,
                 })
                 .await;
+        }
+    }
+
+    if let Some((jack, evicted)) = pending_eviction.take() {
+        if jack == output_jack {
+            restore_jack_owner(evicted).await;
+        } else {
+            *pending_eviction = Some((jack, evicted));
         }
     }
 

--- a/faderpunk/src/tasks/configure.rs
+++ b/faderpunk/src/tasks/configure.rs
@@ -14,7 +14,6 @@ use libfp::{
     AuxJackMode, ConfigMsgIn, ConfigMsgOut, Layout, Value, APP_MAX_PARAMS, GLOBAL_CHANNELS,
 };
 use max11300::config::{ConfigMode0, ConfigMode3, ConfigMode5, Mode, Port, DACRANGE};
-use portable_atomic::Ordering;
 
 use crate::apps::{get_channels, get_config, REGISTERED_APP_IDS};
 use crate::layout::{EvictionCmd, LAYOUT_EVICTION_REQ, LAYOUT_EVICTION_RES, LAYOUT_WATCH};

--- a/faderpunk/src/tasks/configure.rs
+++ b/faderpunk/src/tasks/configure.rs
@@ -19,10 +19,10 @@ use portable_atomic::Ordering;
 use crate::apps::{get_channels, get_config, REGISTERED_APP_IDS};
 use crate::layout::{EvictionCmd, LAYOUT_EVICTION_REQ, LAYOUT_EVICTION_RES, LAYOUT_WATCH};
 use crate::storage::factory_reset;
-use crate::tasks::clock::{VOCT_MEASURE_REQ, VOCT_MEASURE_RES};
 use crate::tasks::global_config::{get_global_config, GLOBAL_CONFIG_WATCH};
 use crate::tasks::max::{MaxCmd, MAX_CHANNEL, MAX_VALUES_DAC};
 use crate::tasks::midi::{SharedUsbSender, CONFIG_CABLE};
+use crate::tasks::voct_freq::{VOCT_MEASURE_REQ, VOCT_MEASURE_RES};
 use crate::version::FIRMWARE_VERSION;
 
 use super::transport::USB_MAX_PACKET_SIZE;
@@ -378,7 +378,11 @@ async fn handle_measure_voct(
     };
 
     let res = match freq_res {
-        Ok(Ok(freq_hz)) => proto.send_msg(ConfigMsgOut::VoOctFrequency { freq_hz }).await,
+        Ok(Ok(freq_hz)) => {
+            proto
+                .send_msg(ConfigMsgOut::VoOctFrequency { freq_hz })
+                .await
+        }
         _ => proto.send_msg(ConfigMsgOut::VoOctCalError).await,
     };
 

--- a/faderpunk/src/tasks/configure.rs
+++ b/faderpunk/src/tasks/configure.rs
@@ -359,6 +359,9 @@ async fn handle_measure_voct(
     let drive_and_measure = async {
         MAX_VALUES_DAC[output_jack as usize].store(dac_counts, Ordering::Relaxed);
         embassy_time::Timer::after_millis(300).await;
+        // Clear any stale result a previous, timed-out measurement might
+        // still be holding, so it can't be mistaken for this request's answer.
+        VOCT_MEASURE_RES.reset();
         VOCT_MEASURE_REQ[aux_idx].signal(());
         with_timeout(Duration::from_secs(30), VOCT_MEASURE_RES.wait()).await
     };

--- a/faderpunk/src/tasks/global_config.rs
+++ b/faderpunk/src/tasks/global_config.rs
@@ -1,6 +1,6 @@
 use embassy_executor::Spawner;
 use embassy_futures::select::{select, Either};
-use embassy_sync::{blocking_mutex::raw::ThreadModeRawMutex, watch::Watch};
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, watch::Watch};
 use embassy_time::Timer;
 use libfp::{AuxJackMode, GlobalConfig, Key, Note, LED_BRIGHTNESS_RANGE};
 use max11300::config::{ConfigMode0, ConfigMode3, Mode, Port};
@@ -33,7 +33,7 @@ fn swing_to_val(swing: i8) -> u16 {
 }
 
 pub static GLOBAL_CONFIG_WATCH: Watch<
-    ThreadModeRawMutex,
+    CriticalSectionRawMutex,
     GlobalConfig,
     GLOBAL_CONFIG_WATCH_SUBSCRIBERS,
 > = Watch::new_with(GlobalConfig::new());

--- a/faderpunk/src/tasks/max.rs
+++ b/faderpunk/src/tasks/max.rs
@@ -358,16 +358,16 @@ async fn message_loop(max_driver: &'static SharedMax) {
                 _ => {}
             },
             MaxCmd::GpoSetHigh { port } => {
-                max.gpo_set_high(port).await.unwrap();
+                max.gpo_set_high(port).await.ok();
             }
             MaxCmd::GpoSetLow { port } => {
-                max.gpo_set_low(port).await.unwrap();
+                max.gpo_set_low(port).await.ok();
             }
             MaxCmd::GpoSetHighMany(ports) => {
-                max.gpo_set_high_many(&ports).await.unwrap();
+                max.gpo_set_high_many(&ports).await.ok();
             }
             MaxCmd::GpoSetLowMany(ports) => {
-                max.gpo_set_low_many(&ports).await.unwrap();
+                max.gpo_set_low_many(&ports).await.ok();
             }
         }
     }

--- a/faderpunk/src/tasks/mod.rs
+++ b/faderpunk/src/tasks/mod.rs
@@ -10,3 +10,4 @@ pub mod leds;
 pub mod max;
 pub mod midi;
 pub mod transport;
+pub mod voct_freq;

--- a/faderpunk/src/tasks/voct_freq.rs
+++ b/faderpunk/src/tasks/voct_freq.rs
@@ -1,0 +1,187 @@
+//! AUX-input frequency measurement for the V/Oct calibration wizard.
+//!
+//! The three AUX pins are owned by the clock task; `aux_pin_loop` time-shares
+//! each pin between clock-edge detection (`clock::make_ext_clock_loop`) and
+//! frequency measurement, switching over when a measurement is requested.
+
+use embassy_futures::select::select;
+use embassy_rp::gpio::Input;
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
+use embassy_time::{with_timeout, Duration, Instant};
+
+use libfp::ClockSrc;
+
+use crate::tasks::clock::make_ext_clock_loop;
+
+/// Signals the AUX pin loop to pause clock detection and run a frequency
+/// measurement. Index corresponds to aux pin: 0=Atom, 1=Meteor, 2=Cube.
+pub static VOCT_MEASURE_REQ: [Signal<CriticalSectionRawMutex, ()>; 3] =
+    [const { Signal::new() }; 3];
+/// Result of a V/Oct frequency measurement: Ok(freq_hz) or Err(()) on timeout.
+pub static VOCT_MEASURE_RES: Signal<CriticalSectionRawMutex, Result<f32, ()>> = Signal::new();
+
+/// Measure the frequency of an incoming signal on `pin` by timing rising edges.
+/// Returns `Ok(freq_hz)` or `Err(())` on timeout (2 s without a valid edge).
+/// Accepts only signals in the 10 Hz – 10 kHz band; edges outside this range
+/// are discarded without corrupting the period accumulator.
+///
+/// 256 samples span ~580 ms at 440 Hz, keeping endpoint jitter below 0.01%.
+async fn sync_to_rising_edge(pin: &mut Input<'_>, timeout: Duration) -> Result<Instant, ()> {
+    loop {
+        with_timeout(timeout, pin.wait_for_rising_edge())
+            .await
+            .map_err(|_| ())?;
+        let now = Instant::now();
+        // Level-check: if pin is already LOW the edge was a narrow glitch that
+        // resolved before Embassy scheduled us. Skip it without advancing the
+        // anchor — mirrors little-helper's ISR-level pin re-read.
+        if pin.is_high() {
+            return Ok(now);
+        }
+    }
+}
+
+async fn measure_frequency(pin: &mut Input<'_>) -> Result<f32, ()> {
+    const ROUGH_SAMPLES: u64 = 8;
+    const FINE_SAMPLES: u64 = 256;
+    const MIN_PERIOD_US: u64 = 100; // 10 kHz upper limit
+    const MAX_PERIOD_US: u64 = 100_000; // 10 Hz lower limit
+    const TIMEOUT: Duration = Duration::from_secs(2);
+
+    // --- Phase 1: rough period estimate (wide gate, few samples) ---
+    let mut last_edge = sync_to_rising_edge(pin, TIMEOUT).await?;
+    let mut rough_total_us: u64 = 0;
+    let mut rough_valid: u64 = 0;
+
+    while rough_valid < ROUGH_SAMPLES {
+        let now = sync_to_rising_edge(pin, TIMEOUT).await?;
+        let period_us = now.duration_since(last_edge).as_micros();
+
+        if period_us < MIN_PERIOD_US {
+            continue;
+        }
+        if period_us > MAX_PERIOD_US {
+            last_edge = now;
+            continue;
+        }
+        last_edge = now;
+        rough_total_us += period_us;
+        rough_valid += 1;
+    }
+
+    if rough_total_us == 0 {
+        return Err(());
+    }
+    let rough_period_us = rough_total_us / rough_valid;
+
+    // --- Phase 2: fine measurement with adaptive gate ---
+    // Gate rejects any interval outside [60%, 150%] of the rough period.
+    // A spurious edge mid-cycle creates a sub-fundamental interval that sits
+    // below the 60% floor and is rejected without advancing the anchor.
+    let lo = rough_period_us * 6 / 10;
+    let hi = rough_period_us * 15 / 10;
+
+    last_edge = sync_to_rising_edge(pin, TIMEOUT).await?;
+    let mut total_period_us: u64 = 0;
+    let mut valid: u64 = 0;
+
+    while valid < FINE_SAMPLES {
+        let now = sync_to_rising_edge(pin, TIMEOUT).await?;
+        let period_us = now.duration_since(last_edge).as_micros();
+
+        if period_us < lo {
+            // Short interval: spurious edge — keep current anchor.
+            continue;
+        }
+        if period_us > hi {
+            if period_us > MAX_PERIOD_US {
+                // Gap / sub-10 Hz: reset anchor.
+                last_edge = now;
+            }
+            continue;
+        }
+
+        last_edge = now;
+        total_period_us += period_us;
+        valid += 1;
+    }
+
+    if total_period_us == 0 {
+        return Err(());
+    }
+    Ok(FINE_SAMPLES as f32 * 1_000_000.0 / total_period_us as f32)
+}
+
+/// Runs the clock-detection loop for one AUX pin, breaking out to perform a
+/// frequency measurement whenever `VOCT_MEASURE_REQ[aux_idx]` is signalled.
+pub async fn aux_pin_loop(mut pin: Input<'_>, src: ClockSrc, aux_idx: usize) {
+    loop {
+        select(
+            make_ext_clock_loop(&mut pin, src),
+            VOCT_MEASURE_REQ[aux_idx].wait(),
+        )
+        .await;
+
+        // Measurement requested: measure and signal result; clock loop restarts.
+        let result = measure_frequency(&mut pin).await;
+        VOCT_MEASURE_RES.signal(result);
+    }
+}
+
+/// Debug helper: continuously measures frequency on `pin` and logs each result.
+/// First pass also logs raw per-edge periods to diagnose spurious edges.
+/// Swap into `run_clock_sources` in place of `aux_pin_loop` for field testing.
+#[allow(dead_code)]
+async fn debug_freq_loop(mut pin: Input<'_>) {
+    const TIMEOUT: Duration = Duration::from_secs(2);
+    const MIN_PERIOD_US: u64 = 100;
+    const MAX_PERIOD_US: u64 = 100_000;
+
+    defmt::info!("ATOM debug: logging raw periods for first 20 edges");
+    let Ok(mut last_edge) = sync_to_rising_edge(&mut pin, TIMEOUT).await else {
+        defmt::warn!("ATOM debug: no signal on startup");
+        return;
+    };
+    let mut rejected: u32 = 0;
+    let mut accepted: u32 = 0;
+    let mut min_us: u64 = u64::MAX;
+    let mut max_us: u64 = 0;
+
+    while accepted < 20 {
+        let Ok(now) = sync_to_rising_edge(&mut pin, TIMEOUT).await else {
+            defmt::warn!("ATOM debug: timeout during raw period log");
+            break;
+        };
+        let period_us = now.duration_since(last_edge).as_micros();
+        if !(MIN_PERIOD_US..=MAX_PERIOD_US).contains(&period_us) {
+            rejected += 1;
+            last_edge = now;
+            continue;
+        }
+        defmt::info!("ATOM raw period: {} us", period_us);
+        if period_us < min_us {
+            min_us = period_us;
+        }
+        if period_us > max_us {
+            max_us = period_us;
+        }
+        last_edge = now;
+        accepted += 1;
+    }
+    defmt::info!(
+        "ATOM raw: {} accepted, {} rejected, min={} us, max={} us",
+        accepted,
+        rejected,
+        min_us,
+        max_us
+    );
+
+    defmt::info!("ATOM debug: starting continuous frequency measurement");
+    loop {
+        defmt::info!("ATOM debug: waiting for signal...");
+        match measure_frequency(&mut pin).await {
+            Ok(hz) => defmt::info!("ATOM freq: {} Hz", hz),
+            Err(()) => defmt::warn!("ATOM: no signal (timeout after 2s)"),
+        }
+    }
+}

--- a/gen-bindings/src/main.rs
+++ b/gen-bindings/src/main.rs
@@ -28,6 +28,7 @@ fn main() {
             libfp::ConfigMsgIn,
             libfp::ConfigMsgOut,
             libfp::Curve,
+            libfp::CustomVoOctCurve,
             libfp::GlobalConfig,
             libfp::I2cMode,
             libfp::Key,

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -406,17 +406,7 @@ impl VoltPerOct {
         match self {
             VoltPerOct::Standard => 410,
             VoltPerOct::Buchla => 492,
-            VoltPerOct::Custom(idx) => {
-                let cpo = curves
-                    .get(idx as usize)
-                    .map(|c| c.counts_per_oct)
-                    .unwrap_or(0);
-                if cpo == 0 {
-                    410
-                } else {
-                    cpo as i16
-                }
-            }
+            VoltPerOct::Custom(idx) => resolve_custom_cpo(idx, curves) as i16,
         }
     }
 
@@ -442,18 +432,27 @@ impl VoltPerOct {
         match self {
             VoltPerOct::Standard => 1.0,
             VoltPerOct::Buchla => 1.2,
-            VoltPerOct::Custom(idx) => {
-                let cpo = curves
-                    .get(idx as usize)
-                    .map(|c| c.counts_per_oct)
-                    .unwrap_or(0);
-                if cpo == 0 {
-                    1.0
-                } else {
-                    cpo as f32 / 409.5
-                }
-            }
+            VoltPerOct::Custom(idx) => resolve_custom_cpo(idx, curves) as f32 / 409.5,
         }
+    }
+}
+
+/// Resolve a Custom curve's calibrated counts-per-octave, clamped to a
+/// plausible hardware range and falling back to the nominal Standard value
+/// (410) if uncalibrated (0) or implausible. Shared by
+/// `counts_per_oct_with_curves`/`voltage_scale_with_curves` so their
+/// fallback rule can't drift apart, and so a corrupt or wildly-miscalibrated
+/// curve can't produce a negative `i16` count (the raw `u16` would otherwise
+/// wrap when cast for any value above `i16::MAX`).
+fn resolve_custom_cpo(idx: u8, curves: &[CustomVoOctCurve; 4]) -> u16 {
+    let cpo = curves
+        .get(idx as usize)
+        .map(|c| c.counts_per_oct)
+        .unwrap_or(0);
+    if cpo == 0 || cpo > 2000 {
+        410
+    } else {
+        cpo
     }
 }
 
@@ -1502,8 +1501,42 @@ impl MidiOut {
 
 #[cfg(test)]
 mod tests {
-    use super::{Layout, GLOBAL_CHANNELS};
+    use super::{CustomVoOctCurve, Layout, VoltPerOct, GLOBAL_CHANNELS};
     use heapless::Vec;
+
+    #[test]
+    fn custom_cpo_falls_back_to_standard_when_uncalibrated_or_implausible() {
+        let uncalibrated = [CustomVoOctCurve::default(); 4];
+        assert_eq!(
+            VoltPerOct::Custom(0).counts_per_oct_with_curves(&uncalibrated),
+            410
+        );
+
+        // A wildly-miscalibrated curve above the plausible range must not be
+        // used verbatim: cast to i16 it would otherwise wrap negative.
+        let mut wild = [CustomVoOctCurve::default(); 4];
+        wild[0].counts_per_oct = 43_000;
+        assert_eq!(VoltPerOct::Custom(0).counts_per_oct_with_curves(&wild), 410);
+        // Falls back to the same resolved 410 counts/oct as the counts
+        // variant above (410 / 409.5), not an artificial exact 1.0 — the two
+        // variants must agree on what "uncalibrated" resolves to.
+        assert!(
+            (VoltPerOct::Custom(0).voltage_scale_with_curves(&wild) - 410.0 / 409.5).abs() < 1e-6
+        );
+
+        // A plausible calibrated curve is used as-is, consistently between
+        // the counts and scale variants (410/409.5 would disagree otherwise).
+        let mut calibrated = [CustomVoOctCurve::default(); 4];
+        calibrated[0].counts_per_oct = 450;
+        assert_eq!(
+            VoltPerOct::Custom(0).counts_per_oct_with_curves(&calibrated),
+            450
+        );
+        assert!(
+            (VoltPerOct::Custom(0).voltage_scale_with_curves(&calibrated) - 450.0 / 409.5).abs()
+                < 1e-6
+        );
+    }
 
     fn mock_get_channels(app_id: u8) -> Option<usize> {
         match app_id {

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -382,12 +382,14 @@ impl Key {
 }
 
 /// Volts-per-octave standard. Selects pitch calibration for quantizer and pitch apps.
-/// `Standard` = 1V/Oct (Eurorack), `Buchla` = 1.2V/Oct.
+/// `Standard` = 1V/Oct (Eurorack), `Buchla` = 1.2V/Oct, `Custom(idx)` = user-calibrated curve.
 #[derive(Clone, Copy, Default, Debug, PartialEq, Serialize, Deserialize, PostcardBindings)]
 pub enum VoltPerOct {
     #[default]
     Standard,
     Buchla,
+    /// Index into `GlobalConfig::custom_voct_curves` (0–3).
+    Custom(u8),
 }
 
 impl VoltPerOct {
@@ -395,6 +397,26 @@ impl VoltPerOct {
         match self {
             VoltPerOct::Standard => 410,
             VoltPerOct::Buchla => 492,
+            VoltPerOct::Custom(_) => 410,
+        }
+    }
+
+    /// Like `counts_per_oct` but resolves custom curves from the stored calibration data.
+    pub fn counts_per_oct_with_curves(self, curves: &[CustomVoOctCurve; 4]) -> i16 {
+        match self {
+            VoltPerOct::Standard => 410,
+            VoltPerOct::Buchla => 492,
+            VoltPerOct::Custom(idx) => {
+                let cpo = curves
+                    .get(idx as usize)
+                    .map(|c| c.counts_per_oct)
+                    .unwrap_or(0);
+                if cpo == 0 {
+                    410
+                } else {
+                    cpo as i16
+                }
+            }
         }
     }
 
@@ -402,6 +424,7 @@ impl VoltPerOct {
         match self {
             VoltPerOct::Standard => 12.0,
             VoltPerOct::Buchla => 10.0,
+            VoltPerOct::Custom(_) => 12.0,
         }
     }
 
@@ -409,8 +432,38 @@ impl VoltPerOct {
         match self {
             VoltPerOct::Standard => 1.0,
             VoltPerOct::Buchla => 1.2,
+            VoltPerOct::Custom(_) => 1.0,
         }
     }
+
+    /// Like `voltage_scale` but resolves custom curves from calibration data.
+    /// Derives scale from `counts_per_oct / 409.5` (the DAC counts for 1V in a 10V range).
+    pub fn voltage_scale_with_curves(self, curves: &[CustomVoOctCurve; 4]) -> f32 {
+        match self {
+            VoltPerOct::Standard => 1.0,
+            VoltPerOct::Buchla => 1.2,
+            VoltPerOct::Custom(idx) => {
+                let cpo = curves
+                    .get(idx as usize)
+                    .map(|c| c.counts_per_oct)
+                    .unwrap_or(0);
+                if cpo == 0 {
+                    1.0
+                } else {
+                    cpo as f32 / 409.5
+                }
+            }
+        }
+    }
+}
+
+/// One user-calibrated V/Oct gain curve stored in `GlobalConfig`.
+/// `counts_per_oct = 0` means uncalibrated; apps fall back to the Standard value (410).
+#[derive(Clone, Copy, Default, Serialize, Deserialize, PostcardBindings, Encode, Decode)]
+pub struct CustomVoOctCurve {
+    #[n(0)]
+    #[cbor(default)]
+    pub counts_per_oct: u16,
 }
 
 impl From<VoltPerOct> for Value {
@@ -662,6 +715,9 @@ pub struct GlobalConfig {
     #[n(6)]
     #[cbor(default)]
     pub takeover_mode: TakeoverMode,
+    #[n(7)]
+    #[cbor(default)]
+    pub custom_voct_curves: [CustomVoOctCurve; 4],
 }
 
 impl Default for GlobalConfig {
@@ -685,6 +741,7 @@ impl GlobalConfig {
             midi: MidiConfig::new(),
             quantizer: QuantizerConfig::new(),
             takeover_mode: TakeoverMode::Pickup,
+            custom_voct_curves: [CustomVoOctCurve { counts_per_oct: 0 }; 4],
         }
     }
 
@@ -1104,6 +1161,27 @@ pub enum ConfigMsgIn {
     },
     FactoryReset,
     GetVersion,
+    /// Set `output_jack` to `dac_counts` (0-10V DAC range), then measure the
+    /// frequency on `aux_input` (0=Atom, 1=Meteor, 2=Cube). Responds with
+    /// `VoOctFrequency` or `VoOctCalError`. Call twice with dac_counts=410
+    /// then dac_counts=2460 to get the two reference frequencies.
+    MeasureVoOct {
+        output_jack: u8,
+        aux_input: u8,
+        dac_counts: u16,
+    },
+    /// Set `output_jack` to `dac_counts` (0-10V DAC range) and hold it there.
+    /// Used for manual V/Oct calibration where the user reads the resulting
+    /// frequency off an external meter. Responds with `VoOctOutputSet`.
+    SetVoOctOutput {
+        output_jack: u8,
+        dac_counts: u16,
+    },
+    /// Release `output_jack` back to high-Z so apps can reclaim it. Responds
+    /// with `VoOctOutputSet`.
+    ReleaseVoOctOutput {
+        output_jack: u8,
+    },
 }
 
 #[derive(Clone, Serialize, PostcardBindings)]
@@ -1117,6 +1195,14 @@ pub enum ConfigMsgOut<'a> {
     AppConfig(u8, usize, ConfigMeta<'a>),
     AppState(u8, &'a [Value]),
     Version { major: u8, minor: u8, patch: u8 },
+    /// Frequency measured on the selected AUX input during V/Oct calibration.
+    VoOctFrequency {
+        freq_hz: u32,
+    },
+    /// V/Oct calibration measurement failed (no signal or timeout).
+    VoOctCalError,
+    /// Acknowledges `SetVoOctOutput` / `ReleaseVoOctOutput`.
+    VoOctOutputSet,
 }
 
 pub struct Config<const N: usize> {
@@ -1761,6 +1847,7 @@ mod tests {
             midi: decoded_v0.midi,
             quantizer: decoded_v0.quantizer,
             takeover_mode: decoded_v0.takeover_mode,
+            custom_voct_curves: Default::default(),
         };
         assert_eq!(migrated.led_brightness, 111);
 
@@ -1858,6 +1945,7 @@ mod tests {
             midi: decoded_v17.midi,
             quantizer: decoded_v17.quantizer,
             takeover_mode: TakeoverMode::Pickup,
+            custom_voct_curves: Default::default(),
         };
         assert_eq!(migrated.led_brightness, 111);
         assert_eq!(migrated.clock.swing_amount, 0);

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -1197,7 +1197,7 @@ pub enum ConfigMsgOut<'a> {
     Version { major: u8, minor: u8, patch: u8 },
     /// Frequency measured on the selected AUX input during V/Oct calibration.
     VoOctFrequency {
-        freq_hz: u32,
+        freq_hz: f32,
     },
     /// V/Oct calibration measurement failed (no signal or timeout).
     VoOctCalError,

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -1193,7 +1193,11 @@ pub enum ConfigMsgOut<'a> {
     Layout(Layout),
     AppConfig(u8, usize, ConfigMeta<'a>),
     AppState(u8, &'a [Value]),
-    Version { major: u8, minor: u8, patch: u8 },
+    Version {
+        major: u8,
+        minor: u8,
+        patch: u8,
+    },
     /// Frequency measured on the selected AUX input during V/Oct calibration.
     VoOctFrequency {
         freq_hz: f32,

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -2,6 +2,7 @@
 
 use core::ops::Add;
 
+use crate::quantizer::Pitch;
 use embassy_time::Duration;
 use heapless::Vec;
 use max11300::config::{ADCRANGE, DACRANGE};
@@ -769,6 +770,20 @@ impl GlobalConfig {
             }
             _ => {}
         }
+    }
+
+    /// Convert a quantized pitch to DAC counts, resolving any Custom V/Oct
+    /// curve from this config's `custom_voct_curves`. Prefer this over
+    /// `Pitch::as_counts_with_curves` when a `GlobalConfig` value is already
+    /// in hand.
+    pub fn pitch_as_counts(&self, pitch: Pitch, range: Range, vpo: VoltPerOct) -> u16 {
+        pitch.as_counts_with_curves(range, vpo, &self.custom_voct_curves)
+    }
+
+    /// Return DAC counts-per-octave for `vpo`, resolving any Custom V/Oct
+    /// curve from this config's `custom_voct_curves`.
+    pub fn vpo_counts_per_oct(&self, vpo: VoltPerOct) -> i16 {
+        vpo.counts_per_oct_with_curves(&self.custom_voct_curves)
     }
 }
 

--- a/libfp/src/quantizer.rs
+++ b/libfp/src/quantizer.rs
@@ -1,7 +1,7 @@
 // V/oct quantizer, based on the ideas in
 // https://github.com/pichenettes/eurorack/blob/master/braids/quantizer_scales.h
 
-use crate::{Key, MidiNote, Note, Range, VoltPerOct};
+use crate::{CustomVoOctCurve, Key, MidiNote, Note, Range, VoltPerOct};
 use heapless::Vec;
 use libm::roundf;
 
@@ -33,6 +33,26 @@ impl Pitch {
             Range::_Neg5_5V => ((scaled + 5.0) / 10.0) * 4095.0,
         };
 
+        roundf(counts).clamp(0.0, 4095.0) as u16
+    }
+
+    /// Like `as_counts` but resolves custom V/Oct curves from calibration data.
+    pub fn as_counts_with_curves(
+        &self,
+        range: Range,
+        vpo: VoltPerOct,
+        curves: &[CustomVoOctCurve; 4],
+    ) -> u16 {
+        if let Some(raw) = self.raw {
+            return raw;
+        }
+        let voltage = self.as_v_oct();
+        let scaled = voltage * vpo.voltage_scale_with_curves(curves);
+        let counts = match range {
+            Range::_0_10V => (scaled / 10.0) * 4095.0,
+            Range::_0_5V => (scaled / 5.0) * 4095.0,
+            Range::_Neg5_5V => ((scaled + 5.0) / 10.0) * 4095.0,
+        };
         roundf(counts).clamp(0.0, 4095.0) as u16
     }
 


### PR DESCRIPTION
## Summary

- Adds an automated V/Oct calibration wizard to the Custom V/Oct Curves settings panel: drives the selected output jack to 1V and 4V, measures the VCO audio frequency on the chosen AUX input (Atom/Meteor/Cube), and computes the exact counts-per-octave for that VCO
- Pre-settles the VCO before the confirmation measurement (SetVoOctOutput + 800ms JS delay) to compensate for slow CV response when voltage drops
- Frequency measurement returns `f32` for sub-Hz precision instead of integer Hz

Based on #572.

## Test plan

- Connect a VCO V/Oct input to a Faderpunk output jack and the VCO audio output to an AUX input (Atom/Meteor/Cube)
- Open Custom V/Oct Curves in settings, run the automated calibration wizard on a free slot
- Confirm the wizard completes without error and the measured gain matches the VCO's known tracking (e.g. 1.020 V/Oct)
- Confirm the confirmation step passes (within expected cents)
- Assign the calibrated curve to a pitch app and verify the VCO tracks correctly across the keyboard