### PR TITLE
fix: correct ppqn values in Automator Resolution param labels

### DIFF
--- a/faderpunk/src/apps/automator.rs
+++ b/faderpunk/src/apps/automator.rs
@@ -58,7 +58,7 @@ pub static CONFIG: Config<PARAMS> = Config::new(
 .add_param(Param::MidiOut)
 .add_param(Param::Enum {
     name: "Resolution",
-    variants: &["1 ppqn / 2 bars", "2 ppqn / 4 bars", "4 ppqn / 8 bars"],
+    variants: &["24 ppqn / 2 bars", "12 ppqn / 4 bars", "6 ppqn / 8 bars"],
 });
 
 pub struct Params {


### PR DESCRIPTION
## Summary
- Fixes the Automator's Resolution enum labels, which read "1/2/4 ppqn" but actually correspond to 24/12/6 ppqn.

## Test plan
- [ ] Flash to hardware, select the Automator app, open Resolution in the configurator, confirm the labels read "24 ppqn / 2 bars", "12 ppqn / 4 bars", "6 ppqn / 8 bars".