### PR TITLE
fix: silence stuck gate in genseq and tb3po

### DIFF
--- a/faderpunk/src/apps/genseq.rs
+++ b/faderpunk/src/apps/genseq.rs
@@ -278,6 +278,20 @@ pub async fn run(
                     }
                     register_pitch = storage.query(|s| s.register_pitch);
                 }
+                ClockEvent::Stop => {
+                    // No phase reset (see ClockEvent::Stop docs) — just silence
+                    // whatever note/gate is currently held, including a legato
+                    // tie whose note-off would otherwise wait on a Tick that
+                    // will never come.
+                    if gate_on {
+                        gate_out.set_value(0);
+                        gate_on = false;
+                        midi.send_note_off(last_note_on.get()).await;
+                        leds.set(1, Led::Top, led_color, Brightness::Custom(0));
+                    }
+                    pending_note_off = false;
+                    aux_out.set_value(0);
+                }
                 ClockEvent::Tick => {
                     let clkn = ticks() as u32;
                     if clkn.is_multiple_of(div) {

--- a/faderpunk/src/apps/tb3po.rs
+++ b/faderpunk/src/apps/tb3po.rs
@@ -460,22 +460,37 @@ pub async fn run(
                     }
 
                     // Gate / MIDI
-                    if (is_gated || is_slid_prev) && !muted {
-                        accent_active_glob.set(is_accent);
+                    if is_gated || is_slid_prev {
+                        if muted {
+                            // Muted: don't sound a new note, but still resolve
+                            // any gate/note left open by a prior slide step —
+                            // the duty-cycle countdown above only turns the
+                            // gate off on non-slid steps, so this retrigger
+                            // point is otherwise the only place that off is
+                            // ever sent.
+                            if gate_active_glob.get() {
+                                gate_active_glob.set(false);
+                                gate_out.set_low().await;
+                                midi.send_note_off(last_midi_note_glob.get()).await;
+                                accent_out.set_value(0);
+                            }
+                        } else {
+                            accent_active_glob.set(is_accent);
 
-                        // Quantise for MIDI note (use target pitch for note identity)
-                        let out = quantizer.get_quantized_note(target_raw).await;
-                        let note = out.as_midi();
+                            // Quantise for MIDI note (use target pitch for note identity)
+                            let out = quantizer.get_quantized_note(target_raw).await;
+                            let note = out.as_midi();
 
-                        midi.send_note_off(last_midi_note_glob.get()).await;
-                        let velocity = if is_accent { 4095 } else { 2048 };
-                        midi.send_note_on(note, velocity).await;
-                        last_midi_note_glob.set(note);
+                            midi.send_note_off(last_midi_note_glob.get()).await;
+                            let velocity = if is_accent { 4095 } else { 2048 };
+                            midi.send_note_on(note, velocity).await;
+                            last_midi_note_glob.set(note);
 
-                        gate_out.set_high().await;
-                        gate_active_glob.set(true);
-                        accent_out.set_value(if is_accent { 4095 } else { 0 });
-                        gate_off_ticks_glob.set((div / 2).max(1));
+                            gate_out.set_high().await;
+                            gate_active_glob.set(true);
+                            accent_out.set_value(if is_accent { 4095 } else { 0 });
+                            gate_off_ticks_glob.set((div / 2).max(1));
+                        }
                     }
 
                     // Apply any pending pattern regeneration (density changed since last tick)


### PR DESCRIPTION
## Summary
- genseq: the clock task never handled `ClockEvent::Stop`, so a legato-held gate (or any gate mid-duty-cycle) stayed high forever once the clock stopped, since no further tick would arrive to resolve it.
- tb3po: the gate/MIDI retrigger block — the only place a slid note's off is ever sent — was skipped entirely while muted, so muting mid-slide left the gate/note stuck until an unmuted gated step eventually came around.

## Test plan
On hardware, for both GenSeq and TB-3PO:
- [ ] Start a pattern with legato/slide active, stop the clock mid-tie, confirm the gate (and MIDI note, if used) goes low/off immediately.
- [ ] Start a pattern with slide active, press mute mid-tie, confirm the gate/note goes low/off immediately instead of staying held.
- [ ] Confirm normal (non-slide) sequencing and mute/unmute behavior is unaffected.