### PR TITLE
chore: migrate to panic = "immediate-abort" for current nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["panic-immediate-abort"]
+
 [workspace]
 members = ["faderpunk", "libfp"]
 
@@ -10,7 +12,9 @@ lto = true
 incremental = false
 codegen-units = 1
 debug = 2
+panic = "immediate-abort"
 
 [profile.dev]
 lto = true
 opt-level = "z"
+panic = "immediate-abort"

--- a/faderpunk/.cargo/config.toml
+++ b/faderpunk/.cargo/config.toml
@@ -10,5 +10,6 @@ target = "thumbv8m.main-none-eabihf"
 DEFMT_LOG = "debug"
 
 [unstable]
-build-std = ["core"]
-build-std-features = ["panic_immediate_abort"]
+# core+alloc required with panic = "immediate-abort" so deps do not pull a
+# second sysroot core (duplicate lang item).
+build-std = ["core", "alloc"]


### PR DESCRIPTION
## Summary
- Nightly no longer supports `build-std-features = ["panic_immediate_abort"]`; builds fail with a `core` compile_error.
- Opt into Cargo's `panic-immediate-abort` feature and set `panic = "immediate-abort"` on release/dev profiles.
- Keep `-Zbuild-std` with `core` + `alloc` (alloc avoids a duplicate-lang-item clash against the sysroot).

## Test plan
- [ ] `direnv exec . ./build-uf2.sh` (from `faderpunk/` path / package build-std) succeeds on current devenv nightly
- [ ] `cargo clippy -p libfp -- -D warnings` and `cargo test --lib -p libfp` still pass
