### PR TITLE
fix: avoid blocking MIDI CC sends from stalling app control loops

### DIFF
--- a/faderpunk/src/app.rs
+++ b/faderpunk/src/app.rs
@@ -406,16 +406,26 @@ impl MidiOutput {
 
     /// Sends a MIDI CC message. In NRPN mode, sends as 14-bit NRPN instead.
     /// value is normalized to a range of 0-4095
+    ///
+    /// Non-blocking: callers use this for continuous "latest value wins"
+    /// streams (LFOs, CV converters, etc.), so a full app MIDI queue drops
+    /// this update rather than stalling the caller's control loop — the next
+    /// update supersedes it anyway. Unlike note on/off, dropping here can't
+    /// leave a stuck note.
     pub async fn send_cc(&self, cc: MidiCc, value: u16) {
         if self.nrpn_mode {
             let msg = MidiMsg::nrpn(self.midi_channel, cc.as_u16(), value, self.midi_out);
-            self.midi_sender.send((self.start_channel, msg)).await;
+            let _ = self.midi_sender.try_send((self.start_channel, msg));
         } else {
-            let msg = MidiMessage::Controller {
-                controller: cc.into(),
-                value: scale_bits_12_7(value),
+            let event = LiveEvent::Midi {
+                channel: self.midi_channel,
+                message: MidiMessage::Controller {
+                    controller: cc.into(),
+                    value: scale_bits_12_7(value),
+                },
             };
-            self.send_midi_msg(msg).await;
+            let msg = MidiMsg::new(event, self.midi_out, MidiEventSource::Local);
+            let _ = self.midi_sender.try_send((self.start_channel, msg));
         }
     }
 


### PR DESCRIPTION
## Summary
- `MidiOutput::send_cc` blocked on a bounded channel send inside apps' per-tick control loops (e.g. LFO). Under MIDI backpressure — worse in NRPN mode, which sends 4x the CC traffic — this stalled the whole loop, freezing CV output until the queue drained.
- Switch `send_cc` (CC and NRPN branches) to `try_send`, dropping the update instead of blocking. Safe because CC/NRPN is a continuous "latest value wins" stream — a dropped sample is superseded by the next tick. Note on/off and other discrete MIDI events are untouched (still blocking) since dropping a note-off could leave a stuck note.

## Root cause context

The severity here traces back to #590 (moving the config protocol onto shared USB-MIDI SysEx), which raised the per-write USB timeout from 1ms to 5ms to tolerate slow-polling embedded MIDI hosts. When nothing drains the USB IN endpoint — the out-of-the-box state on a bus-powered module with no computer attached, since USB MIDI-out is enabled by default — every USB-targeted write now blocks for the full 5ms instead of 1ms before giving up. `midi_out_task` drains the shared `MIDI_CHANNEL`/`APP_MIDI_CHANNEL` sequentially, and NRPN sends stay sequential across their 4 CC sub-messages, so this directly cut NRPN-mode drain rate from ~250 updates/sec to ~50/sec — amplifying the freeze this PR fixes.

This PR fixes the freeze itself: pre-fix, `send_cc`'s blocking `.send().await` stalls the app's control-loop coroutine before it reaches the CV/DAC write in the same tick, so CV output stops updating entirely until the backlog drains. Post-fix, `try_send` decouples CV output from MIDI channel state, so the freeze is gone — but under the same saturation conditions, CC/NRPN updates could still be silently dropped instead of guaranteed-delivered, which for a continuously-varying signal can look like coarser/steppier MIDI CC output on the wire (CV is unaffected either way).

The root cause (USB writes blocking for the full timeout whenever no host is attached) is fixed separately in #619, hardware-confirmed to resolve the channel saturation that caused this. This PR remains valuable on its own regardless — it's the only thing standing between a full app-loop freeze and note on/off, which can't safely take the same drop-on-full approach `send_cc` does here.

## Test plan
- [ ] Recreate the reported layout (LFO with NRPN enabled on a channel, MIDI-heavy layout with several other MIDI-out apps active) and confirm CV output stays smooth on power-up, without needing to connect the configurator to "fix" it
- [ ] Confirm MIDI CC/NRPN output still reaches a receiving device normally under light load
- [ ] Confirm note on/off apps (e.g. euclid, bernoulli, notefader) still behave correctly — no regression from this change since they're unaffected