### PR TITLE
feat: variable PPQN external clock input and phase-correct clock ticks

### DIFF
--- a/configurator/src/components/SettingsTab.tsx
+++ b/configurator/src/components/SettingsTab.tsx
@@ -39,6 +39,7 @@ export interface Inputs {
   auxMeteorDiv?: ClockDivision["tag"];
   auxCubeDiv?: ClockDivision["tag"];
   clockSrc: ClockSrc["tag"];
+  extPpqn: number;
   i2cMode: I2cMode["tag"];
   internalBpm: number;
   swingAmount: number;
@@ -110,6 +111,7 @@ const SettingsForm = ({ config }: SettingsFormProps) => {
       auxCubeDiv:
         "value" in config.aux[2] ? config.aux[2].value.tag : undefined,
       clockSrc: config.clock.clock_src.tag,
+      extPpqn: config.clock.ext_ppqn,
       resetSrc: config.clock.reset_src.tag,
       internalBpm: config.clock.internal_bpm,
       swingAmount: config.clock.swing_amount,
@@ -295,7 +297,7 @@ const transformFormToGlobalConfig = (formValues: Inputs): GlobalConfig => {
     aux: auxArray,
     clock: {
       clock_src: { tag: formValues.clockSrc },
-      ext_ppqn: 24,
+      ext_ppqn: formValues.extPpqn,
       reset_src: { tag: formValues.resetSrc },
       internal_bpm: formValues.internalBpm,
       swing_amount: formValues.swingAmount,

--- a/configurator/src/components/settings/ClockSettings.tsx
+++ b/configurator/src/components/settings/ClockSettings.tsx
@@ -1,11 +1,11 @@
 import type { ClockSrc, ResetSrc } from "@atov/fp-config";
 import { Input } from "@heroui/input";
-import { SelectItem } from "@heroui/select";
+import { Select, SelectItem } from "@heroui/select";
 import { Tooltip } from "@heroui/tooltip";
 import classNames from "classnames";
-import { Controller, useFormContext } from "react-hook-form";
+import { Controller, useFormContext, useWatch } from "react-hook-form";
 import { Icon } from "../Icon";
-import { inputProps } from "../input/defaultProps";
+import { inputProps, selectProps } from "../input/defaultProps";
 import type { Inputs } from "../SettingsTab";
 import { ControlledSelect } from "./ControlledFields";
 
@@ -38,6 +38,22 @@ const clockSrcItems: ClockSrcItem[] = [
   { key: "MidiUsb", value: "MIDI USB", icon: "usb" },
 ];
 
+// Integral ratios of the internal 24 PPQN clock: divisors are multiplied up,
+// multiples divided down. Must stay in sync with the firmware's
+// `effective_ppqn` and the validator in utils/validators.ts.
+const extPpqnItems = [
+  { key: "1", value: "1 PPQN (quarter notes)" },
+  { key: "2", value: "2 PPQN (8th notes)" },
+  { key: "3", value: "3 PPQN (8th triplets)" },
+  { key: "4", value: "4 PPQN (16th notes)" },
+  { key: "6", value: "6 PPQN (16th triplets)" },
+  { key: "8", value: "8 PPQN (32nd notes)" },
+  { key: "12", value: "12 PPQN (32nd triplets)" },
+  { key: "24", value: "24 PPQN (MIDI / DIN sync)" },
+  { key: "48", value: "48 PPQN" },
+  { key: "96", value: "96 PPQN" },
+];
+
 const resetSrcItems: ResetSrcItems[] = [
   { key: "None", value: "None" },
   { key: "Atom", value: "Atom", icon: "atom", iconClass: "text-cyan-fp" },
@@ -52,6 +68,9 @@ const resetSrcItems: ResetSrcItems[] = [
 
 export const ClockSettings = () => {
   const { control } = useFormContext<Inputs>();
+  const clockSrc = useWatch({ control, name: "clockSrc" });
+  const isAnalogClockSrc =
+    clockSrc === "Atom" || clockSrc === "Meteor" || clockSrc === "Cube";
 
   return (
     <div className="mb-12">
@@ -82,6 +101,43 @@ export const ClockSettings = () => {
             </SelectItem>
           )}
         </ControlledSelect>
+        <Controller
+          name="extPpqn"
+          control={control}
+          render={({ field }) => (
+            <Select
+              {...selectProps}
+              classNames={{
+                ...selectProps.classNames,
+                label: "font-medium pb-2 w-full",
+              }}
+              label={
+                <div className="flex w-full items-center justify-between gap-1">
+                  <span>External PPQN</span>
+                  <Tooltip
+                    content="Pulses per quarter note of the analog clock input. Below 24 the clock is multiplied up, above 24 divided down. MIDI clock is always 24 PPQN. Swing is bypassed unless set to 24."
+                    showArrow={true}
+                  >
+                    <button type="button" className="cursor-help">
+                      <Icon className="h-4 w-4" name="info" />
+                    </button>
+                  </Tooltip>
+                </div>
+              }
+              placeholder="External PPQN"
+              isDisabled={!isAnalogClockSrc}
+              selectedKeys={[String(field.value)]}
+              onSelectionChange={(keys) => {
+                if (keys.currentKey) {
+                  field.onChange(Number(keys.currentKey));
+                }
+              }}
+              items={extPpqnItems}
+            >
+              {(item) => <SelectItem>{item.value}</SelectItem>}
+            </Select>
+          )}
+        />
         <ControlledSelect
           name="resetSrc"
           control={control}

--- a/configurator/src/utils/validators.ts
+++ b/configurator/src/utils/validators.ts
@@ -224,7 +224,14 @@ const globalConfigSchema = z.object({
   aux: z.array(taggedObjectSchema).length(3),
   clock: z.object({
     clock_src: taggedObjectSchema,
-    ext_ppqn: z.number().int().min(1).max(96),
+    ext_ppqn: z
+      .number()
+      .int()
+      .min(1)
+      .max(96)
+      .refine((n) => 24 % n === 0 || n % 24 === 0, {
+        message: "External PPQN must be a divisor or multiple of 24",
+      }),
     reset_src: taggedObjectSchema,
     internal_bpm: z.number().min(1).max(300),
     swing_amount: z.number().int().min(-35).max(35).default(0),

--- a/faderpunk/src/app.rs
+++ b/faderpunk/src/app.rs
@@ -23,7 +23,7 @@ use crate::{
     events::{EventPubSubChannel, InputEvent},
     tasks::{
         buttons::{is_channel_button_pressed, is_shift_button_pressed},
-        clock::{ClockSubscriber, CLOCK_PUBSUB, TICK_COUNTER},
+        clock::{ClockSubscriber, CLOCK_PUBSUB},
         global_config::get_global_config,
         i2c::{I2cLeaderMessage, I2cLeaderSender},
         leds::{set_led_mode, LedMode, LedMsg},
@@ -314,10 +314,9 @@ impl Clock {
     pub async fn wait_for_event(&mut self, division: ClockDivision) -> ClockEvent {
         loop {
             match self.subscriber.next_message_pure().await {
-                ClockEvent::Tick => {
-                    let ticks = TICK_COUNTER.load(Ordering::Relaxed);
+                ClockEvent::Tick(ticks) => {
                     if ticks.is_multiple_of(division as u64) {
-                        return ClockEvent::Tick;
+                        return ClockEvent::Tick(ticks);
                     }
                 }
                 ClockEvent::Stop => {
@@ -329,16 +328,6 @@ impl Clock {
             }
         }
     }
-
-    #[allow(dead_code)]
-    pub fn get_ticker(&self) -> fn() -> u64 {
-        ticks
-    }
-}
-
-#[allow(dead_code)]
-fn ticks() -> u64 {
-    TICK_COUNTER.load(Ordering::Relaxed)
 }
 
 pub enum SceneEvent {

--- a/faderpunk/src/apps/automator.rs
+++ b/faderpunk/src/apps/automator.rs
@@ -216,8 +216,6 @@ pub async fn run(
     };
 
     let mut clock = app.use_clock();
-    // Function pointer into TICK_COUNTER; used by clock_handler to check 16th-note boundaries.
-    let tick_fn = clock.get_ticker();
     let fader = app.use_faders();
     let buttons = app.use_buttons();
     let leds = app.use_leds();
@@ -261,7 +259,7 @@ pub async fn run(
     // CV output is driven by main_loop, which slews loop_target_glob at 1 ms.
     //
     // PendingStart / PendingCommit are quantised to 16th-note boundaries:
-    // 24 PPQN / 4 = 6 underlying ticks per 16th note.  tick_fn() % 6 == 0
+    // 24 PPQN / 4 = 6 underlying ticks per 16th note.  tick % 6 == 0
     // detects this boundary regardless of the active clock_div.
     let clock_handler = async {
         // play_buf is intentionally absent: the authoritative buffer lives in
@@ -282,7 +280,7 @@ pub async fn run(
             .await;
 
             match event {
-                Ok(ClockEvent::Tick) => {
+                Ok(ClockEvent::Tick(tick)) => {
                     if !clock_running_glob.get() {
                         clock_running_glob.set(true);
                     }
@@ -297,10 +295,10 @@ pub async fn run(
 
                     // Process any pending command from button_handler.
                     // PendingStart / PendingCommit are held until a 16th-note
-                    // boundary (TICK_COUNTER % 6 == 0); all others fire immediately.
+                    // boundary (tick % 6 == 0); all others fire immediately.
                     let cmd = cmd_glob.get();
                     if cmd != LooperCmd::None {
-                        let on_16th = tick_fn().is_multiple_of(6);
+                        let on_16th = tick.is_multiple_of(6);
                         let ready = match cmd {
                             LooperCmd::PendingStart | LooperCmd::PendingCommit => on_16th,
                             _ => true,
@@ -324,7 +322,7 @@ pub async fn run(
                                             s.has_loop = true;
                                             s.loop_len = loop_len as u16;
                                         });
-                                        loop_start_tick = tick_fn() as u32;
+                                        loop_start_tick = tick as u32;
                                         state_glob.set(LooperState::Playing);
                                         leds.set(0, Led::Button, led_color, Brightness::Mid);
                                     } else if state_glob.get() != LooperState::Playing {
@@ -345,7 +343,7 @@ pub async fn run(
                                     // storage.inner was already updated by the scene recall;
                                     // just sync metadata and re-anchor the phase clock.
                                     loop_len = storage.query(|s| s.loop_len as usize).max(1);
-                                    loop_start_tick = tick_fn() as u32;
+                                    loop_start_tick = tick as u32;
                                 }
                                 LooperCmd::None => {}
                             }
@@ -378,7 +376,7 @@ pub async fn run(
                                     s.has_loop = true;
                                     s.loop_len = MAX_BUFFER_SAMPLES as u16;
                                 });
-                                loop_start_tick = tick_fn() as u32;
+                                loop_start_tick = tick as u32;
                                 rec_head = 0;
                                 state_glob.set(LooperState::Playing);
                                 leds.set(0, Led::Button, led_color, Brightness::Mid);
@@ -386,7 +384,7 @@ pub async fn run(
                             // CV output still driven by main_loop.
                         }
                         LooperState::Playing => {
-                            let clkn = (tick_fn() as u32).wrapping_sub(loop_start_tick);
+                            let clkn = (tick as u32).wrapping_sub(loop_start_tick);
                             let read_head = (clkn / clock_div as u32) as usize % loop_len;
                             if read_head == 0 {
                                 leds.set(0, Led::Button, Color::White, Brightness::High);

--- a/faderpunk/src/apps/bernoulli.rs
+++ b/faderpunk/src/apps/bernoulli.rs
@@ -160,7 +160,6 @@ pub async fn run(
     let curve = Curve::Linear;
 
     let mut clock = app.use_clock();
-    let ticks = clock.get_ticker();
     let die = app.use_die();
     let faders = app.use_faders();
     let buttons = app.use_buttons();
@@ -230,14 +229,14 @@ pub async fn run(
                     leds.unset(1, Led::Top);
                 }
 
-                ClockEvent::Tick => {
+                ClockEvent::Tick(tick) => {
                     let div = div_glob.get();
                     if div != cached_div {
                         cached_div = div;
                         cached_gate_step = (cached_div * gatel / 100).clamp(1, cached_div - 1);
                     }
 
-                    let clkn = ticks() as u32;
+                    let clkn = tick as u32;
 
                     if clkn.is_multiple_of(cached_div) {
                         let probability = prob_glob.get();

--- a/faderpunk/src/apps/clk_div.rs
+++ b/faderpunk/src/apps/clk_div.rs
@@ -164,7 +164,6 @@ pub async fn run(
     });
 
     let mut clock = app.use_clock();
-    let ticks = clock.get_ticker();
     let fader = app.use_faders();
     let buttons = app.use_buttons();
     let leds = app.use_leds();
@@ -215,14 +214,14 @@ pub async fn run(
                     note_on = false;
                     jack.set_low().await;
                 }
-                ClockEvent::Tick => {
+                ClockEvent::Tick(tick) => {
                     let muted = glob_muted.get();
                     let div = div_glob.get();
                     if div != cached_div {
                         cached_div = div;
                         cached_gate_step = (cached_div * gatel / 100).clamp(1, cached_div - 1);
                     }
-                    let clkn = ticks() as u32;
+                    let clkn = tick as u32;
 
                     if clkn.is_multiple_of(cached_div) && !muted {
                         jack.set_high().await;

--- a/faderpunk/src/apps/clk_div_plus.rs
+++ b/faderpunk/src/apps/clk_div_plus.rs
@@ -176,7 +176,6 @@ pub async fn run(
     });
 
     let mut clock = app.use_clock();
-    let ticks = clock.get_ticker();
 
     let fader = app.use_faders();
     let buttons = app.use_buttons();
@@ -252,12 +251,12 @@ pub async fn run(
                         leds.set(1, Led::Bottom, led_color, Brightness::Off);
                     }
                 }
-                ClockEvent::Tick => {
+                ClockEvent::Tick(tick) => {
                     if storage.query(|s| s.dest) != 0 {
                         continue;
                     }
 
-                    let clkn = ticks() as u32;
+                    let clkn = tick as u32;
                     let muted = glob_muted.get();
                     let div_u32 = div_glob.get();
                     let gate_step = (div_u32 * gatel / 100).clamp(1, div_u32.saturating_sub(1));

--- a/faderpunk/src/apps/euclid.rs
+++ b/faderpunk/src/apps/euclid.rs
@@ -210,15 +210,10 @@ pub async fn run(
     let fut1 = async {
         let mut note_on = false;
         let mut aux_on = false;
-        let mut tick_origin: u32 = 0;
-        // Re-anchor the phase on the next tick, so `clkn` counts from 0 at
-        // spawn and after every reset (step 0 lands on the downbeat).
-        let mut reorigin = true;
 
         loop {
             match clock.wait_for_event(ClockDivision::_1).await {
                 ClockEvent::Reset => {
-                    reorigin = true;
                     midi.send_note_off(note).await;
                     midi.send_note_off(note2).await;
                     note_on = false;
@@ -235,11 +230,7 @@ pub async fn run(
                     jack[1].set_low().await;
                 }
                 ClockEvent::Tick(tick) => {
-                    if reorigin {
-                        tick_origin = tick as u32;
-                        reorigin = false;
-                    }
-                    let clkn = (tick as u32).wrapping_sub(tick_origin);
+                    let clkn = tick as u32;
                     let muted = glob_muted.get();
                     let div = div_glob.get();
 

--- a/faderpunk/src/apps/euclid.rs
+++ b/faderpunk/src/apps/euclid.rs
@@ -155,7 +155,6 @@ pub async fn run(
     storage: &ManagedStorage<Storage>,
 ) {
     let mut clock = app.use_clock();
-    let ticks = clock.get_ticker();
     let die = app.use_die();
     let faders = app.use_faders();
     let buttons = app.use_buttons();
@@ -211,10 +210,15 @@ pub async fn run(
     let fut1 = async {
         let mut note_on = false;
         let mut aux_on = false;
+        let mut tick_origin: u32 = 0;
+        // Re-anchor the phase on the next tick, so `clkn` counts from 0 at
+        // spawn and after every reset (step 0 lands on the downbeat).
+        let mut reorigin = true;
 
         loop {
             match clock.wait_for_event(ClockDivision::_1).await {
                 ClockEvent::Reset => {
+                    reorigin = true;
                     midi.send_note_off(note).await;
                     midi.send_note_off(note2).await;
                     note_on = false;
@@ -230,8 +234,12 @@ pub async fn run(
                     jack[0].set_low().await;
                     jack[1].set_low().await;
                 }
-                ClockEvent::Tick => {
-                    let clkn = ticks() as u32;
+                ClockEvent::Tick(tick) => {
+                    if reorigin {
+                        tick_origin = tick as u32;
+                        reorigin = false;
+                    }
+                    let clkn = (tick as u32).wrapping_sub(tick_origin);
                     let muted = glob_muted.get();
                     let div = div_glob.get();
 

--- a/faderpunk/src/apps/fp_grids.rs
+++ b/faderpunk/src/apps/fp_grids.rs
@@ -429,17 +429,22 @@ pub async fn run(
         },
     );
 
-    reset_all_outputs(&midi, leds, notes, ghost_note, &jack, &note_on_glob, &accent_on_glob).await;
+    reset_all_outputs(
+        &midi,
+        leds,
+        notes,
+        ghost_note,
+        &jack,
+        &note_on_glob,
+        &accent_on_glob,
+    )
+    .await;
 
     let main_loop = async {
         let mut clock = app.use_clock();
 
         let mut output_mode = output_mode_glob.get();
         let mut dnb_pattern = dnb_pattern_glob.get();
-        let mut tick_origin: u32 = 0;
-        // Re-anchor the phase on the next tick, so `clkn` counts from 0 at
-        // spawn and after every start/reset (step 0 lands on the downbeat).
-        let mut reorigin = true;
         let ghost_velocity = (midi_velocity - (midi_velocity / 4)).clamp(1, 127);
 
         let mut generator = PatternGenerator::default();
@@ -478,32 +483,47 @@ pub async fn run(
         loop {
             match clock.wait_for_event(ClockDivision::_1).await {
                 ClockEvent::Reset => {
-                    reorigin = true;
                     output_mode = output_mode_glob.get();
-                    reset_all_outputs(&midi, leds, notes, ghost_note, &jack, &note_on_glob, &accent_on_glob)
-                        .await;
+                    reset_all_outputs(
+                        &midi,
+                        leds,
+                        notes,
+                        ghost_note,
+                        &jack,
+                        &note_on_glob,
+                        &accent_on_glob,
+                    )
+                    .await;
 
                     generator.set_seed(die.roll());
                     generator.set_output_mode(output_mode);
-                    generator.reset();
-                    dnb_vary_pattern_glob.set(false);
-                    dnb_reset_pattern_glob.set(false);
-                }
-                ClockEvent::Stop => {
-                    // Prevent hanging notes / gate CVs if clock is stopped
-                    reset_all_outputs(&midi, leds, notes, ghost_note, &jack, &note_on_glob, &accent_on_glob)
-                        .await;
-                    dnb_vary_pattern_glob.set(false);
-                    dnb_reset_pattern_glob.set(false);
-                }
-                ClockEvent::Start => {
-                    reorigin = true;
                     generator.reset();
                     // Ensure initial DnB pattern is generated at start of sequence
                     if output_mode == OutputMode::OutputModeDnB {
                         generator.queue_dnb_pattern_change(dnb_pattern_glob.get());
                     }
+                    dnb_vary_pattern_glob.set(false);
+                    dnb_reset_pattern_glob.set(false);
                 }
+                ClockEvent::Stop => {
+                    // Prevent hanging notes / gate CVs if clock is stopped
+                    reset_all_outputs(
+                        &midi,
+                        leds,
+                        notes,
+                        ghost_note,
+                        &jack,
+                        &note_on_glob,
+                        &accent_on_glob,
+                    )
+                    .await;
+                    dnb_vary_pattern_glob.set(false);
+                    dnb_reset_pattern_glob.set(false);
+                }
+                // Start may be a resume (MIDI Continue) with no phase reset; a
+                // true transport start is always preceded by Reset, which
+                // handles the restart.
+                ClockEvent::Start => {}
                 // Assume always 24PPQN
                 ClockEvent::Tick(tick) => {
                     let muted = storage.query(|s| s.mute_saved);
@@ -513,11 +533,7 @@ pub async fn run(
                         OutputMode::OutputModeDnB => generator.get_dnb_24ppqn_pattern_division(),
                     };
 
-                    if reorigin {
-                        tick_origin = tick as u32;
-                        reorigin = false;
-                    }
-                    let clkn = (tick as u32).wrapping_sub(tick_origin);
+                    let clkn = tick as u32;
                     // If we have reached the next sequence step, or on the first step
                     if clkn.is_multiple_of(div) {
                         // If output mode has changed since last step, change generator mode and reset the sequence
@@ -1209,8 +1225,16 @@ pub async fn run(
                             dnb_pattern_glob: &dnb_pattern_glob,
                         },
                     );
-                    reset_all_outputs(&midi, leds, notes, ghost_note, &jack, &note_on_glob, &accent_on_glob)
-                        .await;
+                    reset_all_outputs(
+                        &midi,
+                        leds,
+                        notes,
+                        ghost_note,
+                        &jack,
+                        &note_on_glob,
+                        &accent_on_glob,
+                    )
+                    .await;
                 }
 
                 SceneEvent::SaveScene(scene) => {

--- a/faderpunk/src/apps/fp_grids.rs
+++ b/faderpunk/src/apps/fp_grids.rs
@@ -433,10 +433,13 @@ pub async fn run(
 
     let main_loop = async {
         let mut clock = app.use_clock();
-        let ticks = clock.get_ticker();
 
         let mut output_mode = output_mode_glob.get();
         let mut dnb_pattern = dnb_pattern_glob.get();
+        let mut tick_origin: u32 = 0;
+        // Re-anchor the phase on the next tick, so `clkn` counts from 0 at
+        // spawn and after every start/reset (step 0 lands on the downbeat).
+        let mut reorigin = true;
         let ghost_velocity = (midi_velocity - (midi_velocity / 4)).clamp(1, 127);
 
         let mut generator = PatternGenerator::default();
@@ -475,7 +478,7 @@ pub async fn run(
         loop {
             match clock.wait_for_event(ClockDivision::_1).await {
                 ClockEvent::Reset => {
-                    // defmt::info!("[{}] Clock reset!", ticks());
+                    reorigin = true;
                     output_mode = output_mode_glob.get();
                     reset_all_outputs(&midi, leds, notes, ghost_note, &jack, &note_on_glob, &accent_on_glob)
                         .await;
@@ -487,7 +490,6 @@ pub async fn run(
                     dnb_reset_pattern_glob.set(false);
                 }
                 ClockEvent::Stop => {
-                    // defmt::info!("[{}] Clock stop", ticks());
                     // Prevent hanging notes / gate CVs if clock is stopped
                     reset_all_outputs(&midi, leds, notes, ghost_note, &jack, &note_on_glob, &accent_on_glob)
                         .await;
@@ -495,7 +497,7 @@ pub async fn run(
                     dnb_reset_pattern_glob.set(false);
                 }
                 ClockEvent::Start => {
-                    // defmt::info!("[{}] Clock start", ticks());
+                    reorigin = true;
                     generator.reset();
                     // Ensure initial DnB pattern is generated at start of sequence
                     if output_mode == OutputMode::OutputModeDnB {
@@ -503,7 +505,7 @@ pub async fn run(
                     }
                 }
                 // Assume always 24PPQN
-                ClockEvent::Tick => {
+                ClockEvent::Tick(tick) => {
                     let muted = storage.query(|s| s.mute_saved);
                     let div = match output_mode {
                         OutputMode::OutputModeDrums => 3, // Grids Drum mode fixed to 1/32nd ticks
@@ -511,7 +513,11 @@ pub async fn run(
                         OutputMode::OutputModeDnB => generator.get_dnb_24ppqn_pattern_division(),
                     };
 
-                    let clkn = ticks() as u32;
+                    if reorigin {
+                        tick_origin = tick as u32;
+                        reorigin = false;
+                    }
+                    let clkn = (tick as u32).wrapping_sub(tick_origin);
                     // If we have reached the next sequence step, or on the first step
                     if clkn.is_multiple_of(div) {
                         // If output mode has changed since last step, change generator mode and reset the sequence

--- a/faderpunk/src/apps/genseq.rs
+++ b/faderpunk/src/apps/genseq.rs
@@ -202,7 +202,6 @@ pub async fn run(
     let fader = app.use_faders();
     let leds = app.use_leds();
     let mut clock = app.use_clock();
-    let ticks = clock.get_ticker();
     let die = app.use_die();
     let quantizer = app.use_quantizer(Range::_0_10V, vpo, bypass);
     let midi = app.use_midi_output(midi_out, midi_chan, false);
@@ -292,8 +291,8 @@ pub async fn run(
                     pending_note_off = false;
                     aux_out.set_value(0);
                 }
-                ClockEvent::Tick => {
-                    let clkn = ticks() as u32;
+                ClockEvent::Tick(tick) => {
+                    let clkn = tick as u32;
                     if clkn.is_multiple_of(div) {
                         clkn_euclid = (clkn_euclid + 1) % euclid_length.max(1) as u16;
                         euclid_step_glob.set(clkn_euclid);

--- a/faderpunk/src/apps/lfo.rs
+++ b/faderpunk/src/apps/lfo.rs
@@ -152,7 +152,6 @@ pub async fn run(
     let buttons = app.use_buttons();
     let leds = app.use_leds();
     let mut clk = app.use_clock();
-    let ticker = clk.get_ticker();
 
     let midi = app.use_midi_output(midi_out, midi_chan, nrpn);
 
@@ -166,6 +165,8 @@ pub async fn run(
     // Clock tick at which the LFO phase is considered zero. 0 = locked to the
     // clock grid; set to the current tick on a manual reset to run out of phase.
     let glob_phase_origin = app.make_global(0u64);
+    // Last tick number seen by the clock future; read by the button future.
+    let glob_ticks = app.make_global(0u64);
 
     let curve = Curve::Exponential;
     let resolution = [384, 192, 96, 48, 24, 16, 12, 8, 6];
@@ -341,7 +342,7 @@ pub async fn run(
             } else {
                 // Offset the phase lock to the current tick so a clocked LFO can
                 // be pushed out of phase with the grid; also resets when free-running.
-                glob_phase_origin.set(ticker());
+                glob_phase_origin.set(glob_ticks.get());
                 glob_lfo_pos.set(0.0);
             }
         }
@@ -378,13 +379,14 @@ pub async fn run(
     let fut5 = async {
         loop {
             match clk.wait_for_event(ClockDivision::_1).await {
-                ClockEvent::Tick => {
+                ClockEvent::Tick(tick) => {
+                    glob_ticks.set(tick);
                     if storage.query(|s| s.clocked) && phase_lock {
                         let ticks_per_cycle =
                             (glob_div.get() as u64).saturating_mul(speed_mult as u64);
                         if ticks_per_cycle > 0 {
                             let phase_in_cycle =
-                                ticker().wrapping_sub(glob_phase_origin.get()) % ticks_per_cycle;
+                                tick.wrapping_sub(glob_phase_origin.get()) % ticks_per_cycle;
                             glob_lfo_pos
                                 .set(phase_in_cycle as f32 * 4096.0 / ticks_per_cycle as f32);
                         }

--- a/faderpunk/src/apps/lfo_plus.rs
+++ b/faderpunk/src/apps/lfo_plus.rs
@@ -190,7 +190,6 @@ pub async fn run(
     let buttons = app.use_buttons();
     let leds = app.use_leds();
     let mut clk = app.use_clock();
-    let ticker = clk.get_ticker();
 
     let midi = app.use_midi_output(midi_out, midi_chan, nrpn);
 
@@ -204,6 +203,8 @@ pub async fn run(
     // Clock tick at which the LFO phase is considered zero. 0 = locked to the
     // clock grid; set to the current tick on a manual/CV reset to run out of phase.
     let glob_phase_origin = app.make_global(0u64);
+    // Last tick number seen by clock_handler; read by the input/button futures.
+    let glob_ticks = app.make_global(0u64);
 
     let curve = Curve::Exponential;
     let resolution = [384, 192, 96, 48, 24, 16, 12, 8, 6];
@@ -266,7 +267,7 @@ pub async fn run(
 
             if destination == 3 {
                 if in_val >= 2458 && oldinputval < 2458 {
-                    glob_phase_origin.set(ticker());
+                    glob_phase_origin.set(glob_ticks.get());
                     glob_lfo_pos.set(0.0);
                 }
                 oldinputval = in_val;
@@ -478,7 +479,7 @@ pub async fn run(
                 if chan == 1 {
                     // Offset the phase lock to the current tick so a clocked LFO
                     // can be pushed out of phase; also resets when free-running.
-                    glob_phase_origin.set(ticker());
+                    glob_phase_origin.set(glob_ticks.get());
                     glob_lfo_pos.set(0.0);
                 }
             }
@@ -517,13 +518,14 @@ pub async fn run(
     let clock_handler = async {
         loop {
             match clk.wait_for_event(ClockDivision::_1).await {
-                ClockEvent::Tick => {
+                ClockEvent::Tick(tick) => {
+                    glob_ticks.set(tick);
                     if storage.query(|s| s.clocked) && phase_lock {
                         let ticks_per_cycle =
                             (glob_div.get() as u64).saturating_mul(speed_mult as u64);
                         if ticks_per_cycle > 0 {
                             let phase_in_cycle =
-                                ticker().wrapping_sub(glob_phase_origin.get()) % ticks_per_cycle;
+                                tick.wrapping_sub(glob_phase_origin.get()) % ticks_per_cycle;
                             glob_lfo_pos
                                 .set(phase_in_cycle as f32 * 4096.0 / ticks_per_cycle as f32);
                         }

--- a/faderpunk/src/apps/notefader.rs
+++ b/faderpunk/src/apps/notefader.rs
@@ -181,7 +181,6 @@ pub async fn run(
         });
 
     let mut clock = app.use_clock();
-    let ticks = clock.get_ticker();
     let quantizer = app.use_quantizer(range, vpo, bypass);
 
     let fader = app.use_faders();
@@ -249,11 +248,11 @@ pub async fn run(
                         jack.set_value(0);
                     }
                 }
-                ClockEvent::Tick => {
+                ClockEvent::Tick(tick) => {
                     let muted = glob_muted.get();
 
                     let div = div_glob.get();
-                    let clkn = ticks() as u32;
+                    let clkn = tick as u32;
 
                     if clkn.is_multiple_of(div) && storage.query(|s| s.clocked) {
                         if !muted {

--- a/faderpunk/src/apps/probatrigger.rs
+++ b/faderpunk/src/apps/probatrigger.rs
@@ -146,7 +146,6 @@ pub async fn run(
     let curve = Curve::Exponential;
 
     let mut clock = app.use_clock();
-    let ticks = clock.get_ticker();
     let die = app.use_die();
     let fader = app.use_faders();
     let buttons = app.use_buttons();
@@ -195,7 +194,7 @@ pub async fn run(
                     note_on = false;
                     jack.set_low().await;
                 }
-                ClockEvent::Tick => {
+                ClockEvent::Tick(tick) => {
                     let muted = glob_muted.get();
                     let div = div_glob.get();
                     if div != cached_div {
@@ -203,7 +202,7 @@ pub async fn run(
                         cached_gate_step = (cached_div * gatel / 100).clamp(1, cached_div - 1);
                     }
                     let val = prob_glob.get();
-                    let clkn = ticks() as u32;
+                    let clkn = tick as u32;
 
                     if clkn.is_multiple_of(cached_div) {
                         if curve.at(val) >= rndval && !muted {

--- a/faderpunk/src/apps/rnd.rs
+++ b/faderpunk/src/apps/rnd.rs
@@ -140,7 +140,6 @@ pub async fn run(
         params.query(|p| (p.range, p.midi_out, p.midi_channel, p.midi_cc, p.nrpn));
 
     let mut clock = app.use_clock();
-    let ticks = clock.get_ticker();
     let rnd = app.use_die();
     let fader = app.use_faders();
     let buttons = app.use_buttons();
@@ -180,9 +179,9 @@ pub async fn run(
         loop {
             match clock.wait_for_event(ClockDivision::_1).await {
                 ClockEvent::Reset => {}
-                ClockEvent::Tick => {
+                ClockEvent::Tick(tick) => {
                     let muted = glob_muted.get();
-                    let clkn = ticks() as u32;
+                    let clkn = tick as u32;
                     let div = div_glob.get();
                     if clkn.is_multiple_of(div) && !muted && storage.query(|s: &Storage| s.clocked)
                     {

--- a/faderpunk/src/apps/rnd_plus.rs
+++ b/faderpunk/src/apps/rnd_plus.rs
@@ -154,7 +154,6 @@ pub async fn run(
         params.query(|p| (p.bipolar, p.midi_out, p.midi_channel, p.midi_cc, p.nrpn, p.color));
 
     let mut clock = app.use_clock();
-    let ticks = clock.get_ticker();
     let rnd = app.use_die();
     let fader = app.use_faders();
     let buttons = app.use_buttons();
@@ -181,6 +180,8 @@ pub async fn run(
 
     let resolution = [384, 192, 96, 48, 24, 16, 12, 8, 6, 4, 3, 2];
 
+    let mut clkn = 0;
+
     let curve = Curve::Exponential;
     let fader_curve = Curve::Exponential;
 
@@ -200,9 +201,10 @@ pub async fn run(
     let fut1 = async {
         loop {
             match clock.wait_for_event(ClockDivision::_1).await {
-                ClockEvent::Reset => {}
-                ClockEvent::Tick => {
-                    let clkn = ticks() as u16;
+                ClockEvent::Reset => {
+                    clkn = 0;
+                }
+                ClockEvent::Tick(_) => {
                     let muted = storage.query(|s: &Storage| s.mute_save);
 
                     let destination = storage.query(|s| s.dest);
@@ -244,6 +246,7 @@ pub async fn run(
                     {
                         leds.unset(1, Led::Bottom);
                     }
+                    clkn += 1;
                 }
                 _ => {}
             }

--- a/faderpunk/src/apps/rnd_plus.rs
+++ b/faderpunk/src/apps/rnd_plus.rs
@@ -180,7 +180,7 @@ pub async fn run(
 
     let resolution = [384, 192, 96, 48, 24, 16, 12, 8, 6, 4, 3, 2];
 
-    let mut clkn = 0;
+    let mut clkn: u16 = 0;
 
     let curve = Curve::Exponential;
     let fader_curve = Curve::Exponential;

--- a/faderpunk/src/apps/seq8.rs
+++ b/faderpunk/src/apps/seq8.rs
@@ -303,7 +303,6 @@ pub async fn run(
     let faders = app.use_faders();
     let mut clk = app.use_clock();
     let die = app.use_die();
-    let ticks = clk.get_ticker();
     let led = app.use_leds();
 
     let midi = [
@@ -340,6 +339,8 @@ pub async fn run(
     let seq_length_glob: Global<[u8; 4]> = app.make_global([16; 4]);
     let gatelength_glob: Global<[u8; 4]> = app.make_global([128; 4]);
     let clockres_glob = app.make_global([6usize; 4]);
+    // Last tick number seen by clock_handler; read by led_handler for display.
+    let ticks_glob: Global<u64> = app.make_global(0);
     let direction_glob: Global<[Direction; 4]> = app.make_global([Direction::Forward; 4]);
     // Cached die-roll thresholds (0..=4096); recomputed when F6 changes.
     let probability_glob: Global<[u16; 4]> = app.make_global([4096; 4]);
@@ -545,7 +546,7 @@ pub async fn run(
         loop {
             app.delay_millis(16).await;
             let clockres = clockres_glob.get();
-            let clockn = ticks() as usize;
+            let clockn = ticks_glob.get() as usize;
             let page = page_glob.get();
 
             if buttons.is_shift_pressed() {
@@ -676,8 +677,9 @@ pub async fn run(
                         gate_out[n].set_low().await;
                     }
                 }
-                ClockEvent::Tick => {
-                    let clockn = ticks() as usize;
+                ClockEvent::Tick(tick) => {
+                    ticks_glob.set(tick);
+                    let clockn = tick as usize;
                     let seq = seq_glob.get();
                     let direction = direction_glob.get();
                     let probability = probability_glob.get();

--- a/faderpunk/src/apps/tb3po.rs
+++ b/faderpunk/src/apps/tb3po.rs
@@ -324,7 +324,6 @@ pub async fn run(
     let faders = app.use_faders();
     let leds = app.use_leds();
     let mut clock = app.use_clock();
-    let ticks = clock.get_ticker();
     let quantizer = app.use_quantizer(pitch_range, vpo, false);
     let midi = app.use_midi_output(midi_out, midi_chan, false);
 
@@ -352,6 +351,8 @@ pub async fn run(
     let last_midi_note_glob: Global<MidiNote> = app.make_global(MidiNote::default());
     // Signals fader_task → clock_task that density changed and pattern needs regenerating
     let regen_pending_glob: Global<bool> = app.make_global(false);
+    // Last tick number seen by clock_task; read by button_task for reseeding.
+    let ticks_glob: Global<u64> = app.make_global(0);
     // Current clock divisor (raw 24-PPQN units); updated by fader_task via resolution table
     let (init_res, init_density_fader, init_seed) =
         storage.query(|s| (s.res_saved, s.density_fader, s.seed));
@@ -372,8 +373,9 @@ pub async fn run(
     let clock_task = async {
         loop {
             match clock.wait_for_event(ClockDivision::_1).await {
-                ClockEvent::Tick => {
-                    let clkn = ticks() as usize;
+                ClockEvent::Tick(tick) => {
+                    ticks_glob.set(tick);
+                    let clkn = tick as usize;
                     let div = div_glob.get();
                     let in_res_mode = latch_layer_glob.get() == LatchLayer::Third;
 
@@ -633,7 +635,7 @@ pub async fn run(
             }
             match chan {
                 0 => {
-                    let new_seed = (ticks() & 0xFFFF) as u16;
+                    let new_seed = (ticks_glob.get() & 0xFFFF) as u16;
                     storage.modify_and_save(|s| s.seed = new_seed);
                     let d = (storage.query(|s| s.density_fader) as u32 * 14 / 4095) as u8;
                     pattern_glob.set(generate_pattern(new_seed, d));

--- a/faderpunk/src/apps/turing.rs
+++ b/faderpunk/src/apps/turing.rs
@@ -221,7 +221,6 @@ pub async fn run(
     let fader = app.use_faders();
     let leds = app.use_leds();
     let mut clock = app.use_clock();
-    let ticks = clock.get_ticker();
     let die = app.use_die();
     let quantizer = app.use_quantizer(range, vpo, bypass);
 
@@ -279,8 +278,8 @@ pub async fn run(
                     }
                     register = storage.query(|s| s.register_saved);
                 }
-                ClockEvent::Tick => {
-                    let clkn = ticks() as usize;
+                ClockEvent::Tick(tick) => {
+                    let clkn = tick as usize;
                     if clkn.is_multiple_of(div) {
                         if (clkn / div).is_multiple_of(length as usize) {
                             let reg_old = storage.query(|s| s.register_saved);

--- a/faderpunk/src/tasks/clock.rs
+++ b/faderpunk/src/tasks/clock.rs
@@ -15,7 +15,7 @@ use embassy_sync::{
 use embassy_time::{Duration, Instant, Timer};
 use heapless::Deque;
 use midly::live::SystemRealtime;
-use portable_atomic::{AtomicBool, AtomicU64, Ordering};
+use portable_atomic::{AtomicBool, Ordering};
 
 use libfp::{
     utils::bpm_to_clock_duration, AuxJackMode, ClockSrc, GlobalConfig, MidiOut, MidiOutConfig,
@@ -44,7 +44,6 @@ const INTERNAL_PPQN: u8 = 24;
 /// How long METRONOME_HIGH stays true after each beat (ms).
 const METRONOME_HIGH_MS: u64 = 25;
 
-pub static TICK_COUNTER: AtomicU64 = AtomicU64::new(0);
 pub static METRONOME_HIGH: AtomicBool = AtomicBool::new(true);
 
 type AuxInputs = (
@@ -113,9 +112,10 @@ pub enum TransportCmd {
 /// Events emitted by the clock task and received via [`Clock::wait_for_event`].
 #[derive(Clone, Copy)]
 pub enum ClockEvent {
-    /// Clock pulse triggering at the set PPQN division.
-    /// Tick counter reports the number of 24ppqn ticks since the last reset.
-    Tick,
+    /// Clock pulse triggering at the set PPQN division. The payload is the
+    /// number of 24ppqn ticks since the last reset, stamped at publish time
+    /// so subscribers never race on a shared counter.
+    Tick(u64),
     /// The clock has started or resumed playback (no phase reset).
     Start,
     /// The clock has stopped. No phase reset; notes/gates should be silenced.
@@ -168,9 +168,10 @@ const SWING_HALF_INTERVAL: u32 = 6;
 const PENDING_EMISSIONS_CAPACITY: usize = 64;
 
 /// Spacing between catch-up emissions when an early external pulse flushes
-/// unfired interpolated ticks. Wide enough for every subscriber to observe
-/// each TICK_COUNTER increment between emissions (see the clamp rationale on
-/// [`swung_offset`]), short enough to be musically instantaneous.
+/// unfired interpolated ticks. Wide enough for subscribers to drain each tick
+/// before the next is published — a same-instant burst (up to 47 ticks at
+/// 1 PPQN) would overflow the pubsub backlog and lagging subscribers would
+/// silently skip ticks — short enough to be musically instantaneous.
 const CATCHUP_SPACING: Duration = Duration::from_micros(500);
 
 /// Swung absolute offset of tick `i` (in `[0, 2H]`) from the start of the swing
@@ -180,10 +181,9 @@ const CATCHUP_SPACING: Duration = Duration::from_micros(500);
 /// The result is clamped to 500µs before the window boundary. Without this,
 /// heavy positive swing pushes the last ticks of the window past the boundary,
 /// causing the engine to fire tick 0 of the next window as an immediate
-/// catch-up. That catch-up creates two ticks in rapid succession: the
-/// gatekeeper processes both before any subscriber runs, incrementing
-/// TICK_COUNTER twice, so subscribers read the same stale counter for both
-/// events and double-fire notes on beat boundaries.
+/// catch-up — two ticks in rapid succession right on a beat boundary. The
+/// tick number in the event payload makes that burst safe to *count*, but
+/// keeping the schedule monotone within the window avoids the audible jitter.
 fn swung_offset(i: u32, t: Duration, swing: i8) -> Duration {
     let h = SWING_HALF_INTERVAL as i64;
     let t_ticks = t.as_ticks() as i64;
@@ -311,21 +311,18 @@ async fn analog_tick_release(ports: heapless::Vec<Port, 4>, trigger_len: u64) {
 #[embassy_executor::task]
 async fn metronome() {
     let mut sub = CLOCK_PUBSUB.subscriber().unwrap();
-    let mut tick_count: u64 = 0;
 
     loop {
         match sub.next_message_pure().await {
-            ClockEvent::Tick => {
-                tick_count += 1;
+            ClockEvent::Tick(ticks) => {
                 // Fire on the first tick of each quarter note (every 24 ppqn ticks).
-                if tick_count % 24 == 1 {
+                if ticks.is_multiple_of(24) {
                     METRONOME_HIGH.store(true, Ordering::Relaxed);
                     Timer::after_millis(METRONOME_HIGH_MS).await;
                     METRONOME_HIGH.store(false, Ordering::Relaxed);
                 }
             }
             ClockEvent::Start | ClockEvent::Reset => {
-                tick_count = 0;
                 METRONOME_HIGH.store(true, Ordering::Relaxed);
             }
             ClockEvent::Stop => {
@@ -347,6 +344,9 @@ async fn run_clock_gatekeeper() {
     let mut config = config_receiver.get().await;
     let mut is_running = false;
     let mut analog_tick_counters: [u16; 3] = [0; 3];
+    // 24ppqn ticks since the last reset, carried in each Tick's payload.
+    // Held at u64::MAX after a reset so the first wrapping increment yields 0.
+    let mut tick_counter: u64 = u64::MAX;
 
     loop {
         match select(clock_in_receiver.receive(), config_receiver.changed()).await {
@@ -398,9 +398,10 @@ async fn run_clock_gatekeeper() {
                         if is_running
                             || matches!(source, ClockSrc::Atom | ClockSrc::Meteor | ClockSrc::Cube)
                         {
-                            // Relies on AtomicU64 wrapping on overflow MAX + 1 to ensure first reported TICK_COUNTER after a Clock::Start is always 0
-                            TICK_COUNTER.fetch_add(1, Ordering::Relaxed);
-                            clock_publisher.publish(ClockEvent::Tick).await;
+                            tick_counter = tick_counter.wrapping_add(1);
+                            clock_publisher
+                                .publish(ClockEvent::Tick(tick_counter))
+                                .await;
                             send_analog_ticks(&spawner, &config, &mut analog_tick_counters).await;
                         }
                     }
@@ -420,7 +421,7 @@ async fn run_clock_gatekeeper() {
                     }
                     // (Re-)start the clock. Full phase reset
                     ClockInEvent::Start(_) => {
-                        TICK_COUNTER.store(u64::MAX, Ordering::Relaxed);
+                        tick_counter = u64::MAX;
                         is_running = true;
                         clock_publisher.publish(ClockEvent::Reset).await;
                         clock_publisher.publish(ClockEvent::Start).await;
@@ -436,7 +437,7 @@ async fn run_clock_gatekeeper() {
                     }
                     // Reset the phase without affecting the run state
                     ClockInEvent::Reset(_) => {
-                        TICK_COUNTER.store(u64::MAX, Ordering::Relaxed);
+                        tick_counter = u64::MAX;
                         clock_publisher.publish(ClockEvent::Reset).await;
                         analog_tick_counters = [0; 3];
                         send_analog_reset(&spawner, &config).await;
@@ -854,8 +855,8 @@ async fn run_unified_clock_engine() {
                             // interpolated ticks to fire in quick succession
                             // *before* this pulse's own tick, so the tick count
                             // at every pulse stays exactly `k * mult`. Spaced
-                            // CATCHUP_SPACING apart so every subscriber observes
-                            // each TICK_COUNTER increment (see `swung_offset`).
+                            // CATCHUP_SPACING apart so the burst cannot overflow
+                            // the pubsub backlog of slow subscribers.
                             let stale = pending_emissions.len() as u32;
                             pending_emissions.clear();
                             for i in 0..=stale {

--- a/faderpunk/src/tasks/clock.rs
+++ b/faderpunk/src/tasks/clock.rs
@@ -160,10 +160,18 @@ const WATCHDOG_FLOOR: Duration = Duration::from_millis(2000);
 /// is one 8th note (12 ticks) and swing is applied at the 16th-note level.
 const SWING_HALF_INTERVAL: u32 = 6;
 
-/// Capacity of the external-clock pending-emission queue. One swing window of
-/// 2H = 12 ticks is scheduled up-front on the window-start pulse; capacity 32
-/// leaves ample headroom for transient jitter.
-const PENDING_EMISSIONS_CAPACITY: usize = 32;
+/// Capacity of the external-clock pending-emission queue. The worst case is a
+/// 1 PPQN clock (multiplier 24) whose pulse arrives early: up to 23 stale
+/// interpolated ticks are re-timed for catch-up, followed by the on-pulse
+/// tick and 23 freshly scheduled ticks — 47 entries. The swing path needs at
+/// most one 12-tick window.
+const PENDING_EMISSIONS_CAPACITY: usize = 64;
+
+/// Spacing between catch-up emissions when an early external pulse flushes
+/// unfired interpolated ticks. Wide enough for every subscriber to observe
+/// each TICK_COUNTER increment between emissions (see the clamp rationale on
+/// [`swung_offset`]), short enough to be musically instantaneous.
+const CATCHUP_SPACING: Duration = Duration::from_micros(500);
 
 /// Swung absolute offset of tick `i` (in `[0, 2H]`) from the start of the swing
 /// window. Used by both the internal clock (to schedule the next tick directly)
@@ -207,6 +215,29 @@ fn watchdog_duration(measured_period: Option<Duration>) -> Duration {
         .map(|p| p * WATCHDOG_MULTIPLIER)
         .unwrap_or(WATCHDOG_FLOOR)
         .max(WATCHDOG_FLOOR)
+}
+
+/// A scheduled 24-PPQN tick emission on the external clock path.
+#[derive(Clone, Copy)]
+struct PendingEmission {
+    at: Instant,
+    /// Emit an unswung MIDI clock tick alongside. Set for multiplied ticks
+    /// (where raw pulses are not forwarded to MIDI); unset in the 24-PPQN
+    /// swing path, where each raw pulse already carries its own MidiTick.
+    send_midi: bool,
+}
+
+/// Snaps the configured external PPQN to a ratio the engine can lock to:
+/// divisors of 24 multiply up, multiples of 24 divide down. Anything else
+/// (unreachable via the configurator) falls back to 24 (straight passthrough).
+fn effective_ppqn(ext_ppqn: u8) -> u8 {
+    if ext_ppqn > 0
+        && (INTERNAL_PPQN.is_multiple_of(ext_ppqn) || ext_ppqn.is_multiple_of(INTERNAL_PPQN))
+    {
+        ext_ppqn
+    } else {
+        INTERNAL_PPQN
+    }
 }
 
 pub async fn start_clock(spawner: &Spawner, aux_inputs: AuxInputs) {
@@ -467,10 +498,13 @@ async fn run_unified_clock_engine() {
     let mut measured_ext_period: Option<Duration> = None;
     let mut delta_history: [Duration; HISTORY_SIZE] = [Duration::from_ticks(0); HISTORY_SIZE];
     let mut history_idx: usize = 0;
-    // Queued swung emissions for the external clock path. Each entry is the
-    // absolute emission time for the front-most unpublished tick. Empty in the
-    // internal or straight-passthrough (`swing == 0`) case.
-    let mut pending_emissions: Deque<Instant, PENDING_EMISSIONS_CAPACITY> = Deque::new();
+    // Queued emissions for the external clock path: swung window ticks
+    // (24 PPQN sources) or interpolated multiplied ticks (sub-24-PPQN
+    // sources). Empty in the internal or straight-passthrough case.
+    let mut pending_emissions: Deque<PendingEmission, PENDING_EMISSIONS_CAPACITY> = Deque::new();
+    // Pulse phase for the external clock divider (ext PPQN > 24): counts
+    // pulses within one 24-PPQN tick; the tick fires at count 0.
+    let mut ext_pulse_div_count: u32 = 0;
     // True if the current swing window's ticks were pre-scheduled on its
     // anchor pulse. Mid-window pulses check this flag to decide whether
     // to suppress (predicted — emission already queued) or fall through
@@ -501,17 +535,16 @@ async fn run_unified_clock_engine() {
             if config.clock.clock_src == ClockSrc::Internal {
                 Timer::at(next_tick_at.min(next_midi_tick_at)).await;
             } else if last_pulse.is_some() && measured_ext_period.is_some() {
-                // Watchdog is armed; also consider any pending swung emission
+                // Watchdog is armed; also consider any pending emission
                 // that may be due sooner.
                 let deadline = pending_emissions
                     .front()
-                    .copied()
-                    .map(|e| e.min(next_tick_at))
+                    .map(|e| e.at.min(next_tick_at))
                     .unwrap_or(next_tick_at);
                 Timer::at(deadline).await;
-            } else if let Some(&front) = pending_emissions.front() {
+            } else if let Some(front) = pending_emissions.front() {
                 // Measurement lost but queue still has emissions (edge case).
-                Timer::at(front).await;
+                Timer::at(front.at).await;
             } else {
                 core::future::pending::<()>().await;
             }
@@ -535,6 +568,7 @@ async fn run_unified_clock_engine() {
                     history_idx = 0;
                     pending_emissions.clear();
                     tick_in_window = 0;
+                    ext_pulse_div_count = 0;
 
                     // Drop transport state to match the gatekeeper's behavior,
                     // which also resets is_running on source change.
@@ -570,6 +604,14 @@ async fn run_unified_clock_engine() {
                                 new_config.clock.swing_amount,
                             );
                     }
+                } else if config.clock.ext_ppqn != new_config.clock.ext_ppqn {
+                    // External PPQN changed on the same source: drop scheduled
+                    // emissions and re-anchor the phase counters. The measured
+                    // pulse period stays valid — only its meaning in 24-PPQN
+                    // ticks changed.
+                    pending_emissions.clear();
+                    tick_in_window = 0;
+                    ext_pulse_div_count = 0;
                 }
 
                 config = new_config;
@@ -618,8 +660,8 @@ async fn run_unified_clock_engine() {
                     match event {
                         ClockInEvent::Start(_) => {
                             is_running = true;
-                            // Fresh downbeat: drop any stale swung emissions and
-                            // re-anchor the window on the next pulse.
+                            // Fresh downbeat: drop any stale scheduled emissions
+                            // and re-anchor the phase on the next pulse.
                             pending_emissions.clear();
                             tick_in_window = 0;
                             // Re-arm the watchdog from now: the previous
@@ -628,6 +670,7 @@ async fn run_unified_clock_engine() {
                             // spurious clock-lost Stop before the first
                             // resumed pulse arrives.
                             next_tick_at = Instant::now() + watchdog_duration(measured_ext_period);
+                            ext_pulse_div_count = 0;
                         }
                         ClockInEvent::Continue(_) => {
                             is_running = true;
@@ -637,10 +680,12 @@ async fn run_unified_clock_engine() {
                         ClockInEvent::Stop(_) => {
                             is_running = false;
                             pending_emissions.clear();
+                            ext_pulse_div_count = 0;
                         }
                         ClockInEvent::Reset(_) => {
                             pending_emissions.clear();
                             tick_in_window = 0;
+                            ext_pulse_div_count = 0;
                         }
                         _ => {}
                     }
@@ -652,6 +697,7 @@ async fn run_unified_clock_engine() {
                         clock_in_sender.send(ClockInEvent::Reset(source)).await;
                         pending_emissions.clear();
                         tick_in_window = 0;
+                        ext_pulse_div_count = 0;
                         continue;
                     }
 
@@ -672,80 +718,19 @@ async fn run_unified_clock_engine() {
                                 continue;
                             }
                         }
-                    }
-
-                    // Window-relative scheduling on external:
-                    //
-                    // - At `tick_in_window == 0` (window anchor), anchor the
-                    //   window to this pulse and, if we have a measured period
-                    //   and non-zero swing, pre-schedule all `2H` emissions
-                    //   for the window using `swung_offset`. This lets
-                    //   negative swing emit *earlier* than the unswung grid
-                    //   without any latency buffer, because we know where
-                    //   every tick in the window will land the moment we
-                    //   anchor it.
-                    // - Mid-window pulses are consumed for measurement and
-                    //   watchdog only; their emissions were already queued at
-                    //   window start.
-                    // - On `S = 0` or before the period has been measured,
-                    //   fall back to straight passthrough — forward every
-                    //   pulse immediately, no queue. This also covers the
-                    //   first window after Start / Reset / source change,
-                    //   which has no prior period to base a prediction on.
-
-                    // Forward every raw pulse as an unswung MIDI clock tick.
-                    clock_in_sender.send(ClockInEvent::MidiTick(source)).await;
-
-                    let swing = config.clock.swing_amount;
-                    if tick_in_window == 0 {
-                        // Window anchor: decide the mode for this whole
-                        // window based on the state *right now*, and stick
-                        // with it until the next anchor.
-                        window_start_at = timestamp;
-                        match measured_ext_period {
-                            Some(t) if swing != 0 => {
-                                // Pre-schedule all 2H emissions for the window.
-                                for i in 0..(2 * SWING_HALF_INTERVAL) {
-                                    let emission = window_start_at + swung_offset(i, t, swing);
-                                    // Belt-and-braces monotonicity guard
-                                    // against any stale entries still sitting
-                                    // in the queue from a prior window that
-                                    // straddled a tempo transition.
-                                    let clamped = match pending_emissions.back() {
-                                        Some(&back) if emission < back => back,
-                                        _ => emission,
-                                    };
-                                    if pending_emissions.is_full() {
-                                        pending_emissions.pop_front();
-                                    }
-                                    let _ = pending_emissions.push_back(clamped);
-                                }
-                                window_predicted = true;
-                            }
-                            _ => {
-                                // No prediction — straight passthrough for
-                                // the anchor pulse and the rest of this
-                                // window, even if swing or the measured
-                                // period change mid-window. The next window
-                                // picks the mode fresh.
-                                clock_in_sender.send(ClockInEvent::Tick(source)).await;
-                                window_predicted = false;
-                            }
+                        // Analog clock sources have no transport of their own —
+                        // incoming pulses *are* the transport. Re-arm the running
+                        // state (and with it the watchdog and emission timer)
+                        // when pulses appear or resume after a watchdog stop.
+                        if !is_running {
+                            is_running = true;
+                            spawner.spawn(store_clock_running(true)).ok();
                         }
-                    } else if !window_predicted {
-                        // Mid-window pulse under an unpredicted window —
-                        // forward it straight.
-                        clock_in_sender.send(ClockInEvent::Tick(source)).await;
-                    }
-                    // else: mid-window pulse under an active prediction —
-                    // emission is already queued, nothing to do here.
-
-                    tick_in_window += 1;
-                    if tick_in_window >= 2 * SWING_HALF_INTERVAL {
-                        tick_in_window = 0;
                     }
 
-                    // Frequency tracking: compute rolling average of pulse intervals
+                    // Frequency tracking: rolling average of raw pulse
+                    // intervals. Done before any scheduling so this pulse's
+                    // own interval informs the interpolation below.
                     if let Some(last) = last_pulse {
                         let delta = timestamp.duration_since(last);
                         delta_history[history_idx] = delta;
@@ -765,8 +750,157 @@ async fn run_unified_clock_engine() {
                             measured_ext_period = Some(avg);
                         }
                     }
-
                     last_pulse = Some(timestamp);
+
+                    // MIDI TimingClock is 24 PPQN by definition; the configured
+                    // external PPQN only applies to the analog inputs.
+                    let ext_ppqn = if is_analog {
+                        effective_ppqn(config.clock.ext_ppqn)
+                    } else {
+                        INTERNAL_PPQN
+                    };
+
+                    if ext_ppqn == INTERNAL_PPQN {
+                        // Window-relative scheduling on external 24 PPQN:
+                        //
+                        // - At `tick_in_window == 0` (window anchor), anchor the
+                        //   window to this pulse and, if we have a measured period
+                        //   and non-zero swing, pre-schedule all `2H` emissions
+                        //   for the window using `swung_offset`. This lets
+                        //   negative swing emit *earlier* than the unswung grid
+                        //   without any latency buffer, because we know where
+                        //   every tick in the window will land the moment we
+                        //   anchor it.
+                        // - Mid-window pulses are consumed for measurement and
+                        //   watchdog only; their emissions were already queued at
+                        //   window start.
+                        // - On `S = 0` or before the period has been measured,
+                        //   fall back to straight passthrough — forward every
+                        //   pulse immediately, no queue. This also covers the
+                        //   first window after Start / Reset / source change,
+                        //   which has no prior period to base a prediction on.
+
+                        // Forward every raw pulse as an unswung MIDI clock tick.
+                        clock_in_sender.send(ClockInEvent::MidiTick(source)).await;
+
+                        let swing = config.clock.swing_amount;
+                        if tick_in_window == 0 {
+                            // Window anchor: decide the mode for this whole
+                            // window based on the state *right now*, and stick
+                            // with it until the next anchor.
+                            window_start_at = timestamp;
+                            match measured_ext_period {
+                                Some(t) if swing != 0 => {
+                                    // Pre-schedule all 2H emissions for the window.
+                                    for i in 0..(2 * SWING_HALF_INTERVAL) {
+                                        let emission = window_start_at + swung_offset(i, t, swing);
+                                        // Belt-and-braces monotonicity guard
+                                        // against any stale entries still sitting
+                                        // in the queue from a prior window that
+                                        // straddled a tempo transition.
+                                        let clamped = match pending_emissions.back() {
+                                            Some(back) if emission < back.at => back.at,
+                                            _ => emission,
+                                        };
+                                        if pending_emissions.is_full() {
+                                            pending_emissions.pop_front();
+                                        }
+                                        let _ = pending_emissions.push_back(PendingEmission {
+                                            at: clamped,
+                                            send_midi: false,
+                                        });
+                                    }
+                                    window_predicted = true;
+                                }
+                                _ => {
+                                    // No prediction — straight passthrough for
+                                    // the anchor pulse and the rest of this
+                                    // window, even if swing or the measured
+                                    // period change mid-window. The next window
+                                    // picks the mode fresh.
+                                    clock_in_sender.send(ClockInEvent::Tick(source)).await;
+                                    window_predicted = false;
+                                }
+                            }
+                        } else if !window_predicted {
+                            // Mid-window pulse under an unpredicted window —
+                            // forward it straight.
+                            clock_in_sender.send(ClockInEvent::Tick(source)).await;
+                        }
+                        // else: mid-window pulse under an active prediction —
+                        // emission is already queued, nothing to do here.
+
+                        tick_in_window += 1;
+                        if tick_in_window >= 2 * SWING_HALF_INTERVAL {
+                            tick_in_window = 0;
+                        }
+                    } else if ext_ppqn < INTERNAL_PPQN {
+                        // Clock multiplier: each pulse anchors `mult` internal
+                        // 24-PPQN ticks. The on-pulse tick fires immediately —
+                        // real pulses are ground truth, so the grid re-locks
+                        // phase on every pulse regardless of tempo changes —
+                        // and the remaining ticks are interpolated across the
+                        // measured pulse period. Swing is not applied to
+                        // multiplied clocks.
+                        let mult = (INTERNAL_PPQN / ext_ppqn) as u32;
+
+                        if pending_emissions.is_empty() {
+                            // On time or late (tempo slowed): the grid simply
+                            // stretches until the pulse lands.
+                            clock_in_sender.send(ClockInEvent::MidiTick(source)).await;
+                            clock_in_sender.send(ClockInEvent::Tick(source)).await;
+                        } else {
+                            // Early pulse (tempo sped up): re-time the unfired
+                            // interpolated ticks to fire in quick succession
+                            // *before* this pulse's own tick, so the tick count
+                            // at every pulse stays exactly `k * mult`. Spaced
+                            // CATCHUP_SPACING apart so every subscriber observes
+                            // each TICK_COUNTER increment (see `swung_offset`).
+                            let stale = pending_emissions.len() as u32;
+                            pending_emissions.clear();
+                            for i in 0..=stale {
+                                let _ = pending_emissions.push_back(PendingEmission {
+                                    at: timestamp + CATCHUP_SPACING * i,
+                                    send_midi: true,
+                                });
+                            }
+                        }
+
+                        // Interpolate the rest of the pulse period. Before the
+                        // first measurement only on-pulse ticks fire (mirrors
+                        // the unpredicted-window fallback above).
+                        if let Some(period) = measured_ext_period {
+                            let tick24 = period / mult;
+                            for i in 1..mult {
+                                let emission = timestamp + tick24 * i;
+                                // Monotonicity guard against catch-up entries
+                                // still ahead of the interpolated schedule.
+                                let at = match pending_emissions.back() {
+                                    Some(back) if emission < back.at => back.at,
+                                    _ => emission,
+                                };
+                                let _ = pending_emissions.push_back(PendingEmission {
+                                    at,
+                                    send_midi: true,
+                                });
+                            }
+                        }
+                    } else {
+                        // Clock divider: the external clock runs above 24 PPQN;
+                        // forward every `div`-th pulse as one internal tick
+                        // (plus its MIDI clock tick), starting with the first
+                        // pulse after a reset so the downbeat stays anchored.
+                        let div = (ext_ppqn / INTERNAL_PPQN) as u32;
+                        if ext_pulse_div_count == 0 {
+                            clock_in_sender.send(ClockInEvent::MidiTick(source)).await;
+                            clock_in_sender.send(ClockInEvent::Tick(source)).await;
+                        }
+                        ext_pulse_div_count += 1;
+                        if ext_pulse_div_count >= div {
+                            ext_pulse_div_count = 0;
+                        }
+                    }
+
                     // Schedule watchdog: if no pulse arrives within the watchdog window,
                     // declare external clock lost.
                     next_tick_at = timestamp + watchdog_duration(measured_ext_period);
@@ -802,12 +936,19 @@ async fn run_unified_clock_engine() {
                             );
                     }
                 } else if is_running {
-                    // External: either a pending swung emission is due, or the
+                    // External: either a pending emission is due, or the
                     // watchdog fired (external clock lost).
                     let now = Instant::now();
-                    let popped = if let Some(&front) = pending_emissions.front() {
-                        if front <= now {
+                    let popped = if let Some(&PendingEmission { at, send_midi }) =
+                        pending_emissions.front()
+                    {
+                        if at <= now {
                             pending_emissions.pop_front();
+                            if send_midi {
+                                clock_in_sender
+                                    .send(ClockInEvent::MidiTick(config.clock.clock_src))
+                                    .await;
+                            }
                             clock_in_sender
                                 .send(ClockInEvent::Tick(config.clock.clock_src))
                                 .await;
@@ -828,6 +969,7 @@ async fn run_unified_clock_engine() {
                         is_running = false;
                         pending_emissions.clear();
                         tick_in_window = 0;
+                        ext_pulse_div_count = 0;
                         spawner.spawn(store_clock_running(false)).ok();
                     }
                 }

--- a/libfp/src/fp_grids_lib/pattern_generator.rs
+++ b/libfp/src/fp_grids_lib/pattern_generator.rs
@@ -297,7 +297,7 @@ impl PatternGenerator {
     ///
     pub fn tick(&mut self, clkn: u32, div: u32) {
         // Derive the sequence step from the absolute clock tick count divided by the clock division,
-        // so the generator stays in sync with ticks() rather than tracking its own independent counter.
+        // so the generator stays in sync with the clock tick count rather than tracking its own independent counter.
         let step_count = clkn / div;
 
         self.sequence_step_ = if self.options_.output_mode == OutputMode::OutputModeDnB {


### PR DESCRIPTION
Adds support for analog clock inputs running at other rates than 24 PPQN, and makes clock ticks phase-correct across all apps. Closes #576. Closes #197.

## External PPQN (analog sources only)

- New `effective_ppqn` handling in the clock engine: divisors of 24 (1/2/3/4/6/8/12) multiply the clock up, multiples (48/96) divide it down. MIDI clock remains fixed at 24 PPQN.
- Multiplier: every real pulse emits its tick immediately and re-locks the phase; the remaining ticks are interpolated across the measured pulse period. Early pulses flush unfired ticks in quick succession (500 us spacing) so the tick count at every pulse stays exact; late pulses stretch the grid.
- Divider: every D-th pulse becomes one tick, with the phase counter reset on start/reset/source change.
- MIDI clock out follows the generated 24 PPQN stream, so downstream gear sees the correct tempo.
- Analog pulses now re-arm the running state after a watchdog stop (previously the emission timer stayed dormant).
- Configurator: new "External PPQN" select in Clock settings, enabled for Atom/Meteor/Cube sources.
- Swing is bypassed when external PPQN is not 24 (phase 2 later).

## Tick number in the event payload

- `ClockEvent::Tick(u64)` now carries the tick number, stamped at publish time. `TICK_COUNTER`/`get_ticker()` are removed; all apps read the payload (or an app-local global for cross-future reads), eliminating double-fires/skips when ticks arrive in quick succession.
- euclid and fp_grids re-anchor their phase from the next tick payload after start/reset/spawn, so step 0 now lands on the downbeat and steps align exactly with the division grid used by seq8 and others.

## Hardware test checklist

- [x] Feed a known-PPQN square (e.g. 4 PPQN, then 1 PPQN) into Atom with matching External PPQN; verify seq8 advances at the correct rate and steps land on the pulses
- [x] Sweep the external tempo up and down; verify no double-fires or skipped steps
- [x] Stop the external clock; verify stop detection (also at 1 PPQN), then resume and verify the clock re-arms
- [x] With external PPQN active, verify MIDI clock out reads the correct BPM in a DAW
- [x] Start/reset into euclid and fp_grids; verify the first pattern step fires on the downbeat and stays tick-aligned with seq8
- [x] Verify internal clock and MIDI clock in behave as before (incl. swing)