### PR TITLE
fix(rnd,rnd_plus): restore last color on unmute and fix mute toggling

### DIFF
--- a/configurator/src/components/ManualTab.tsx
+++ b/configurator/src/components/ManualTab.tsx
@@ -947,7 +947,7 @@ The output range is configured in the parameters: bipolar (−5V to +5V) or unip
 
 In speed mode, incoming CV offsets the speed setting. In free-running mode this changes the internal interval, and in clocked mode it offsets the selected timing-resolution index. In ext clock mode, new random values are generated only when a rising edge is detected (around 1V after attenuation/mute processing). In slew mode, incoming CV modulates transition smoothing.
 
-Channel 2 is the random output lane: Fader 2 sets base speed, **Shift + Fader 2** sets attenuation, and **Button 2 + Fader 2** sets slew. Use **Shift + short press** on Button 2 to mute/unmute output, and **Shift + long press** to toggle free-running versus clocked mode.
+Channel 2 is the random output lane: Fader 2 sets base speed, **Shift + Fader 2** sets attenuation, and **Button 2 + Fader 2** sets slew. A **short press** (no Shift) on Button 2 mutes/unmutes output, and **Shift + long press** toggles free-running versus clocked mode.
 
 Output range can be unipolar (0–10V) or bipolar (-5V to +5V), and MIDI CC follows the same random output stream.`,
     channels: [
@@ -975,10 +975,10 @@ Output range can be unipolar (0–10V) or bipolar (-5V to +5V), and MIDI CC foll
         faderPlusShiftDescription: "Reduces output range",
         faderPlusFnTitle: "Slew",
         faderPlusFnDescription: "Sets random transition smoothing",
-        fnTitle: "No direct action",
-        fnDescription: "",
-        fnPlusShiftTitle: "Mute / Clock mode",
-        fnPlusShiftDescription: "Short: mute, Long: toggle free/clocked",
+        fnTitle: "Mute",
+        fnDescription: "Short press mutes/unmutes output",
+        fnPlusShiftTitle: "Clock mode",
+        fnPlusShiftDescription: "Long press toggles free-running/clocked",
         ledTop: "Positive output level indicator",
         ledTopPlusShift: "Attenuation level in red",
         ledBottom: "Negative output level indicator",

--- a/configurator/src/components/manual/Apps.tsx
+++ b/configurator/src/components/manual/Apps.tsx
@@ -20,15 +20,13 @@ export const Apps = ({ apps }: Props) => (
     <List>
       <li>
         <strong>Short press (no shift)</strong> — Control (when Button mode =
-        Mute), Clock Divider, Clock Divider+, Random CC/CV, Random Trigger,
-        Euclid, Envelope Follower, Turing, Turing+, MIDI to CV, CV2MIDI, CV/OCT
-        to MIDI, Panner, FP-Grids (per-channel trigger mutes), TB-3PO, GenSeq
+        Mute), Clock Divider, Clock Divider+, Random CC/CV, Random+ (output
+        channel), Random Trigger, Euclid, Envelope Follower, Turing, Turing+,
+        MIDI to CV, CV2MIDI, CV/OCT to MIDI, Panner, FP-Grids (per-channel
+        trigger mutes), TB-3PO, GenSeq
       </li>
       <li>
         <strong>Long press (no shift)</strong> — AD Envelope, LFO, LFO+
-      </li>
-      <li>
-        <strong>Shift + short press</strong> — Random+ (output channel)
       </li>
       <li>
         <strong>Shift + long press on button 0 / 2 / 4 / 6</strong> — Sequencer

--- a/faderpunk/src/apps/rnd.rs
+++ b/faderpunk/src/apps/rnd.rs
@@ -233,7 +233,7 @@ pub async fn run(
                     if muted {
                         leds.unset_all();
                     } else {
-                        leds.set(0, Led::Button, LED_COLOR, Brightness::Mid);
+                        leds.set(0, Led::Button, glob_button_color.get(), Brightness::Mid);
                     }
                 }
             }
@@ -298,7 +298,7 @@ pub async fn run(
                         leds.unset(0, Led::Top);
                         leds.unset(0, Led::Bottom);
                     } else {
-                        leds.set(0, Led::Button, LED_COLOR, Brightness::Mid);
+                        leds.set(0, Led::Button, glob_button_color.get(), Brightness::Mid);
                     }
                     latched_glob.set(false);
                 }

--- a/faderpunk/src/apps/rnd_plus.rs
+++ b/faderpunk/src/apps/rnd_plus.rs
@@ -1,5 +1,5 @@
 use embassy_futures::{
-    join::{join, join5},
+    join::{join3, join5},
     select::{select, select3},
 };
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
@@ -170,6 +170,7 @@ pub async fn run(
     let output = app.make_out_jack(1, range).await;
 
     let glob_muted = app.make_global(false);
+    let long_press_fired = app.make_global(false);
     let div_glob = app.make_global(6);
     let val_glob = app.make_global(0);
     let glob_button_color = app.make_global(Color::White);
@@ -265,37 +266,39 @@ pub async fn run(
                     });
                 }
             }
-            if chan == 1 && shift {
-                let muted = !storage.query(|s: &Storage| s.mute_save);
-
-                storage.modify_and_save(|s| {
-                    s.mute_save = muted;
-                });
-
-                if muted {
-                    leds.unset_all();
-                } else {
-                    leds.set(1, Led::Button, led_color, Brightness::Mid);
-                }
-            }
         }
     };
     let long_press = async {
         loop {
             buttons.wait_for_long_press(1).await;
+            long_press_fired.set(true);
 
             if buttons.is_shift_pressed() {
                 let clocked = storage.query(|s: &Storage| s.clocked);
-
-                let muted = !storage.query(|s: &Storage| s.mute_save);
                 storage.modify_and_save(|s| {
                     s.clocked = !clocked;
+                });
+            }
+        }
+    };
+
+    let mute_handler = async {
+        loop {
+            buttons.wait_for_down(1).await;
+            long_press_fired.set(false);
+            buttons.wait_for_up(1).await;
+
+            if !long_press_fired.get() {
+                let muted = !storage.query(|s: &Storage| s.mute_save);
+
+                storage.modify_and_save(|s| {
                     s.mute_save = muted;
                 });
+
                 if muted {
                     leds.unset_all();
                 } else {
-                    leds.set(1, Led::Button, led_color, Brightness::Mid);
+                    leds.set(1, Led::Button, glob_button_color.get(), Brightness::Mid);
                 }
             }
         }
@@ -540,8 +543,9 @@ pub async fn run(
         }
     };
 
-    join(
+    join3(
         long_press,
+        mute_handler,
         join5(fut1, short_press, fader_handler, scene_handler, timed_loop),
     )
     .await;


### PR DESCRIPTION
## Summary
- Random CC/CV and Random+ reset the output button LED to a static color on unmute instead of restoring the last rolled color; both now restore via the tracked last color
- Random+'s Shift + long-press (clock mode toggle) also unintentionally flipped mute as a side effect; the two are now decoupled
- Random+ mute is now a plain short-press (no Shift) on button 2, matching Random CC/CV's UX, instead of requiring Shift + short-press

## Test plan
- [ ] Random CC/CV: let it roll a few random colors, mute, unmute — button LED should return to the last rolled color, not a fixed color
- [ ] Random+: same check on the output channel (button 2)
- [ ] Random+: short-press button 2 (no Shift) toggles mute/unmute
- [ ] Random+: Shift + long-press on button 2 toggles free-running/clocked mode without touching mute state