### PR TITLE
feat(rnd_plus): add sample & hold CV destination mode

### DIFF
--- a/configurator/src/components/ManualTab.tsx
+++ b/configurator/src/components/ManualTab.tsx
@@ -945,8 +945,9 @@ The output range is configured in the parameters: bipolar (−5V to +5V) or unip
 - speed (yellow)
 - ext clock (pink)
 - slew (cyan)
+- sample & hold (white)
 
-In speed mode, incoming CV offsets the speed setting. In free-running mode this changes the internal interval, and in clocked mode it offsets the selected timing-resolution index. In ext clock mode, new random values are generated only when a rising edge is detected (around 1V after attenuation/mute processing). In slew mode, incoming CV modulates transition smoothing.
+In speed mode, incoming CV offsets the speed setting. In free-running mode this changes the internal interval, and in clocked mode it offsets the selected timing-resolution index. In ext clock mode, new random values are generated only when a rising edge is detected (around 1V after attenuation/mute processing). In slew mode, incoming CV modulates transition smoothing. In sample & hold mode, the random generator is bypassed: on each trigger (same clock/free-run timing as the other modes), the attenuated CV input is sampled and held as the output value instead of a new random roll, turning Random+ into a clocked sample-and-hold.
 
 Channel 2 is the random output lane: Fader 2 sets base speed, **Shift + Fader 2** sets attenuation, and **Button 2 + Fader 2** sets slew. A **short press** (no Shift) on Button 2 mutes/unmutes output, and **Shift + long press** toggles free-running versus clocked mode.
 
@@ -962,7 +963,8 @@ Output range can be unipolar (0–10V) or bipolar (-5V to +5V), and MIDI CC foll
         fnTitle: "CV input mute",
         fnDescription: "Mutes/unmutes the CV lane",
         fnPlusShiftTitle: "CV destination",
-        fnPlusShiftDescription: "Speed (yellow), ext clock (pink), slew (cyan)",
+        fnPlusShiftDescription:
+          "Speed (yellow), ext clock (pink), slew (cyan), sample & hold (white)",
         ledTop: "Positive input level indicator",
         ledTopPlusShift: "Destination color on button",
         ledBottom: "Negative input level indicator",

--- a/faderpunk/src/apps/rnd_plus.rs
+++ b/faderpunk/src/apps/rnd_plus.rs
@@ -106,7 +106,7 @@ impl Default for Storage {
             clocked: true,
             in_att: 4095,
             in_mute: false,
-            dest: 0, // 0 => speed, 1 => ext clock, 2 => slew
+            dest: 0, // 0 => speed, 1 => ext clock, 2 => slew, 3 => sample & hold
         }
     }
 }
@@ -219,14 +219,23 @@ pub async fn run(
                         && storage.query(|s: &Storage| s.clocked)
                         && destination != 1
                     {
-                        val_glob.set(rnd.roll());
+                        let new_val = if destination == 3 {
+                            in_val_glob.get()
+                        } else {
+                            rnd.roll()
+                        };
+                        val_glob.set(new_val);
 
                         let rnd_color = if !storage.query(|s: &Storage| s.mute_save) {
-                            let r = (rnd.roll() / 16) as u8;
-                            let g = (rnd.roll() / 16) as u8;
-                            let b = (rnd.roll() / 16) as u8;
+                            if destination == 3 {
+                                led_color
+                            } else {
+                                let r = (rnd.roll() / 16) as u8;
+                                let g = (rnd.roll() / 16) as u8;
+                                let b = (rnd.roll() / 16) as u8;
 
-                            Color::Custom(r, g, b)
+                                Color::Custom(r, g, b)
+                            }
                         } else {
                             Color::Custom(0, 0, 0)
                         };
@@ -263,7 +272,7 @@ pub async fn run(
                         s.in_mute = !s.in_mute;
                     });
                 } else {
-                    let dest = (storage.query(|s| s.dest) + 1) % 3;
+                    let dest = (storage.query(|s| s.dest) + 1) % 4;
                     storage.modify_and_save(|s| {
                         s.dest = dest;
                     });
@@ -500,6 +509,7 @@ pub async fn run(
                     0 => Color::Yellow,
                     1 => Color::Pink,
                     2 => Color::Cyan,
+                    3 => Color::White,
                     _ => Color::Yellow,
                 };
                 leds.set(0, Led::Button, dest_color, Brightness::Mid);
@@ -529,14 +539,19 @@ pub async fn run(
                 let timed_div = (curve.at(4095 - speed) as u32 * 5000 / 4095 + 71) as u16;
 
                 if destination != 1 && count.is_multiple_of(timed_div as u32) {
-                    val_glob.set(rnd.roll());
+                    let new_val = if destination == 3 { in_val } else { rnd.roll() };
+                    val_glob.set(new_val);
 
                     let rnd_color = if !storage.query(|s: &Storage| s.mute_save) {
-                        let r = (rnd.roll() / 16) as u8;
-                        let g = (rnd.roll() / 16) as u8;
-                        let b = (rnd.roll() / 16) as u8;
+                        if destination == 3 {
+                            led_color
+                        } else {
+                            let r = (rnd.roll() / 16) as u8;
+                            let g = (rnd.roll() / 16) as u8;
+                            let b = (rnd.roll() / 16) as u8;
 
-                        Color::Custom(r, g, b)
+                            Color::Custom(r, g, b)
+                        }
                     } else {
                         Color::Custom(0, 0, 0)
                     };


### PR DESCRIPTION
Closes #582.

## Summary
- Adds a 4th CV destination to Random+ (Shift + short-press on button 1 to cycle), shown white on the destination LED
- In this mode, the random generator is bypassed: on each existing trigger (clock division / free-run timer), the attenuated CV input is sampled and held as the output value, turning Random+ into a clocked sample-and-hold

## Test plan
- [ ] Flash and load a Random+ instance
- [ ] Shift + short-press button 1 to cycle CV destination to sample & hold (button LED turns white)
- [ ] Patch a varying CV signal into the input jack, confirm the output steps to the sampled input value on each clock tick / free-run interval, both clocked and free-running
- [ ] Confirm the other destinations (speed, ext clock, slew) still behave as before