### PR TITLE
feat: Curve::Deadzone fader curve + wire into 8 apps

### DIFF
--- a/configurator/public/icons/deadzone.svg
+++ b/configurator/public/icons/deadzone.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <path d="M17,84.3L40.85,48.6L52.85,48.6L76.7,12.9"
+        stroke="currentColor"
+        stroke-width="4"
+        fill="none"
+        stroke-linecap="round"
+        stroke-linejoin="round" />
+</svg>

--- a/faderpunk/src/apps/automator.rs
+++ b/faderpunk/src/apps/automator.rs
@@ -14,8 +14,8 @@ use libfp::{
         attenuate, attenuate_bipolar, interp_loop_sample, midi_gate, slew_exp,
         split_unsigned_value, SlewState,
     },
-    AppIcon, Brightness, ClockDivision, Color, Config, MidiCc, MidiChannel, MidiOut, Param, Range,
-    Value, APP_MAX_PARAMS,
+    AppIcon, Brightness, ClockDivision, Color, Config, Curve, MidiCc, MidiChannel, MidiOut, Param,
+    Range, Value, APP_MAX_PARAMS,
 };
 
 use crate::{
@@ -397,7 +397,11 @@ pub async fn run(
                             } else {
                                 attenuate(sample, att_val)
                             };
-                            let with_offset = (attenuated as i32 + offset_val as i32 - 2048)
+                            // Curved so the fader's center flat zone reliably
+                            // lands on exactly zero offset instead of drifting near it.
+                            let with_offset = (attenuated as i32
+                                + Curve::Deadzone.at(offset_val) as i32
+                                - 2048)
                                 .clamp(0, 4095)
                                 as u16;
                             // Roll interpolation window: current target → prev, new → target.

--- a/faderpunk/src/apps/clkturing.rs
+++ b/faderpunk/src/apps/clkturing.rs
@@ -227,7 +227,9 @@ pub async fn run(
             let inputval = input.get_value();
             if inputval >= 406 && oldinputval < 406 {
                 register = register_glob.get();
-                let prob = prob_glob.get();
+                // Curved so the fader's center flat zone reliably lands on a
+                // balanced 50/50 flip probability instead of drifting near it.
+                let prob = Curve::Deadzone.at(prob_glob.get());
                 let rand = die.roll().clamp(100, 3900);
 
                 let rotation = rotate_select_bit(register, prob, rand, length);

--- a/faderpunk/src/apps/cv2midi.rs
+++ b/faderpunk/src/apps/cv2midi.rs
@@ -7,7 +7,7 @@ use heapless::Vec;
 use libfp::{
     latch::LatchLayer,
     utils::{attenuate, attenuate_bipolar, midi_gate, split_unsigned_value},
-    AppIcon, Brightness, Color, MidiCc, MidiChannel, MidiOut, APP_MAX_PARAMS,
+    AppIcon, Brightness, Color, Curve, MidiCc, MidiChannel, MidiOut, APP_MAX_PARAMS,
 };
 use serde::{Deserialize, Serialize};
 
@@ -188,8 +188,10 @@ pub async fn run(
                         + storage.query(|s| s.offset_saved))
                     .clamp(0, 4095)
                 } else {
+                    // Curved so the fader's center flat zone reliably lands
+                    // on exactly zero offset instead of drifting near it.
                     (attenuate_bipolar(input.get_value(), storage.query(|s| s.att_saved)) as i16
-                        + (storage.query(|s| s.offset_saved) as i16 - 2047))
+                        + (Curve::Deadzone.at(storage.query(|s| s.offset_saved)) as i16 - 2047))
                         .clamp(0, 4095) as u16
                 }
             } else if range.is_bipolar() {

--- a/faderpunk/src/apps/follower.rs
+++ b/faderpunk/src/apps/follower.rs
@@ -172,7 +172,10 @@ pub async fn run(
             );
             let oldval_int = oldval.value();
 
-            let att = storage.query(|s| s.att_saved);
+            // Curved so the fader's center flat zone reliably lands on the
+            // attenuverter's true zero (signal fully attenuated) instead of
+            // drifting near it.
+            let att = Curve::Deadzone.at(storage.query(|s| s.att_saved));
             let offset = storage.query(|s| s.offset_saved) as i32 - 2047;
 
             let outval = ((attenuverter(oldval_int, att) as i32 + offset) as u16).clamp(0, 4095);

--- a/faderpunk/src/apps/follower.rs
+++ b/faderpunk/src/apps/follower.rs
@@ -176,7 +176,9 @@ pub async fn run(
             // attenuverter's true zero (signal fully attenuated) instead of
             // drifting near it.
             let att = Curve::Deadzone.at(storage.query(|s| s.att_saved));
-            let offset = storage.query(|s| s.offset_saved) as i32 - 2047;
+            // Curved so the fader's center flat zone reliably lands on
+            // exactly zero offset instead of drifting near it.
+            let offset = Curve::Deadzone.at(storage.query(|s| s.offset_saved)) as i32 - 2047;
 
             let outval = ((attenuverter(oldval_int, att) as i32 + offset) as u16).clamp(0, 4095);
 

--- a/faderpunk/src/apps/offset_att.rs
+++ b/faderpunk/src/apps/offset_att.rs
@@ -10,7 +10,7 @@ use libfp::{
     ext::FromValue,
     latch::LatchLayer,
     utils::{attenuverter, clickless, split_unsigned_value},
-    AppIcon, Brightness, Color, Config, Param, Range, Value, APP_MAX_PARAMS,
+    AppIcon, Brightness, Color, Config, Curve, Param, Range, Value, APP_MAX_PARAMS,
 };
 
 use crate::app::{App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
@@ -157,7 +157,11 @@ pub async fn run(
             );
             let offset = offset_fad as i32 - 2047;
 
-            let mut outval = (attenuverter(inval, att) as i32 + offset).clamp(0, 4095) as u16;
+            // Curved so the fader's center flat zone reliably lands on the
+            // attenuverter's true zero (signal fully attenuated) instead of
+            // drifting near it.
+            let mut outval =
+                (attenuverter(inval, Curve::Deadzone.at(att)) as i32 + offset).clamp(0, 4095) as u16;
             outval = ((outval as i32 - 2047) * 2 + 2047).clamp(0, 4094) as u16;
 
             output.set_value(outval);

--- a/faderpunk/src/apps/offset_att.rs
+++ b/faderpunk/src/apps/offset_att.rs
@@ -155,7 +155,9 @@ pub async fn run(
                     2047
                 },
             );
-            let offset = offset_fad as i32 - 2047;
+            // Curved so the fader's center flat zone reliably lands on
+            // exactly zero offset instead of drifting near it.
+            let offset = Curve::Deadzone.at(offset_fad) as i32 - 2047;
 
             // Curved so the fader's center flat zone reliably lands on the
             // attenuverter's true zero (signal fully attenuated) instead of

--- a/faderpunk/src/apps/seq8.rs
+++ b/faderpunk/src/apps/seq8.rs
@@ -172,6 +172,31 @@ fn probability_threshold(fader: u16) -> u16 {
     205 + ((fader as u32 * 3891) / 4095) as u16
 }
 
+// The "8 steps" bucket (`raw / 256 + 1 == 8`) spans raw [1792, 2047], centered
+// at ~1920 — not the fader's physical center (2048), since 256 divides evenly
+// into 2048 and lands exactly on the 8/9 boundary. Unlike swing/tb3po, whose
+// hot value happens to straddle 2048, this notch has to be centered off-axis.
+const SEQ_LENGTH_NOTCH_CENTER: i32 = 1920;
+const SEQ_LENGTH_NOTCH_HALF_WIDTH: i32 = 307;
+
+/// Maps the length fader (0..=4095) to a step count (1..=16). Widens a flat
+/// zone (~15% of travel) around the "8 steps" bucket so it's easy to land on
+/// precisely, mirroring `libfp::Curve::Deadzone` but centered on that bucket
+/// instead of the fader's midpoint.
+fn length_fader_to_seq_length(value: u16) -> u8 {
+    let value = value as i32;
+    let start = SEQ_LENGTH_NOTCH_CENTER - SEQ_LENGTH_NOTCH_HALF_WIDTH;
+    let end = SEQ_LENGTH_NOTCH_CENTER + SEQ_LENGTH_NOTCH_HALF_WIDTH;
+    let warped = if value <= start {
+        (value * SEQ_LENGTH_NOTCH_CENTER) / start
+    } else if value >= end {
+        SEQ_LENGTH_NOTCH_CENTER + ((value - end) * (4095 - SEQ_LENGTH_NOTCH_CENTER)) / (4095 - end)
+    } else {
+        SEQ_LENGTH_NOTCH_CENTER
+    };
+    (warped.clamp(0, 4095) / 256 + 1) as u8
+}
+
 /// Maps a raw step counter to a position within `length`, respecting `direction`.
 fn step_position(direction: Direction, step: usize, length: u8, die_roll: u16) -> usize {
     let l = length as usize;
@@ -209,7 +234,7 @@ fn derive_runtime_params(
     let mut clockres = [0usize; 4];
     let mut gatel = [0u8; 4];
     for n in 0..4 {
-        seq_length[n] = (length_faders[n] / 256 + 1) as u8;
+        seq_length[n] = length_fader_to_seq_length(length_faders[n]);
         clockres[n] = resolution[(res_faders[n] / 512) as usize];
         gatel[n] = (clockres[n] * (gate_faders[n] as usize) / 4096) as u8;
         gatel[n] = gatel[n].clamp(1, clockres[n] as u8 - 1);
@@ -943,7 +968,7 @@ fn apply_alt_update(chan: usize, seq_idx: usize, value: u16, ctx: &AltUpdateCont
             ctx.storage
                 .modify_and_save(|s| s.length_fader[seq_idx] = value);
             let mut arr = ctx.seq_length_glob.get();
-            arr[seq_idx] = (value / 256 + 1) as u8;
+            arr[seq_idx] = length_fader_to_seq_length(value);
             ctx.seq_length_glob.set(arr);
         }
         1 => {

--- a/faderpunk/src/apps/slew.rs
+++ b/faderpunk/src/apps/slew.rs
@@ -151,7 +151,9 @@ pub async fn run(
             // attenuverter's true zero (signal fully attenuated) instead of
             // drifting near it.
             let att = Curve::Deadzone.at(storage.query(|s| s.att_saved));
-            let offset = storage.query(|s| s.offset_saved) as i32 - 2047;
+            // Curved so the fader's center flat zone reliably lands on
+            // exactly zero offset instead of drifting near it.
+            let offset = Curve::Deadzone.at(storage.query(|s| s.offset_saved)) as i32 - 2047;
 
             let outval = ((attenuverter(oldval_int, att) as i32 + offset) as u16).clamp(0, 4095);
 

--- a/faderpunk/src/apps/slew.rs
+++ b/faderpunk/src/apps/slew.rs
@@ -10,7 +10,7 @@ use libfp::{
     ext::FromValue,
     latch::LatchLayer,
     utils::{attenuverter, slew_lin, split_signed_value, split_unsigned_value, SlewState},
-    AppIcon, Brightness, Color, Config, Param, Range, Value, APP_MAX_PARAMS,
+    AppIcon, Brightness, Color, Config, Curve, Param, Range, Value, APP_MAX_PARAMS,
 };
 
 use crate::app::{App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
@@ -147,7 +147,10 @@ pub async fn run(
             );
             let oldval_int = oldval.value();
 
-            let att = storage.query(|s| s.att_saved);
+            // Curved so the fader's center flat zone reliably lands on the
+            // attenuverter's true zero (signal fully attenuated) instead of
+            // drifting near it.
+            let att = Curve::Deadzone.at(storage.query(|s| s.att_saved));
             let offset = storage.query(|s| s.offset_saved) as i32 - 2047;
 
             let outval = ((attenuverter(oldval_int, att) as i32 + offset) as u16).clamp(0, 4095);

--- a/faderpunk/src/apps/tb3po.rs
+++ b/faderpunk/src/apps/tb3po.rs
@@ -12,7 +12,8 @@ use serde::{Deserialize, Serialize};
 
 use libfp::{
     ext::FromValue, latch::LatchLayer, utils::apply_slide, AppIcon, Brightness, ClockDivision,
-    Color, Config, MidiChannel, MidiNote, MidiOut, Param, Range, Value, VoltPerOct, APP_MAX_PARAMS,
+    Color, Config, Curve, MidiChannel, MidiNote, MidiOut, Param, Range, Value, VoltPerOct,
+    APP_MAX_PARAMS,
 };
 
 use crate::app::{
@@ -110,7 +111,7 @@ impl Default for Storage {
         Self {
             seed: 0xABCD,
             density_fader: 2048,   // density 7 (center)
-            length_fader: 1920,    // ~16 steps
+            length_fader: 1920,    // 16 steps (falls in the deadzone flat zone)
             transpose_fader: 2048, // 0 semitones
             octave_fader: 2048,    // 0 octave offset
             res_saved: 2048,       // index 4 → RESOLUTION[4] = 6 (16th notes)
@@ -286,6 +287,13 @@ fn raw_pitch_cv(p: &AcidPattern, step: u8, transpose: i16, vpo: VoltPerOct) -> u
 /// → ~100 ms time constant. `rc_coeff` isn't const-evaluable, so the value is inlined.
 const SLIDE_COEFF: f32 = 0.0465_f32;
 
+/// Maps the length fader (0–4095) to a step count (1–32). Runs through
+/// `Curve::Deadzone` first so the fader's center flat zone reliably lands on
+/// 16 steps instead of drifting between 15/16/17 as the fader wobbles.
+fn length_fader_to_num_steps(length_fader: u16) -> u8 {
+    (Curve::Deadzone.at(length_fader) as u32 * 31 / 4095 + 1) as u8
+}
+
 // --- Embassy Task ---
 
 #[embassy_executor::task(pool_size = 16 / CHANNELS)]
@@ -422,7 +430,7 @@ pub async fn run(
                     let pattern = pattern_glob.get();
                     let (num_steps, no_accents, muted, transpose) = storage.query(|s| {
                         (
-                            (s.length_fader as u32 * 31 / 4095 + 1) as u8,
+                            length_fader_to_num_steps(s.length_fader),
                             s.no_accents,
                             s.muted,
                             {
@@ -677,7 +685,7 @@ pub async fn run(
                     )
                 });
             let density = (density_fader as u32 * 14 / 4095) as u8;
-            let num_steps = (length_fader as u32 * 31 / 4095 + 1) as u8;
+            let num_steps = length_fader_to_num_steps(length_fader);
             let gate_active = gate_active_glob.get();
             let accent = accent_active_glob.get();
             let slide_active = slide_active_glob.get();

--- a/faderpunk/src/apps/tb3po.rs
+++ b/faderpunk/src/apps/tb3po.rs
@@ -294,6 +294,16 @@ fn length_fader_to_num_steps(length_fader: u16) -> u8 {
     (Curve::Deadzone.at(length_fader) as u32 * 31 / 4095 + 1) as u8
 }
 
+/// Maps the transpose (±24 semitones) and octave (±4 octaves) faders to a
+/// combined semitone transpose. Each runs through `Curve::Deadzone` first so
+/// its center flat zone reliably lands on exactly 0 instead of drifting
+/// near it.
+fn transpose_semitones(transpose_fader: u16, octave_fader: u16) -> i16 {
+    let semi = Curve::Deadzone.at(transpose_fader) as i32 * 48 / 4095 - 24;
+    let oct = Curve::Deadzone.at(octave_fader) as i32 * 8 / 4095 - 4;
+    (semi + oct * 12) as i16
+}
+
 // --- Embassy Task ---
 
 #[embassy_executor::task(pool_size = 16 / CHANNELS)]
@@ -433,11 +443,7 @@ pub async fn run(
                             length_fader_to_num_steps(s.length_fader),
                             s.no_accents,
                             s.muted,
-                            {
-                                let semi = s.transpose_fader as i32 * 48 / 4095 - 24;
-                                let oct = s.octave_fader as i32 * 8 / 4095 - 4;
-                                (semi + oct * 12) as i16
-                            },
+                            transpose_semitones(s.transpose_fader, s.octave_fader),
                         )
                     });
 

--- a/faderpunk/src/apps/turing.rs
+++ b/faderpunk/src/apps/turing.rs
@@ -300,7 +300,9 @@ pub async fn run(
                             }
                             leds.set(0, Led::Bottom, Color::White, Brightness::Mid);
                         }
-                        let prob = prob_glob.get();
+                        // Curved so the fader's center flat zone reliably lands on a
+                        // balanced 50/50 flip probability instead of drifting near it.
+                        let prob = Curve::Deadzone.at(prob_glob.get());
                         let rand = die.roll().clamp(100, 3900);
 
                         let (new_reg, _, gate_bit) =

--- a/faderpunk/src/tasks/global_config.rs
+++ b/faderpunk/src/tasks/global_config.rs
@@ -2,7 +2,10 @@ use embassy_executor::Spawner;
 use embassy_futures::select::{select, Either};
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, watch::Watch};
 use embassy_time::Timer;
-use libfp::{AuxJackMode, GlobalConfig, Key, Note, LED_BRIGHTNESS_RANGE};
+use libfp::{
+    deadzone_curve_inverse, AuxJackMode, Curve, GlobalConfig, Key, Note, DEADZONE_CENTER,
+    LED_BRIGHTNESS_RANGE,
+};
 use max11300::config::{ConfigMode0, ConfigMode3, Mode, Port};
 use portable_atomic::Ordering;
 
@@ -25,11 +28,19 @@ const SWING_FADER: usize = 14;
 const INTERNAL_BPM_FADER: usize = 15;
 
 fn val_to_swing(val: u16) -> i8 {
-    (((val as i32 * 70) / 4095) - 35).clamp(-35, 35) as i8
+    let val = Curve::Deadzone.at(val) as i32;
+    (((val * 70) / 4095) - 35).clamp(-35, 35) as i8
 }
 
 fn swing_to_val(swing: i8) -> u16 {
-    (((swing.clamp(-35, 35) as i32 + 35) * 4095) / 70).clamp(0, 4095) as u16
+    let swing = swing.clamp(-35, 35);
+    if swing == 0 {
+        // The dead zone collapses a wide raw range to swing 0; redraw the
+        // fader at the exact center of that zone rather than its edge.
+        return DEADZONE_CENTER;
+    }
+    let linear = (((swing as i32 + 35) * 4095) / 70).clamp(0, 4095) as u16;
+    deadzone_curve_inverse(linear)
 }
 
 pub static GLOBAL_CONFIG_WATCH: Watch<

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -793,6 +793,47 @@ pub enum Curve {
     Linear,
     Logarithmic,
     Exponential,
+    Deadzone,
+}
+
+/// Center output value of [`deadzone_curve`]'s flat zone.
+pub const DEADZONE_CENTER: u16 = 2048;
+const DEADZONE_HALF_WIDTH: i32 = 307;
+const DEADZONE_START: i32 = DEADZONE_CENTER as i32 - DEADZONE_HALF_WIDTH;
+const DEADZONE_END: i32 = DEADZONE_CENTER as i32 + DEADZONE_HALF_WIDTH;
+const DEADZONE_MAX: i32 = 4095;
+
+/// Linear ramp with a flat zone (~15% of travel) held at the exact center
+/// value, so the middle of a fader's travel is easy to land on precisely
+/// (e.g. zeroing a bipolar parameter like swing).
+fn deadzone_curve(value: u16) -> u16 {
+    let value = value as i32;
+    let center = DEADZONE_CENTER as i32;
+    let out = if value <= DEADZONE_START {
+        (value * center) / DEADZONE_START
+    } else if value >= DEADZONE_END {
+        center + ((value - DEADZONE_END) * (DEADZONE_MAX - center)) / (DEADZONE_MAX - DEADZONE_END)
+    } else {
+        center
+    };
+    out.clamp(0, DEADZONE_MAX) as u16
+}
+
+/// Inverse of [`deadzone_curve`]. The flat zone maps a whole range of raw
+/// inputs to the single output `DEADZONE_CENTER`, so an input exactly equal
+/// to it resolves back to the exact center of the flat zone — the canonical
+/// representative raw position — rather than to either ramp.
+pub fn deadzone_curve_inverse(value: u16) -> u16 {
+    let value = (value as i32).clamp(0, DEADZONE_MAX);
+    let center = DEADZONE_CENTER as i32;
+    let out = if value < center {
+        (value * DEADZONE_START) / center
+    } else if value > center {
+        DEADZONE_END + ((value - center) * (DEADZONE_MAX - DEADZONE_END)) / (DEADZONE_MAX - center)
+    } else {
+        center
+    };
+    out.clamp(0, DEADZONE_MAX) as u16
 }
 
 impl Curve {
@@ -802,6 +843,7 @@ impl Curve {
             Curve::Linear => value,
             Curve::Exponential => CURVE_EXP[value as usize],
             Curve::Logarithmic => CURVE_LOG[value as usize],
+            Curve::Deadzone => deadzone_curve(value),
         }
     }
 
@@ -810,6 +852,7 @@ impl Curve {
             Curve::Linear => Curve::Exponential,
             Curve::Exponential => Curve::Logarithmic,
             Curve::Logarithmic => Curve::Linear,
+            Curve::Deadzone => Curve::Linear,
         }
     }
 }
@@ -2006,5 +2049,52 @@ mod tests {
         let decoded: GlobalConfig = minicbor::decode(&encoded).unwrap();
         assert_eq!(decoded.led_brightness, 111);
         assert_eq!(decoded.clock.swing_amount, 0);
+    }
+
+    #[test]
+    fn deadzone_curve_covers_full_range_at_endpoints() {
+        assert_eq!(Curve::Deadzone.at(0), 0);
+        assert_eq!(Curve::Deadzone.at(4095), 4095);
+    }
+
+    #[test]
+    fn deadzone_curve_flat_zone_holds_exact_center() {
+        let start = DEADZONE_START as u16;
+        let end = DEADZONE_END as u16;
+        for raw in [start, start + 50, DEADZONE_CENTER, end - 50, end] {
+            assert_eq!(Curve::Deadzone.at(raw), DEADZONE_CENTER);
+        }
+    }
+
+    #[test]
+    fn deadzone_curve_inverse_returns_center_for_center_input() {
+        assert_eq!(deadzone_curve_inverse(DEADZONE_CENTER), DEADZONE_CENTER);
+    }
+
+    #[test]
+    fn deadzone_curve_inverse_round_trips_ramp_values() {
+        // Values right at DEADZONE_START/END are excluded: the forward curve
+        // already returns exactly DEADZONE_CENTER there (same as the flat
+        // zone), so their inverse is legitimately ambiguous.
+        let just_below_start = (DEADZONE_START - 1) as u16;
+        let just_above_end = (DEADZONE_END + 1) as u16;
+        for raw in [
+            0,
+            500,
+            1000,
+            1500,
+            just_below_start,
+            just_above_end,
+            3000,
+            3500,
+            4095,
+        ] {
+            let warped = Curve::Deadzone.at(raw);
+            let recovered = deadzone_curve_inverse(warped);
+            assert!(
+                (recovered as i32 - raw as i32).abs() <= 1,
+                "raw={raw} warped={warped} recovered={recovered}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #548.

## Summary
- Adds `Curve::Deadzone` to `libfp`: a linear fader curve with a flat ~15%-of-travel zone held at the exact center value, making it easy to land precisely on a fader's meaningful center/neutral position.
- Wires it into 8 apps, each verified on hardware during development:
  - Global swing fader (`global_config.rs`) — flat zone at swing = 0, with `deadzone_curve_inverse` for correct LED redraw on scene recall.
  - `tb3po` — length fader snaps to 16 steps (bucket happens to straddle fader center).
  - `seq8` — length fader snaps to 8 steps via an off-center notch (that bucket doesn't straddle center, needed a repositioned flat zone).
  - `turing` / `turing+` (`clkturing`) — probability fader snaps to a balanced 50/50 flip probability.
  - `offset_att`, `follower`, `slew` — attenuverter fader snaps to true zero (fully attenuated).
  - `offset_att`, `follower`, `slew`, `automator`, `cv2midi`, `tb3po` — bipolar offset/transpose/octave faders snap to exactly zero offset.

## Test plan
Already tested on hardware per-app during development:
- [x] Swing: wide flat zone at center, full ±35 range at extremes, scene recall redraws fader LED at zone center
- [x] tb3po: length fader reliably lands on 16 steps
- [x] seq8: length fader reliably lands on 8 steps
- [x] turing / turing+: probability fader gives a clearly balanced feel at center, full lock/random still reachable
- [x] offset_att / follower / slew: attenuverter and offset faders reliably zero out at center