### PR TITLE
fix: isolate MIDI clock ticks from note/CC out queue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,10 +50,13 @@ Follow this for **every** task, in order. Do not skip steps.
 
    Then **STOP.** Wait for the user to review and adjust the code. Do not commit.
 
-3. **On the user's go: commit.** A single one-line message in
+3. **On the user's go: commit.** A single one-line subject in
    conventional-commit format (`feat:`, `fix:`, `chore:`, `refactor:`, …,
    optionally scoped e.g. `feat(genseq):`). Commit with the system git user
    (commits are signed). Do **not** add a `Co-authored-by: Claude` trailer.
+   In the commit body, state clearly that an AI coding agent authored the
+   change on the user's behalf (e.g. `Authored by an AI coding agent on
+   behalf of <user>.`).
 
 4. **After committing, ask again** before opening a PR.
 
@@ -67,6 +70,11 @@ Follow this for **every** task, in order. Do not skip steps.
    - **Configurator fix** → steps for how to confirm the fix in the
      **configurator** (browser + live device).
    - Anything else → no checklist.
+
+6. **Never merge, approve, or otherwise accept a PR.** Open the PR and hand
+   it to the user. Merging, approving, enabling auto-merge, or closing via
+   merge is exclusively the user's decision — even if the user asks you to
+   "finish" or "land" the change.
 
 ## Environment & Toolchain
 
@@ -345,7 +353,9 @@ manually in a Chromium browser with a live device connection.
 6. **FRAM address ranges**: Don't overlap storage regions in `storage.rs`.
 7. **Atomic ordering**: Use `Ordering::Relaxed` for non-synchronized state, `Acquire`/`Release` for synchronized.
 8. **Web MIDI requirements**: Browser must support Web MIDI with SysEx (Chromium, Firefox); HTTPS required for non-localhost. The user must grant the MIDI/SysEx permission.
-9. **Commit trailers**: One-line conventional-commit messages; do not add a `Co-authored-by: Claude` trailer.
+9. **Commit messages**: Conventional-commit subject; body must note AI authorship
+   on the user's behalf. Do not add a `Co-authored-by: Claude` trailer. Never
+   merge/approve/accept PRs — only open them for the user.
 
 ## File Structure Summary
 

--- a/faderpunk/src/tasks/clock.rs
+++ b/faderpunk/src/tasks/clock.rs
@@ -27,7 +27,7 @@ use crate::{
     state::{is_clock_running, update_state},
     tasks::{
         max::{MaxCmd, MAX_CHANNEL},
-        midi::{MidiClockMsg, MidiOutEvent, MIDI_CHANNEL},
+        midi::{MidiClockMsg, MIDI_CLOCK_CHANNEL},
     },
     Spawner, GLOBAL_CONFIG_WATCH,
 };
@@ -298,7 +298,7 @@ async fn metronome() {
 #[embassy_executor::task]
 async fn run_clock_gatekeeper() {
     let clock_publisher = CLOCK_PUBSUB.publisher().unwrap();
-    let midi_sender = MIDI_CHANNEL.sender();
+    let midi_clock_sender = MIDI_CLOCK_CHANNEL.sender();
     let clock_in_receiver = CLOCK_IN_CHANNEL.receiver();
     let mut config_receiver = GLOBAL_CONFIG_WATCH.receiver().unwrap();
 
@@ -407,7 +407,11 @@ async fn run_clock_gatekeeper() {
                 if should_send_midi {
                     if let Some(rt_event) = midi_rt_event {
                         let msg = MidiClockMsg::new(rt_event, midi_target);
-                        let _ = midi_sender.try_send(MidiOutEvent::Clock(msg));
+                        // Dedicated realtime queue: never contended by app
+                        // note/CC traffic, so ticks are not dropped under
+                        // load. try_send keeps the gatekeeper non-blocking;
+                        // the queue only fills if all outputs stall entirely.
+                        let _ = midi_clock_sender.try_send(msg);
                     }
                 }
             }

--- a/faderpunk/src/tasks/midi.rs
+++ b/faderpunk/src/tasks/midi.rs
@@ -113,7 +113,6 @@ impl MidiClockMsg {
 #[derive(Clone, Copy)]
 pub enum MidiOutEvent {
     Event(MidiMsg),
-    Clock(MidiClockMsg),
 }
 
 #[derive(Clone, Copy)]
@@ -124,6 +123,18 @@ pub enum MidiEvent {
 
 pub static MIDI_CHANNEL: Channel<CriticalSectionRawMutex, MidiOutEvent, MIDI_CHANNEL_SIZE> =
     Channel::new();
+
+/// Dedicated high-priority queue for MIDI realtime (clock/transport)
+/// messages. Kept separate from `MIDI_CHANNEL` so note/CC bursts from apps
+/// can never fill the queue and cause clock ticks to be dropped, which
+/// external gear perceives as wildly wrong BPM. Drained with priority by
+/// `midi_out_task`.
+const MIDI_CLOCK_CHANNEL_SIZE: usize = 32;
+pub static MIDI_CLOCK_CHANNEL: Channel<
+    CriticalSectionRawMutex,
+    MidiClockMsg,
+    MIDI_CLOCK_CHANNEL_SIZE,
+> = Channel::new();
 
 // Channel for apps (Core 1) to send MIDI to the distributor task (Core 1)
 pub static APP_MIDI_CHANNEL: Channel<ThreadModeRawMutex, (usize, MidiMsg), MIDI_CHANNEL_SIZE> =
@@ -289,6 +300,32 @@ pub async fn midi_distributor() {
     }
 }
 
+/// Writes a realtime clock/transport message to all its target outputs.
+async fn write_clock_msg<'a>(
+    usb_tx: &SharedUsbSender<'a>,
+    uart0_tx: &mut UartTx<'static, Async>,
+    uart1_tx: &mut BufferedUartTx,
+    msg: MidiClockMsg,
+) {
+    let event = LiveEvent::Realtime(msg.event);
+    let usb_fut = async {
+        if let MidiOut([true, _, _]) = msg.target {
+            let _ = write_msg_to_usb(usb_tx, event).await;
+        }
+    };
+    let out1_fut = async {
+        if let MidiOut([_, true, _]) = msg.target {
+            let _ = write_msg_to_uart1(uart1_tx, event).await;
+        }
+    };
+    let out2_fut = async {
+        if let MidiOut([_, _, true]) = msg.target {
+            let _ = write_msg_to_uart0(uart0_tx, event).await;
+        }
+    };
+    join3(usb_fut, out1_fut, out2_fut).await;
+}
+
 pub async fn midi_out_task<'a>(
     usb_tx: &SharedUsbSender<'a>,
     mut uart0_tx: UartTx<'static, Async>,
@@ -296,6 +333,7 @@ pub async fn midi_out_task<'a>(
 ) {
     let mut config_receiver = GLOBAL_CONFIG_WATCH.receiver().unwrap();
     let midi_receiver = MIDI_CHANNEL.receiver();
+    let clock_receiver = MIDI_CLOCK_CHANNEL.receiver();
 
     let config = config_receiver.get().await;
     let mut disabled_outs_for_local = config.midi.outs.map(|c| {
@@ -312,8 +350,24 @@ pub async fn midi_out_task<'a>(
     });
 
     loop {
-        match select(midi_receiver.receive(), config_receiver.changed()).await {
-            Either::First(midi_out_msg) => {
+        // Realtime clock first: drain any pending ticks before touching the
+        // note/CC queue so heavy app traffic can never delay or starve them.
+        if let Ok(clock_msg) = clock_receiver.try_receive() {
+            write_clock_msg(usb_tx, &mut uart0_tx, &mut uart1_tx, clock_msg).await;
+            continue;
+        }
+
+        match select3(
+            clock_receiver.receive(),
+            midi_receiver.receive(),
+            config_receiver.changed(),
+        )
+        .await
+        {
+            Either3::First(clock_msg) => {
+                write_clock_msg(usb_tx, &mut uart0_tx, &mut uart1_tx, clock_msg).await;
+            }
+            Either3::Second(midi_out_msg) => {
                 match midi_out_msg {
                     MidiOutEvent::Event(MidiMsg::Live {
                         event,
@@ -398,28 +452,9 @@ pub async fn midi_out_task<'a>(
                             }
                         }
                     }
-                    MidiOutEvent::Clock(msg) => {
-                        let event = LiveEvent::Realtime(msg.event);
-                        let usb_fut = async {
-                            if let MidiOut([true, _, _]) = msg.target {
-                                let _ = write_msg_to_usb(usb_tx, event).await;
-                            }
-                        };
-                        let out1_fut = async {
-                            if let MidiOut([_, true, _]) = msg.target {
-                                let _ = write_msg_to_uart1(&mut uart1_tx, event).await;
-                            }
-                        };
-                        let out2_fut = async {
-                            if let MidiOut([_, _, true]) = msg.target {
-                                let _ = write_msg_to_uart0(&mut uart0_tx, event).await;
-                            }
-                        };
-                        join3(usb_fut, out1_fut, out2_fut).await;
-                    }
                 }
             }
-            Either::Second(new_config) => {
+            Either3::Third(new_config) => {
                 disabled_outs_for_local = new_config.midi.outs.map(|c| {
                     matches!(
                         c,
@@ -513,7 +548,7 @@ pub async fn midi_in_task<'a>(
                     if len == 0 {
                         continue;
                     }
-                    let packets = usb_rx_buf[..len].chunks_exact(4);
+                    let (packets, _) = usb_rx_buf[..len].as_chunks::<4>();
                     for packet in packets {
                         let cable = packet[0] >> 4;
                         let msg_len = len_from_cin(packet[0]);


### PR DESCRIPTION
## Summary
- Route MIDI realtime clock/transport through a dedicated `MIDI_CLOCK_CHANNEL` so app note/CC bursts cannot fill `MIDI_CHANNEL` and drop ticks (external gear then reads wrong BPM).
- Drain that queue with priority in `midi_out_task`; gatekeeper still uses non-blocking `try_send`.
- Document in `AGENTS.md` that AI-authored commits must say so in the body, and that agents must never merge/approve PRs.

Authored by an AI coding agent on behalf of @kosmar.

## Test plan
- [ ] On hardware: run internal MIDI clock out while apps generate heavy note/CC traffic; confirm external gear BPM stays stable (no dropped ticks / tempo jumps).
- [ ] Start/stop/continue transport still reaches configured MIDI outs.
- [ ] Note/CC from apps still egress normally under light load.
