### PR TITLE
fix: skip USB writes when the host isn't attached

### DIFF
--- a/faderpunk/src/tasks/configure.rs
+++ b/faderpunk/src/tasks/configure.rs
@@ -3,6 +3,7 @@ use embassy_sync::channel::Channel;
 use embassy_sync::signal::Signal;
 use embassy_time::{with_timeout, Duration};
 use heapless::Vec;
+use portable_atomic::Ordering;
 use postcard::{from_bytes, to_slice};
 
 use libfp::sysex::{
@@ -60,6 +61,7 @@ pub enum ProtocolError {
     TransmissionError,
     CorruptedMessage,
     Timeout,
+    NotConnected,
 }
 
 pub async fn start_config_loop<'a>(usb_tx: &'a SharedUsbSender<'a>) {
@@ -291,6 +293,9 @@ impl<'a> ConfigTransport<'a> {
 }
 
 async fn write_usb_packet(usb_tx: &SharedUsbSender<'_>, data: &[u8]) -> Result<(), ProtocolError> {
+    if !crate::tasks::transport::USB_CONNECTED.load(Ordering::Relaxed) {
+        return Err(ProtocolError::NotConnected);
+    }
     let mut tx = usb_tx.lock().await;
     with_timeout(
         Duration::from_millis(CONFIG_WRITE_TIMEOUT_MS),

--- a/faderpunk/src/tasks/midi.rs
+++ b/faderpunk/src/tasks/midi.rs
@@ -24,6 +24,7 @@ use midly::{
     stream::MidiStream,
     MidiMessage,
 };
+use portable_atomic::Ordering;
 
 use libfp::{ClockSrc, MidiIn, MidiOut, MidiOutConfig, MidiOutMode, GLOBAL_CHANNELS};
 
@@ -209,6 +210,9 @@ async fn write_msg_to_usb<'a>(
     usb_tx: &SharedUsbSender<'a>,
     midi_ev: LiveEvent<'a>,
 ) -> Result<(), TimeoutError> {
+    if !crate::tasks::transport::USB_CONNECTED.load(Ordering::Relaxed) {
+        return Err(TimeoutError);
+    }
     let mut usb_buf = [0_u8; 4];
     // Cable nibble 0 (performance MIDI) | CIN
     usb_buf[0] = cin_from_live_event(&midi_ev) as u8;

--- a/faderpunk/src/tasks/transport.rs
+++ b/faderpunk/src/tasks/transport.rs
@@ -4,7 +4,8 @@ use embassy_rp::peripherals::USB;
 use embassy_rp::usb;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::mutex::Mutex;
-use embassy_usb::{Builder, Config as UsbConfig};
+use embassy_usb::{Builder, Config as UsbConfig, Handler};
+use portable_atomic::{AtomicBool, Ordering};
 
 use embassy_rp::uart::{Async, BufferedUart, UartTx};
 
@@ -19,6 +20,44 @@ const USB_VENDOR_NAME: &str = "ATOV";
 const USB_PRODUCT_NAME: &str = "Faderpunk";
 
 pub const USB_MAX_PACKET_SIZE: u16 = 64;
+
+/// True once the USB device has completed enumeration and the host has
+/// selected our configuration (SET_CONFIGURATION). False on boot, on a bus
+/// reset, and whenever de-configured. Lets USB writes in tasks/midi.rs and
+/// tasks/configure.rs short-circuit instead of paying a per-write timeout
+/// when no host is attached — the out-of-the-box state, since USB MIDI-out
+/// defaults on.
+///
+/// Known gap: this only covers "never enumerated" / "de-configured via a
+/// bus reset". A host that completed enumeration but has no application
+/// actively reading the MIDI port (or a cable pulled without a subsequent
+/// bus reset) still reads as connected here.
+pub static USB_CONNECTED: AtomicBool = AtomicBool::new(false);
+
+struct UsbConnectionHandler;
+
+impl Handler for UsbConnectionHandler {
+    fn configured(&mut self, configured: bool) {
+        USB_CONNECTED.store(configured, Ordering::Relaxed);
+    }
+
+    fn reset(&mut self) {
+        // Event::Reset does not imply configured(false) — without this, a
+        // real bus reset (unplug/replug) would leave the flag stuck true
+        // until the next full enumeration completes.
+        USB_CONNECTED.store(false, Ordering::Relaxed);
+    }
+
+    fn suspended(&mut self, suspended: bool) {
+        // embassy-rp has no VBUS sensing, so Suspend fires from bus
+        // inactivity alone — a real logical suspend and a cable physically
+        // pulled after enumeration are indistinguishable here, and both
+        // warrant the same response (nothing is draining the endpoint
+        // either way). Without this, unplugging after a session had been
+        // enumerated would leave the flag stuck true.
+        USB_CONNECTED.store(!suspended, Ordering::Relaxed);
+    }
+}
 
 pub async fn start_transports(
     spawner: &Spawner,
@@ -70,6 +109,9 @@ async fn run_transports(
     let mut control_buf = [0; 64];
     // Serves the jack name strings; must outlive the USB device.
     let mut jack_name_handler = JackNameHandler::new();
+    // Must outlive `usb_builder`/`usb`, so declared alongside the other
+    // buffers above, before the builder borrows them.
+    let mut usb_conn_handler = UsbConnectionHandler;
 
     let mut usb_builder = Builder::new(
         usb_driver,
@@ -79,6 +121,8 @@ async fn run_transports(
         &mut [], // no MS OS descriptors
         &mut control_buf,
     );
+
+    usb_builder.handler(&mut usb_conn_handler);
 
     // Two virtual cables: cable 0 = performance MIDI, cable 1 = config SysEx
     let usb_midi = MidiClass::new(


### PR DESCRIPTION
## Summary

MIDI output stalled when the unit runs with no computer attached (the default configuration, since USB MIDI-out is enabled out of the box). PR #590 raised the per-write USB timeout from 1ms to 5ms to support slow-polling embedded MIDI hosts; when nothing drains the USB endpoint, every USB-targeted write now pays that full timeout. Because all MIDI output funnels through one shared, bounded queue serving every app in the layout, sustained USB-targeted traffic (NRPN mode is worst-case, at 4 CC messages per update) backed up that queue and stalled other apps trying to send MIDI, not just the source of the traffic.

## Changes

- `tasks/transport.rs`: new `USB_CONNECTED` flag, set by a new `Handler` hooked to `configured()`, `reset()`, and `suspended()`.
  - `configured()`/`reset()` cover enumeration/de-enumeration (a bus reset doesn't imply `configured(false)`, so both are needed).
  - `suspended()` covers a cable physically pulled after having been connected: embassy-rp has no VBUS sensing, so `Event::Suspend` fires purely from bus inactivity — a real logical suspend and a physical unplug are indistinguishable to the hardware, and both warrant the same response (nothing is draining the endpoint either way). Without this, disconnecting after a session had been enumerated left the flag stuck `true`, so writes went back to timing out on every message instead of short-circuiting — confirmed on hardware, now fixed.
- `tasks/midi.rs` / `tasks/configure.rs`: USB writes check the flag first and return immediately instead of attempting the write when no host is attached.

Remaining known limitation: enumerated, host present, but no application actively reading the MIDI port — that state is indistinguishable from a genuinely working connection at the USB protocol level, so it still reads as connected here.

## Test plan

- [x] Unit running standalone (no USB cable/host attached), layout with an NRPN-mode LFO plus other MIDI/CV apps active: other apps no longer stall — confirmed on hardware.
- [x] Boot without USB, connect to a host, then disconnect: no more stalling after disconnect — confirmed on hardware.
- [x] Connect/disconnect USB while running: picked up cleanly, no stuck state — confirmed on hardware.
- [ ] Connect to a host with a MIDI app holding the port open: confirm USB MIDI out still works normally (no false negative once a host is genuinely present).