### PR TITLE
fix: silence stuck gate in tb3po on mute during slide

### DIFF
--- a/faderpunk/src/apps/tb3po.rs
+++ b/faderpunk/src/apps/tb3po.rs
@@ -460,22 +460,37 @@ pub async fn run(
                     }
 
                     // Gate / MIDI
-                    if (is_gated || is_slid_prev) && !muted {
-                        accent_active_glob.set(is_accent);
+                    if is_gated || is_slid_prev {
+                        if muted {
+                            // Muted: don't sound a new note, but still resolve
+                            // any gate/note left open by a prior slide step —
+                            // the duty-cycle countdown above only turns the
+                            // gate off on non-slid steps, so this retrigger
+                            // point is otherwise the only place that off is
+                            // ever sent.
+                            if gate_active_glob.get() {
+                                gate_active_glob.set(false);
+                                gate_out.set_low().await;
+                                midi.send_note_off(last_midi_note_glob.get()).await;
+                                accent_out.set_value(0);
+                            }
+                        } else {
+                            accent_active_glob.set(is_accent);
 
-                        // Quantise for MIDI note (use target pitch for note identity)
-                        let out = quantizer.get_quantized_note(target_raw).await;
-                        let note = out.as_midi();
+                            // Quantise for MIDI note (use target pitch for note identity)
+                            let out = quantizer.get_quantized_note(target_raw).await;
+                            let note = out.as_midi();
 
-                        midi.send_note_off(last_midi_note_glob.get()).await;
-                        let velocity = if is_accent { 4095 } else { 2048 };
-                        midi.send_note_on(note, velocity).await;
-                        last_midi_note_glob.set(note);
+                            midi.send_note_off(last_midi_note_glob.get()).await;
+                            let velocity = if is_accent { 4095 } else { 2048 };
+                            midi.send_note_on(note, velocity).await;
+                            last_midi_note_glob.set(note);
 
-                        gate_out.set_high().await;
-                        gate_active_glob.set(true);
-                        accent_out.set_value(if is_accent { 4095 } else { 0 });
-                        gate_off_ticks_glob.set((div / 2).max(1));
+                            gate_out.set_high().await;
+                            gate_active_glob.set(true);
+                            accent_out.set_value(if is_accent { 4095 } else { 0 });
+                            gate_off_ticks_glob.set((div / 2).max(1));
+                        }
                     }
 
                     // Apply any pending pattern regeneration (density changed since last tick)


### PR DESCRIPTION
## Summary
The gate/MIDI retrigger block — the only place a slid note's off is ever sent — was skipped entirely while muted, so muting mid-slide left the gate/note stuck until an unmuted gated step eventually came around.

## Test plan
On hardware, for TB-3PO:
- [ ] Start a pattern with slide active, press mute mid-tie, confirm the gate/note goes low/off immediately instead of staying held.
- [ ] Confirm normal (non-slide) sequencing and mute/unmute behavior is unaffected.