### PR TITLE
fix(configurator): keep save button green until next edit

### DIFF
--- a/configurator/src/components/ActiveApp.tsx
+++ b/configurator/src/components/ActiveApp.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { type Value } from "@atov/fp-config";
 import { useForm } from "react-hook-form";
 import classNames from "classnames";
@@ -32,8 +32,27 @@ export const ActiveApp = ({ app, layoutId, params, startChannel }: Props) => {
     register,
     control,
     handleSubmit,
+    watch,
+    getValues,
     formState: { isSubmitting },
   } = useForm();
+  // Snapshot of the form values as of the last successful save. Some HeroUI
+  // inputs (e.g. Select) synthesize onChange events without a native `type`,
+  // so react-hook-form's watch info can't reliably tell a real edit from
+  // other notifications — comparing against this snapshot works regardless.
+  const savedSnapshotRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const subscription = watch((values) => {
+      if (
+        savedSnapshotRef.current !== null &&
+        JSON.stringify(values) !== savedSnapshotRef.current
+      ) {
+        setSaved(false);
+      }
+    });
+    return () => subscription.unsubscribe();
+  }, [watch]);
 
   const onSubmit = async (
     data: Record<string, string | boolean | boolean[]>,
@@ -51,8 +70,8 @@ export const ActiveApp = ({ app, layoutId, params, startChannel }: Props) => {
       );
     }
     if (device || isSimulator) {
+      savedSnapshotRef.current = JSON.stringify(getValues());
       setSaved(true);
-      setTimeout(() => setSaved(false), 2000);
     }
   };
 

--- a/configurator/src/components/SettingsTab.tsx
+++ b/configurator/src/components/SettingsTab.tsx
@@ -142,8 +142,18 @@ const SettingsForm = ({ config }: SettingsFormProps) => {
   const [configuratorVersion, setConfiguratorVersion] = useState<string>("");
   const {
     handleSubmit,
+    watch,
     formState: { isSubmitting },
   } = methods;
+
+  useEffect(() => {
+    const subscription = watch((_, { type }) => {
+      if (type === "change") {
+        setSaved(false);
+      }
+    });
+    return () => subscription.unsubscribe();
+  }, [watch]);
 
   const onSubmit: SubmitHandler<Inputs> = useCallback(
     async (formValues: Inputs) => {
@@ -157,7 +167,6 @@ const SettingsForm = ({ config }: SettingsFormProps) => {
       }
       if (device || isSimulator) {
         setSaved(true);
-        setTimeout(() => setSaved(false), 2000);
       }
     },
     [device, isSimulator, setConfig],


### PR DESCRIPTION
Closes #544.

## Summary
- Save buttons in Settings and app Parameters now stay green ("Saved") until the user makes another edit, instead of reverting after a fixed 2s timer.
- Settings: clears on the next `react-hook-form` field change (reliable there since all fields go through `Controller`).
- App Parameters: clears based on a form-value snapshot comparison, since some HeroUI inputs (Select, curve/range widgets) synthesize onChange events without a native event `type`, making react-hook-form's change-type detection unreliable for them.
- Regenerated configurator/libfp TypeScript bindings (`./gen-bindings.sh`) to match current `main`; the previous bindings had drifted from an unmerged branch.