### PR TITLE
fix: align .text section start to 8 bytes

### DIFF
--- a/faderpunk/memory.x
+++ b/faderpunk/memory.x
@@ -36,8 +36,13 @@ SECTIONS {
 
 } INSERT AFTER .vector_table;
 
-/* move .text to start /after/ the boot info */
-_stext = ADDR(.start_block) + SIZEOF(.start_block);
+/* move .text to start /after/ the boot info.
+ * ALIGN(8): .text contains input sections requiring 8-byte alignment, but the
+ * raw end of .start_block (0x1000013c) is only 4-aligned. rust-lld warns
+ * ("address of section .text is not a multiple of alignment") and the
+ * misaligned section caused flaky app-task spawn crashes that moved to a
+ * different app with every code change. */
+_stext = ALIGN(ADDR(.start_block) + SIZEOF(.start_block), 8);
 
 SECTIONS {
     /* ### Picotool 'Binary Info' Entries

--- a/faderpunk/memory.x
+++ b/faderpunk/memory.x
@@ -36,12 +36,8 @@ SECTIONS {
 
 } INSERT AFTER .vector_table;
 
-/* move .text to start /after/ the boot info.
- * ALIGN(8): .text contains input sections requiring 8-byte alignment, but the
- * raw end of .start_block (0x1000013c) is only 4-aligned. rust-lld warns
- * ("address of section .text is not a multiple of alignment") and the
- * misaligned section caused flaky app-task spawn crashes that moved to a
- * different app with every code change. */
+/* Move .text after the boot info and satisfy its current 8-byte
+ * output-section alignment requirement. */
 _stext = ALIGN(ADDR(.start_block) + SIZEOF(.start_block), 8);
 
 SECTIONS {


### PR DESCRIPTION
## Summary
- `_stext = ADDR(.start_block) + SIZEOF(.start_block)` places `.text` at 0x1000013c, which is not a multiple of the section’s current 8-byte alignment requirement. rust-lld has been warning about this on every build (“address of section .text is not a multiple of alignment”).
- Fix: `ALIGN(..., 8)` pads 4 bytes after `.start_block` so `.text` starts at 0x10000140 and satisfies the ELF output-section alignment invariant.
- Note: this corrects the aggregate section-header alignment; it does not by itself prove that the earlier flaky app-task spawn crashes were caused by that misalignment (shifting code addresses can also mask a separate layout-sensitive bug).

Found while debugging dense preset pushes with the preset editor (#602). Host-side pacing there reduces USB pressure; this change clears the linker alignment warning and keeps `.text` properly aligned.

## Test plan
- [ ] Build firmware: rust-lld alignment warning is gone
- [ ] Flash to hardware and push a dense layout (10+ apps incl. multiple instances of the same app) via the configurator