### PR TITLE
fix(clock): re-arm external clock watchdog on Start/Continue

### DIFF
--- a/faderpunk/src/tasks/clock.rs
+++ b/faderpunk/src/tasks/clock.rs
@@ -200,6 +200,15 @@ fn swung_offset(i: u32, t: Duration, swing: i8) -> Duration {
     Duration::from_ticks((raw.max(0) as u64).min(window_end as u64))
 }
 
+/// How long to wait for the next external pulse before declaring the clock
+/// lost. Falls back to `WATCHDOG_FLOOR` while no period has been measured.
+fn watchdog_duration(measured_period: Option<Duration>) -> Duration {
+    measured_period
+        .map(|p| p * WATCHDOG_MULTIPLIER)
+        .unwrap_or(WATCHDOG_FLOOR)
+        .max(WATCHDOG_FLOOR)
+}
+
 pub async fn start_clock(spawner: &Spawner, aux_inputs: AuxInputs) {
     spawner.spawn(run_clock_sources(aux_inputs)).unwrap();
     spawner.spawn(run_clock_gatekeeper()).unwrap();
@@ -613,22 +622,21 @@ async fn run_unified_clock_engine() {
                             // re-anchor the window on the next pulse.
                             pending_emissions.clear();
                             tick_in_window = 0;
+                            // Re-arm the watchdog from now: the previous
+                            // deadline is anchored to the last pre-stop pulse
+                            // and may already have elapsed, which would fire a
+                            // spurious clock-lost Stop before the first
+                            // resumed pulse arrives.
+                            next_tick_at = Instant::now() + watchdog_duration(measured_ext_period);
                         }
                         ClockInEvent::Continue(_) => {
                             is_running = true;
+                            // Same watchdog re-arm as Start.
+                            next_tick_at = Instant::now() + watchdog_duration(measured_ext_period);
                         }
                         ClockInEvent::Stop(_) => {
                             is_running = false;
                             pending_emissions.clear();
-                            // Invalidate external tracking state so a stale
-                            // `next_tick_at` can't race a later Start/Continue
-                            // (see the identical reset on clock-source change,
-                            // below) and fire a spurious watchdog Stop before
-                            // the real resumed pulse ever arrives.
-                            last_pulse = None;
-                            measured_ext_period = None;
-                            delta_history = [Duration::from_ticks(0); HISTORY_SIZE];
-                            history_idx = 0;
                         }
                         ClockInEvent::Reset(_) => {
                             pending_emissions.clear();
@@ -760,13 +768,8 @@ async fn run_unified_clock_engine() {
 
                     last_pulse = Some(timestamp);
                     // Schedule watchdog: if no pulse arrives within the watchdog window,
-                    // declare external clock lost. Use a generous floor so drastic tempo
-                    // changes (or slow analog clocks) don't trip it.
-                    let watchdog = measured_ext_period
-                        .map(|p| p * WATCHDOG_MULTIPLIER)
-                        .unwrap_or(WATCHDOG_FLOOR)
-                        .max(WATCHDOG_FLOOR);
-                    next_tick_at = timestamp + watchdog;
+                    // declare external clock lost.
+                    next_tick_at = timestamp + watchdog_duration(measured_ext_period);
                 }
             },
 
@@ -822,9 +825,6 @@ async fn run_unified_clock_engine() {
                             .send(ClockInEvent::Stop(config.clock.clock_src))
                             .await;
                         last_pulse = None;
-                        measured_ext_period = None;
-                        delta_history = [Duration::from_ticks(0); HISTORY_SIZE];
-                        history_idx = 0;
                         is_running = false;
                         pending_emissions.clear();
                         tick_in_window = 0;

--- a/faderpunk/src/tasks/clock.rs
+++ b/faderpunk/src/tasks/clock.rs
@@ -620,6 +620,15 @@ async fn run_unified_clock_engine() {
                         ClockInEvent::Stop(_) => {
                             is_running = false;
                             pending_emissions.clear();
+                            // Invalidate external tracking state so a stale
+                            // `next_tick_at` can't race a later Start/Continue
+                            // (see the identical reset on clock-source change,
+                            // below) and fire a spurious watchdog Stop before
+                            // the real resumed pulse ever arrives.
+                            last_pulse = None;
+                            measured_ext_period = None;
+                            delta_history = [Duration::from_ticks(0); HISTORY_SIZE];
+                            history_idx = 0;
                         }
                         ClockInEvent::Reset(_) => {
                             pending_emissions.clear();
@@ -813,6 +822,9 @@ async fn run_unified_clock_engine() {
                             .send(ClockInEvent::Stop(config.clock.clock_src))
                             .await;
                         last_pulse = None;
+                        measured_ext_period = None;
+                        delta_history = [Duration::from_ticks(0); HISTORY_SIZE];
+                        history_idx = 0;
                         is_running = false;
                         pending_emissions.clear();
                         tick_in_window = 0;


### PR DESCRIPTION
## Summary

A user reported that Faderpunk fails to resume clock-driven apps after syncing to Loopy Pro (iPad) over MIDI: a real Stop, followed by a pause, followed by a genuine Start (0xFA) leaves the clock permanently dead — no ticks ever reach apps again. A quick Stop → Play (which the source sends as Continue, 0xFB, since the transport position hasn't reset) works every time. Reproduced identically over both USB and DIN.

## Root cause

In `run_unified_clock_engine` (`faderpunk/src/tasks/clock.rs`), the external watchdog deadline `next_tick_at` is only ever advanced by incoming pulses. If the source stops sending Clock while its transport is stopped, the deadline goes stale; on the next Start/Continue the timer fires immediately — before the first resumed clock pulse can arrive — and the watchdog sends a spurious `Stop` that silently undoes the just-processed Start. Sources that keep transmitting Clock continuously never accumulate staleness, which is why the bug only shows with sources (like Loopy Pro) that gate their Clock stream on transport stop.

## Fix

Re-arm `next_tick_at` from `Instant::now()` in the external `Start` and `Continue` arms, using the same watchdog window as the pulse path (now shared via a small `watchdog_duration()` helper). The stale deadline can no longer race the resume, regardless of what the source did while stopped.

This replaces the first approach on this branch (clearing `last_pulse`/`measured_ext_period`/`delta_history` on Stop), which review showed was both leaky and lossy: a couple of Clock ticks trailing the Stop (bursty USB MIDI, or a source that gates its clock slightly late) would rebuild the cleared state and resurrect the race, and discarding the tempo measurement disarmed the watchdog until two fresh pulses arrived and made the first swing window after every resume play unswung. Re-arming at the resume transition avoids all of that: tempo memory survives stops and the watchdog is armed from the moment of resume.

Checked for overlap with two other open PRs that touch this same function: #551 (Auto sync source mode) inherits the identical gap in its non-Auto fallback path — this fix still applies once rebased. #579 (variable PPQN external clock) only adds a re-arm for analog sources; MIDI sources are untouched by it, so this fix remains independently necessary.

## Verification

Static gates pass clean (`cargo fmt --all -- --check`, `cargo clippy --bin faderpunk -- -D warnings`). `libfp` is untouched.

## Hardware test checklist

- [ ] Set clock source to external MIDI (test both USB and DIN)
- [ ] Start a clock-driven app (e.g. a clock divider or sequencer using `use_clock()`)
- [ ] Start the external transport, let it run a few seconds, send Stop, wait several seconds (past the ~2-8s watchdog window), then send a real Start (position at 0). Confirm the app resumes ticking as soon as the first real clock pulse arrives — no permanent dead state
- [ ] Same as above, but stop in a way that lets a few Clock ticks trail the Stop message (e.g. wiggle the transport) — must still start cleanly
- [ ] Regression: quick Stop → Continue with minimal wait still works as before
- [ ] Regression: silence the external clock entirely while running — the watchdog must still stop the clock after ~2-8s

---
_Generated by [Claude Code](https://claude.ai/code)_
