### PR TITLE
feat: default clock to running on factory-fresh boot

### DIFF
--- a/faderpunk/src/state.rs
+++ b/faderpunk/src/state.rs
@@ -7,11 +7,21 @@ use crate::storage;
 /// Persisted to FRAM as CBOR. Adding/removing fields is migration-free as long
 /// as every field carries `#[cbor(default)]` and a fresh `#[n(N)]`. See the
 /// `GlobalConfig` doc comment in `libfp::lib` for the full convention.
-#[derive(Serialize, Deserialize, Encode, Decode, Clone, Copy, Default, Debug)]
+#[derive(Serialize, Deserialize, Encode, Decode, Clone, Copy, Debug)]
 pub struct RuntimeState {
     #[n(0)]
     #[cbor(default)]
     pub clock_is_running: bool,
+}
+
+/// A factory-fresh unit (empty/unreadable FRAM) boots with the internal
+/// clock running, rather than requiring the user to press Start first.
+impl Default for RuntimeState {
+    fn default() -> Self {
+        Self {
+            clock_is_running: true,
+        }
+    }
 }
 
 static STATE: Mutex<CriticalSectionRawMutex, RuntimeState> = Mutex::new(RuntimeState {


### PR DESCRIPTION
## Summary
- `RuntimeState::default()` now sets `clock_is_running: true` instead of deriving the bool's `false` default, so a factory-fresh unit (blank/erased FRAM, first boot or after `factory_reset()`) boots with the internal clock running instead of requiring a Start press.
- Scoped to the "no persisted state at all" fallback path only — any unit with a previously saved run state (running or stopped) still restores exactly what was saved.

## Test plan
- [ ] Factory-reset a unit (hold channel buttons 0+1 at boot) → confirm the internal clock is running immediately after boot, no Start press needed.
- [ ] On a unit where the clock was previously stopped and that state was saved → power-cycle → confirm it still boots stopped (proves the change is scoped to fresh units only).

Authored by an AI coding agent on behalf of Arthur Gibert.