### PR TITLE
feat: add CV Combine and Gate Combine apps

### DIFF
--- a/PR-474-REVIEW.md
+++ b/PR-474-REVIEW.md
@@ -1,0 +1,82 @@
+# PR 474 rebase — review notes
+
+Branch `feat/combine-rebased` (commit 4514a9b7) squashes and rebases
+[PR #474](https://github.com/ATOVproject/faderpunk/pull/474) ("Add CV Combine
+and Gate Combine apps", by rjsmith) onto current `origin/main`. That PR's
+original branch (`feature/combine`) had drifted far enough from `main` that a
+normal commit-by-commit rebase wasn't practical — see the conversation this
+file came from for the full account of what changed structurally during the
+rebase (new non-persisted `JackRegistry` in `state.rs`, `GATE_LEVELS` replacing
+the deleted `MAX_TRIGGERS_GPO`, etc).
+
+`/code-review` was run against this branch after the rebase. Findings below,
+none fixed yet.
+
+## Real logic bugs in the new apps (pre-existing in the original PR)
+
+1. **`gatecombine.rs:292`** — the probability gate re-rolls every 1ms instead
+   of once per rising edge. `old_out_gate_was_high` is set from the
+   *post*-probability output instead of the *pre*-probability combined
+   signal, so a failed die roll doesn't stick. For a 20ms gate at 50%
+   probability the effective pass rate is `1-(0.5)^20` ≈ 99.9999%, not 50%.
+   The app's main control is close to non-functional for realistic gate
+   lengths.
+
+2. **`cvcombine.rs:297`** — "A − B" combine mode subtracts an extra 4095.
+   `a_plus_5v - b_plus_5v - _10V` reduces to `a_in_v - b_in_v - 4095`, so a
+   subtraction that should land near the top of the range gets clamped to the
+   bottom instead. Copy-pasted from the Add mode's shift-cancellation trick,
+   which doesn't apply here.
+
+3. **`cvcombine.rs:298`** — "Max" combine mode has no single-channel special
+   case (unlike Min and Average). A single active bipolar channel reading
+   negative gets wrongly clamped to 0, because the disabled channel's forced
+   "0V" midpoint beats the real negative value in the comparison.
+
+4. **`cvcombine.rs:422`** (and duplicated at line 369) — fader-to-divisor
+   (1–12) mapping truncates instead of rounds, biasing low across most of the
+   fader's range. The documented "12 = semitones" setting is only reachable
+   at the exact top ADC reading instead of a normal top-of-travel band.
+
+## Gaps in the JackRegistry mechanism built during this rebase (mine to own)
+
+5. **Confirmed — param-only respawns don't clear the registry.**
+   `storage.rs:710-748`'s `param_handler` just `break`s its loop on a config
+   change, which respawns `run()` fresh but never goes through
+   `App::exit_handler`/`reset()` (only a full layout change triggers that).
+   Any app that changes jack *type* via a plain parameter toggle — e.g.
+   Turing's "Gate output" switch — leaves the old registry entry behind
+   alongside the new one. Structural, not specific to Turing.
+
+6. **`app.rs:808`** — `get_out_global_jack_value`'s doc comment claims
+   pointing it at a gate jack "will return 0," but `MAX_VALUES_DAC` is never
+   cleared on reset (only `GATE_LEVELS` and the registry are). A channel that
+   used to run a CV app and now runs something else returns whatever stale
+   voltage was last written there.
+
+7. **Low-severity** — `layout.rs`'s `exit_app` 10ms grace timer was already a
+   heuristic, not a real barrier, before this rebase. The new
+   `clear_jacks().await` call added to `reset()` rides on that same soft
+   deadline. Unlikely to bite in practice (uncontended mutex lock), but worth
+   naming.
+
+8. **Root cause of #5** — `JackRegistry` duplicates per-channel ownership
+   info that `LayoutManager` already tracks, via convention only (nothing
+   compiler-enforced ties a jack-type change to a registry update).
+
+## Lower priority / style
+
+9. `cvcombine.rs:244` — jack config sampled once at spawn, never refreshed;
+   could race cold-boot spawn order or go stale if the sampled app's Range
+   changes independently later.
+10. Mute/LED toggle logic duplicated 3-4x per file instead of factored out;
+    existing `Global<bool>::toggle()` helper goes unused.
+11. `get_out_jacks()`/etc. copy the full 16-entry array by value instead of
+    indexing under the lock — harmless at current call volumes.
+
+## Open question
+
+Items 1-4 are the contributor's own app logic — candidates to send back to
+rjsmith rather than fix here. Items 5-6 are gaps in this session's own
+rework and are probably worth fixing before this goes anywhere. Nothing here
+has been fixed yet as of commit 4514a9b7.

--- a/configurator/src/components/ManualTab.tsx
+++ b/configurator/src/components/ManualTab.tsx
@@ -1593,6 +1593,160 @@ On load, both registers are restored at the next phrase boundary so the recalled
       },
     ],
   },
+  {
+    appId: 44,
+    title: "CV Combine",
+    description:
+      "Precision CV adder / combiner / quantizer of two outputs from other apps",
+    color: "Yellow",
+    icon: "knob-round",
+    params: [
+      "Enable Jack A",
+      "Jack A #",
+      "Enable Jack B",
+      "Jack B #",
+      "Color",
+      "Quantise enable",
+      "Range",
+      "Combine Mode",
+    ],
+    storage: [
+      "Jack A Mute",
+      "Jack B Mute",
+      "Quantize",
+      "CV offset enabled",
+      "CV offset",
+      "CV Offset divisor",
+    ],
+    text: `
+Combines the output voltages of up to two other specified output jacks belonging to other apps in the same layout.  It simulates the behaviour of Eurorack precision adder / CV math modules.
+
+* Two selected CV output jacks are sampled every millisecond, combined, optionally quantised, optionally applied a voltage offset, then finally re-scales the output signal to the required output voltage range.
+* If the final voltage value exceed the min and max of the output Range, the summed CV will be hardclipped to the min or max of the Range.
+* The fader sets an CV offset which is applied to the combined CV output after the quantiser.
+* By default, the offset is an effective range of -5V to + 5V, in steps of 1V. So if you are combining two v/o pitch signals, this shifts the post-quantized signal from -5 to +5 octaves. The bottom LED shows the level of the offset, with the midpoint (off) representing zero offset, fully lit (blue) representing +5V, and fully lit (red) representing -5V.
+* Shift + Fader sets a divisor for the offset (in range 1 at the bottom to 12 at the top) so you can use fractions of a volt as an offset. When the divisor is 12, and the CV is used for V/o pitch, the offset is in units of semitones.
+* The offset can be toggled on and off by Shift + long-pressing the button.
+* This app does not emit any MIDI events
+
+#### CV Combine Modes
+
+The app has 5 modes for combining the CV from the two sampled jacks:
+1. **A + B**: Sums the CV from the two jacks together,
+2. **A - B**: Subtracts the CV of the second jack from the first,
+3. **Max**: Outputs the higher of the two CVs,
+4. **Min**: Outputs the lower of the two CVs,
+5. **Average**: Outputs the average of the two CVs (if both channels active)
+
+#### Tip: Steevio Sequencing
+Replicate the magic sequencing techniques of the modular musician, Steevio!:
+1. Set up a "Sequencer" 8-channel app with two note patterns with different lengths and tempo (e.g. 5 and 7 steps).
+2. Place an "CV Combine" app somewhere else on the layout, configuring its "A" and "B" Jack channels to the first two "CV Output" jacks of the Sequencer (channels 1 & 3 on the Sequencer).
+3. Set the Combine's output range to 0-10V, turn on Quantize output (to match the fixed 0-10V output range of the Sequencer app).
+4. Play with the CV offset to change the played octave
+5. Patch the CV Combine output CV to your favourite V/O oscillator
+ 
+#### Tip: Muting 
+Mute and unmute the CV Combine's "A" and "B" channels to bring in either pattern
+ 
+#### Tip: Combine Modes
+Try out the different Combine Modes for different variations in how the two patterns interact. 
+ 
+#### Tip: Octave and semitone shifting
+* Add some octave shifts (+5 to -5 octave offsets) by moving the bipolar offset fader (no offset in the middle of its range)
+* Hold Shift and experiment with different offset divisors. 
+* With a divisor of 12 (fader at top of its range), the offset is in semitones
+
+#### Tip: Mix LFOs and Control CVs
+Configure the CV Combine to mix an LFO and a Control app together, or two LFOs set to different frequencies, for more complex modulation patterns.  Disable the quantizer in this case to preserve the smoothness of the LFO signal.
+ 
+#### Tip: Scene Switching
+Save different scene settings for a CV Combine app with different offsets or channel mutes, then switch betwen them during a performance.  If you also change the scene settings of the upstream CV generating apps, you can get some really interesting switched melodies and modulation.
+
+#### Acknowledgements.
+
+* Created by Richard Smith (Discord: Phommed)
+    `,
+    channels: [
+      {
+        jackTitle: "CV Output",
+        jackDescription: "Combined, quantized, offset CV signal",
+        faderTitle: "CV offset",
+        faderDescription: "Applies bipolar CV offset after the quantizer",
+        faderPlusShiftTitle: "Offset Divisor",
+        faderPlusShiftDescription:
+          "Divides offset per volt, from 1 (octaves) to 12 (semitones)",
+        fnTitle: "Mute & offset",
+        fnDescription: "Short Mute A input- Long Toggle offset",
+        fnPlusShiftTitle: "Mute",
+        fnPlusShiftDescription: "Mute B input",
+        ledTop: "CV output level",
+        ledTopPlusShift: "Offset divisor (1-12)",
+        ledBottom: "Offset",
+      },
+    ],
+  },
+  {
+    appId: 45,
+    title: "Gate Combine",
+    description: "Binary logic combination of two gate signals from other apps",
+    color: "Yellow",
+    icon: "knob-round",
+    params: [
+      "Enable Jack A",
+      "Jack A #",
+      "Enable Jack B",
+      "Jack B #",
+      "Color",
+      "Combine Mode",
+    ],
+    storage: ["Jack A Mute", "Jack B Mute", "Gate probability"],
+    text: `
+Combines two output gates or triggers from other apps into a single combined gate signal, using binary logic.  The combined gate signal is then passed through a probabilistic gate that is controlled by the app's fader:
+* If the combined signal goes high, and the probablistic gate allows it through, the output gate will go high, and stay high until the combined signal goes low, 
+* else the output will be low.
+
+
+#### Combine Modes
+
+Gate Combine has different binary logic modes to generate a separate gate signal from two gate signals that generated by other apps in the same Faderpunk layout:
+1. **OR**: Gate output is high if either A or B are high
+2. **AND**: Gate output is high only if A and B are both high
+3. **XOR**: Gate output is high only if one of A or B are high (but not both at the same time)
+4. **NOR**: Gate output is high only if both A and B are low
+5. **NAND**: Gate output is low if both A and B are high
+6. **XNOR**: Gate output is high if either A & B are both low or both high
+
+#### Tip: Combine clock-quantized drum triggers
+Combine the output gate or trigger signals from two other app channels (e.g. "Euclid" and "Random Trigger") using one of the
+combine modes and patch the output gate to a drum voice or envelope trigger.  It's a great way of creating more rhythms from
+a smaller number of trigger sources.
+
+#### Tip: Inverted Gate
+Configure input channel's A & B to the same gate signal (e.g. from a Euclid app), then use the NAND or NOR combine mode to
+get an inverted version of the original gate signal at the output, which can be used to trigger different voices or functions
+at the opposite time of the original gate (e.g. trigger an envelope that controls a VCA with a Bass voice)
+
+#### Acknowledgements.
+
+* Created by Richard Smith (Discord: Phommed)
+    `,
+    channels: [
+      {
+        jackTitle: "Gate out",
+        jackDescription: "Combined gate output signal",
+        faderTitle: "Gate chance",
+        faderDescription:
+          "Chance of firing new gate after the combine logic (0 - 100%)",
+        fnTitle: "Mute A",
+        fnDescription: "Mute A input",
+        fnPlusShiftTitle: "Mute B",
+        fnPlusShiftDescription: "Mute B input",
+        ledTop: "Gate output",
+        ledBottom: "Chance",
+      },
+    ],
+  },
 ];
 
 export const ManualTab = () => {

--- a/faderpunk/src/app.rs
+++ b/faderpunk/src/app.rs
@@ -9,18 +9,22 @@ use max11300::config::{
     NSAMPLES,
 };
 use midly::{live::LiveEvent, num::u4, MidiMessage, PitchBend};
-use portable_atomic::Ordering;
+use portable_atomic::{AtomicBool, Ordering};
 
 use libfp::{
     latch::AnalogLatch,
     quantizer::{Pitch, QuantizerState},
     utils::{scale_bits_12_7, scale_bits_14_12},
     Brightness, ClockDivision, Color, Key, MidiCc, MidiChannel, MidiIn, MidiNote, MidiOut, Note,
-    Range, TakeoverMode, VoltPerOct,
+    Range, TakeoverMode, VoltPerOct, GLOBAL_CHANNELS,
 };
 
 use crate::{
     events::{EventPubSubChannel, InputEvent},
+    state::{
+        clear_jacks, get_gate_jacks, get_in_jacks, get_out_jacks, register_gate_jack,
+        register_in_jack, register_out_jack,
+    },
     tasks::{
         buttons::{is_channel_button_pressed, is_shift_button_pressed},
         clock::{ClockSubscriber, CLOCK_PUBSUB, TICK_COUNTER},
@@ -86,9 +90,16 @@ impl<const N: usize> Leds<N> {
     }
 }
 
+/// Last level each channel's `GateJack` was set to. App-facing counterpart to
+/// `MAX_VALUES_DAC`: read by other apps (e.g. Gate Combine) to sample a gate
+/// jack's current output without a round trip through the MAX task.
+static GATE_LEVELS: [AtomicBool; GLOBAL_CHANNELS] =
+    [const { AtomicBool::new(false) }; GLOBAL_CHANNELS];
+
+#[derive(Clone, Copy)]
 pub struct InJack {
-    channel: usize,
-    range: Range,
+    pub channel: usize,
+    pub range: Range,
 }
 
 impl InJack {
@@ -105,8 +116,9 @@ impl InJack {
     }
 }
 
+#[derive(Clone, Copy)]
 pub struct GateJack {
-    channel: usize,
+    pub channel: usize,
 }
 
 impl GateJack {
@@ -115,19 +127,22 @@ impl GateJack {
     }
 
     pub async fn set_high(&self) {
+        GATE_LEVELS[self.channel].store(true, Ordering::Relaxed);
         let port = Port::try_from(self.channel).unwrap();
         MAX_CHANNEL.sender().send(MaxCmd::GpoSetHigh { port }).await;
     }
 
     pub async fn set_low(&self) {
+        GATE_LEVELS[self.channel].store(false, Ordering::Relaxed);
         let port = Port::try_from(self.channel).unwrap();
         MAX_CHANNEL.sender().send(MaxCmd::GpoSetLow { port }).await;
     }
 }
 
+#[derive(Clone, Copy)]
 pub struct OutJack {
-    channel: usize,
-    range: Range,
+    pub channel: usize,
+    pub range: Range,
 }
 
 impl OutJack {
@@ -754,7 +769,10 @@ impl<const N: usize> App<N> {
         )
         .await;
 
-        InJack::new(self.start_channel + chan, range)
+        let global_chan = self.start_channel + chan;
+        let jack = InJack::new(global_chan, range);
+        register_in_jack(global_chan, jack).await;
+        jack
     }
 
     pub async fn make_out_jack(&self, chan: usize, range: Range) -> OutJack {
@@ -766,7 +784,10 @@ impl<const N: usize> App<N> {
         self.reconfigure_jack(chan, Mode::Mode5(ConfigMode5(dac_range)), None)
             .await;
 
-        OutJack::new(self.start_channel + chan, range)
+        let global_chan = self.start_channel + chan;
+        let jack = OutJack::new(global_chan, range);
+        register_out_jack(global_chan, jack).await;
+        jack
     }
 
     pub async fn make_gate_jack(&self, chan: usize, level: u16) -> GateJack {
@@ -774,7 +795,53 @@ impl<const N: usize> App<N> {
         self.reconfigure_jack(chan, Mode::Mode3(ConfigMode3), Some(level))
             .await;
 
-        GateJack::new(self.start_channel + chan)
+        let global_chan = self.start_channel + chan;
+        let jack = GateJack::new(global_chan);
+        register_gate_jack(global_chan, jack).await;
+        jack
+    }
+
+    /// Obtain current output value from any CV jack global channel, 0-based (not an app-specific channel)
+    /// If output jack voltage range is 0-10V or -5 to +5V, return value is in range 0-4095
+    /// If output jack voltage range in 0-5V, return value is in range 0-2047
+    ///
+    /// If you point this at a gate out jack by mistake, it will return 0.
+    ///
+    pub fn get_out_global_jack_value(global_chan: usize) -> u16 {
+        let chan = global_chan.clamp(0, GLOBAL_CHANNELS - 1);
+        MAX_VALUES_DAC[chan].load(Ordering::Relaxed)
+    }
+
+    /// Obtain current gate value from any Gate Jack global channel, 0-based (not an app-specific channel).
+    /// If gate is hi, will return true
+    /// If gate is lo, will return false
+    pub fn get_out_global_gate_jack_is_high(global_chan: usize) -> bool {
+        let chan = global_chan.clamp(0, GLOBAL_CHANNELS - 1);
+        GATE_LEVELS[chan].load(Ordering::Relaxed)
+    }
+
+    /// Gets a possible copy of the stored config of a given global CV output jack channel, if any
+    #[allow(unused)]
+    pub async fn get_out_jack_config(global_chan: usize) -> Option<OutJack> {
+        let chan = global_chan.clamp(0, GLOBAL_CHANNELS - 1);
+        let jacks = get_out_jacks().await;
+        jacks[chan]
+    }
+
+    /// Gets a possible copy of the stored config of a given global Gate output jack channel, if any
+    #[allow(unused)]
+    pub async fn get_gate_jack_config(global_chan: usize) -> Option<GateJack> {
+        let chan = global_chan.clamp(0, GLOBAL_CHANNELS - 1);
+        let jacks = get_gate_jacks().await;
+        jacks[chan]
+    }
+
+    /// Gets a possible copy of the stored config of a given global Gate input jack channel, if any
+    #[allow(unused)]
+    pub async fn get_in_jack_config(global_chan: usize) -> Option<InJack> {
+        let chan = global_chan.clamp(0, GLOBAL_CHANNELS - 1);
+        let jacks = get_in_jacks().await;
+        jacks[chan]
     }
 
     pub async fn delay_millis(&self, millis: u64) {
@@ -860,6 +927,9 @@ impl<const N: usize> App<N> {
         for chan in 0..N {
             self.reconfigure_jack(chan, Mode::Mode0(ConfigMode0), None)
                 .await;
+            let global_chan = self.start_channel + chan;
+            GATE_LEVELS[global_chan].store(false, Ordering::Relaxed);
+            clear_jacks(global_chan).await;
         }
     }
 

--- a/faderpunk/src/apps/cvcombine.rs
+++ b/faderpunk/src/apps/cvcombine.rs
@@ -1,0 +1,523 @@
+//! # CV Combine app
+//!
+//! Precision CV adder / combiner / quantizer of one or two other output variable CV jacks belonging to other apps
+//!
+//! This app is able to sum the output voltages of up to two other specified output jacks belonging to other apps in the same layout.
+//! It simulates the behaviour of Eurorack precision adder / CV math modules.
+//!
+//! Created by Richard Smith (@phommed on Faderpunk Discord) in February 2026.
+//!
+use embassy_futures::{
+    join::join5,
+    select::{select, select3},
+};
+use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
+use heapless::Vec;
+use libfp::{
+    ext::FromValue, latch::LatchLayer, AppIcon, Brightness, Color, Config, Param, Range, Value,
+    VoltPerOct, APP_MAX_PARAMS, GLOBAL_CHANNELS,
+};
+
+use libm::roundf;
+use serde::{Deserialize, Serialize};
+
+use crate::app::{App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
+
+pub const CHANNELS: usize = 1;
+pub const PARAMS: usize = 8;
+
+const _5V: i16 = 2047;
+const _10V: i16 = 4095;
+const V_PER_OCTAVE: f32 = 409.5;
+
+// App configuration visible to the configurator
+pub static CONFIG: Config<PARAMS> = Config::new(
+    "CV Combine",
+    "Adds two CV outputs from other channels, with octave offset and optional global quantization",
+    Color::Yellow,
+    AppIcon::KnobRound,
+)
+.add_param(Param::bool {
+    name: "Enable Jack A",
+})
+.add_param(Param::i32 {
+    name: "Jack A #",
+    min: 1,
+    max: 16,
+})
+.add_param(Param::bool {
+    name: "Enable Jack B",
+})
+.add_param(Param::i32 {
+    name: "Jack B #",
+    min: 1,
+    max: 16,
+})
+.add_param(Param::Color {
+    name: "Color",
+    variants: &[
+        Color::Blue,
+        Color::Green,
+        Color::Rose,
+        Color::Orange,
+        Color::Cyan,
+        Color::Pink,
+        Color::Violet,
+        Color::Yellow,
+    ],
+})
+.add_param(Param::Range {
+    name: "Range",
+    variants: &[Range::_0_10V, Range::_0_5V, Range::_Neg5_5V],
+})
+.add_param(Param::bool {
+    name: "Quantize output",
+})
+.add_param(Param::Enum {
+    name: "Combine Mode",
+    variants: &["A+B", "A-B", "Max", "Min", "Average"],
+});
+
+pub struct Params {
+    // Will be added if = true
+    channel_a_enabled: bool,
+    // Output jack number 1 - GLOBAL_CHANNELS to be sampled
+    channel_a_jack_num: i32,
+    // Will be added if = true
+    channel_b_enabled: bool,
+    // Output jack number 1 - GLOBAL_CHANNELS to be sampled
+    channel_b_jack_num: i32,
+    // LED colour
+    color: Color,
+    // Output CV range
+    range: Range,
+    // Quantize output = true
+    quantize: bool,
+    // Output combination mode
+    combine_mode: usize,
+}
+
+impl Default for Params {
+    fn default() -> Self {
+        Self {
+            channel_a_enabled: false,
+            channel_a_jack_num: 1,
+            channel_b_enabled: false,
+            channel_b_jack_num: 1,
+            color: Color::Yellow,
+            range: Range::_0_10V,
+            quantize: false,
+            combine_mode: 0, // A + B
+        }
+    }
+}
+
+impl AppParams for Params {
+    fn from_values(values: &[Value]) -> Option<Self> {
+        if values.len() < PARAMS {
+            return None;
+        }
+        Some(Self {
+            channel_a_enabled: bool::from_value(values[0]),
+            channel_a_jack_num: i32::from_value(values[1]),
+            channel_b_enabled: bool::from_value(values[2]),
+            channel_b_jack_num: i32::from_value(values[3]),
+            color: Color::from_value(values[4]),
+            range: Range::from_value(values[5]),
+            quantize: bool::from_value(values[6]),
+            combine_mode: usize::from_value(values[7]),
+        })
+    }
+
+    fn to_values(&self) -> Vec<Value, APP_MAX_PARAMS> {
+        let mut vec = Vec::new();
+        vec.push(self.channel_a_enabled.into()).unwrap();
+        vec.push(self.channel_a_jack_num.into()).unwrap();
+        vec.push(self.channel_b_enabled.into()).unwrap();
+        vec.push(self.channel_b_jack_num.into()).unwrap();
+        vec.push(self.color.into()).unwrap();
+        vec.push(self.range.into()).unwrap();
+        vec.push(self.quantize.into()).unwrap();
+        vec.push(self.combine_mode.into()).unwrap();
+        vec
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Storage {
+    channel_a_mute_saved: bool,
+    channel_b_mute_saved: bool,
+    offset_enabled_saved: bool,
+    offset_voltage_saved: u16,
+    offset_divisor_saved: u16,
+}
+
+impl Default for Storage {
+    fn default() -> Self {
+        Self {
+            channel_a_mute_saved: false,
+            channel_b_mute_saved: false,
+            offset_enabled_saved: true,
+            offset_voltage_saved: 0,
+            offset_divisor_saved: 0,
+        }
+    }
+}
+
+impl AppStorage for Storage {}
+
+// Wrapper task - required for all apps
+#[embassy_executor::task(pool_size = 16/CHANNELS)]
+pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMutex, bool>) {
+    let param_store = ParamStore::<Params>::new(app.app_id, app.layout_id, Params::default());
+    let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
+
+    param_store.load().await;
+    storage.load().await;
+
+    let app_loop = async {
+        loop {
+            select3(
+                run(&app, &param_store, &storage),
+                param_store.param_handler(),
+                storage.saver_task(),
+            )
+            .await;
+        }
+    };
+
+    select(app_loop, app.exit_handler(exit_signal)).await;
+}
+
+// Main app logic
+pub async fn run(
+    app: &App<CHANNELS>,
+    params: &ParamStore<Params>,
+    storage: &ManagedStorage<Storage>,
+) {
+    // first_channel and second_channel params are converted to usize in range 0 - (GLOBAL_CHANNELS-1)
+    let (
+        channel_a_enabled,
+        channel_a_jack_num,
+        channel_b_enabled,
+        channel_b_jack_num,
+        led_color,
+        range,
+        quantize,
+        combine_mode,
+    ) = params.query(|p| {
+        (
+            p.channel_a_enabled,
+            p.channel_a_jack_num,
+            p.channel_b_enabled,
+            p.channel_b_jack_num,
+            p.color,
+            p.range,
+            p.quantize,
+            p.combine_mode,
+        )
+    });
+
+    let channel_a_safe = (channel_a_jack_num.clamp(1, GLOBAL_CHANNELS as i32) - 1) as usize;
+    let channel_b_safe = (channel_b_jack_num.clamp(1, GLOBAL_CHANNELS as i32) - 1) as usize;
+
+    let output = app.make_out_jack(0, range).await;
+    let fader = app.use_faders();
+    let buttons = app.use_buttons();
+    let leds = app.use_leds();
+
+    let quantizer = app.use_quantizer(range, VoltPerOct::Standard, false);
+    let channel_a_mute_glob = app.make_global(storage.query(|s| s.channel_a_mute_saved));
+    let channel_b_mute_glob = app.make_global(storage.query(|s| s.channel_b_mute_saved));
+    let glob_latch_layer = app.make_global(LatchLayer::Main);
+
+    // Set up initial state of LED button
+    if channel_a_mute_glob.get() {
+        leds.unset(0, Led::Button);
+    } else {
+        leds.set(0, Led::Button, led_color, Brightness::Mid);
+    }
+
+    let main_fut = async {
+        // Get output jack config to find the configured output CV Range
+        // Assume app config changes will re-spawn this app and re-execute this code.
+        let a_jack_config = if channel_a_enabled {
+            App::<CHANNELS>::get_out_jack_config(channel_a_safe).await
+        } else {
+            None
+        };
+        let b_jack_config = if channel_b_enabled {
+            App::<CHANNELS>::get_out_jack_config(channel_b_safe).await
+        } else {
+            None
+        };
+
+        loop {
+            app.delay_millis(1).await;
+
+            let channel_a_active = channel_a_enabled && !channel_a_mute_glob.get();
+            let channel_b_active = channel_b_enabled && !channel_b_mute_glob.get();
+
+            // Prevent feedback loops by disabling the possibility to sample from the same channel that the app is outputting on
+            let channel_a_use = channel_a_active && app.start_channel != channel_a_safe;
+            let channel_b_use = channel_b_active && app.start_channel != channel_b_safe;
+
+            // Get sampled jack values and transform to voltage values according to their individual configured CV Range.
+            // If channel not active, treat as zero. If jack config not found (e.g. app unplugged), also treat as zero.
+            let a_in_v: i16 = if channel_a_use {
+                match a_jack_config {
+                    Some(config) => {
+                        let raw = App::<CHANNELS>::get_out_global_jack_value(channel_a_safe);
+                        config.range.jack_value_to_voltage_value(raw)
+                    }
+                    None => 0,
+                }
+            } else {
+                0
+            };
+            let b_in_v: i16 = if channel_b_use {
+                match b_jack_config {
+                    Some(config) => {
+                        let raw = App::<CHANNELS>::get_out_global_jack_value(channel_b_safe);
+                        config.range.jack_value_to_voltage_value(raw)
+                    }
+                    None => 0,
+                }
+            } else {
+                0
+            };
+            let a_plus_5v = a_in_v + _5V;
+            let b_plus_5v = b_in_v + _5V;
+
+            let mut out_v: i16 = if combine_mode == 0 {
+                // Add
+                a_plus_5v + b_plus_5v - _10V
+            } else if combine_mode == 1 {
+                // Subtract
+                a_plus_5v - b_plus_5v - _10V
+            } else if combine_mode == 2 {
+                // Max
+                if a_plus_5v > b_plus_5v {
+                    a_in_v
+                } else {
+                    b_in_v
+                }
+            } else if combine_mode == 3 {
+                // Min
+                if channel_a_use && channel_b_use {
+                    if a_plus_5v < b_plus_5v {
+                        a_in_v
+                    } else {
+                        b_in_v
+                    }
+                } else if channel_a_use && !channel_b_use {
+                    a_in_v
+                } else if !channel_a_use && channel_b_use {
+                    b_in_v
+                } else {
+                    0
+                }
+            } else if combine_mode == 4 {
+                // Average
+                // If both channels active, output their average, else either a or b only
+                if channel_a_use && channel_b_use {
+                    ((a_plus_5v + b_plus_5v) / 2) - _5V
+                } else if channel_a_use && !channel_b_use {
+                    a_in_v
+                } else {
+                    b_in_v
+                }
+            } else {
+                0
+            };
+
+            // Optionally add additional octave or divided semitone offset
+            let (offset_enabled, offset_voltage_saved, offset_divisor_saved) = storage.query(|s| {
+                (
+                    s.offset_enabled_saved,
+                    s.offset_voltage_saved,
+                    s.offset_divisor_saved,
+                )
+            });
+            let mut offset_v = 0;
+            let mut offset_divisor = 1;
+            if offset_enabled {
+                offset_divisor = if offset_divisor_saved > 0 {
+                    offset_divisor_saved
+                } else {
+                    1
+                };
+                offset_v = calculate_offset_voltage(offset_voltage_saved, offset_divisor);
+                out_v += offset_v;
+            }
+
+            // Update bottom LED to either show offset or divisor level
+            match glob_latch_layer.get() {
+                LatchLayer::Main => {
+                    if offset_enabled && offset_v > 0 {
+                        let pos: u8 = (offset_v / 8).clamp(0, 255) as u8;
+                        leds.set(0, Led::Bottom, Color::Blue, Brightness::Custom(pos));
+                    } else if offset_enabled && offset_v < 0 {
+                        let neg = ((offset_v.abs()) / 8).clamp(0, 255) as u8;
+                        leds.set(0, Led::Bottom, Color::Rose, Brightness::Custom(neg));
+                    } else {
+                        leds.unset(0, Led::Bottom);
+                    }
+                }
+                LatchLayer::Alt => {
+                    let divisor: u8 =
+                        (((11.0 / 4095.0) * offset_divisor as f32) as i16 + 1).clamp(1, 12) as u8;
+                    leds.set(
+                        0,
+                        Led::Bottom,
+                        Color::Green,
+                        Brightness::Custom(21 * divisor),
+                    ); // 255/12 is approx 21
+                }
+                _ => {}
+            };
+
+            // Clamp to output voltage range, negative voltages clamped to 0V if output range does not support negative voltages
+            out_v = out_v.clamp(-_5V, _10V);
+            let out_safe = match range {
+                Range::_0_10V => out_v.clamp(0, _10V) as u16,
+                Range::_0_5V => out_v.clamp(0, _5V) as u16 * 2,
+                Range::_Neg5_5V => (out_v.clamp(-_5V, _5V) + _5V) as u16,
+            };
+
+            // Optionally quantize output CV to global quantizer scale
+            let out: u16 = if quantize {
+                let out_pitch = quantizer.get_quantized_note(out_safe).await;
+                out_pitch.as_counts(range, VoltPerOct::Standard)
+            } else {
+                out_safe
+            };
+
+            output.set_value(out);
+            leds.set(0, Led::Top, led_color, Brightness::Custom((out / 16) as u8));
+
+            // Change state of button when shift is pressed or released to show correct active state of channels A & B
+            glob_latch_layer.set(LatchLayer::from(buttons.is_shift_pressed()));
+            if !buttons.is_shift_pressed() {
+                let muted = storage.query(|s| s.channel_a_mute_saved);
+                if muted {
+                    leds.unset(0, Led::Button);
+                } else {
+                    leds.set(0, Led::Button, led_color, Brightness::Mid);
+                }
+            } else {
+                let muted = storage.query(|s| s.channel_b_mute_saved);
+                if muted {
+                    leds.unset(0, Led::Button);
+                } else {
+                    leds.set(0, Led::Button, led_color, Brightness::Mid);
+                }
+            }
+        }
+    };
+
+    // Returns offset voltage in range -2047 to  + 2047 (ie. -5V to +5V)
+    fn calculate_offset_voltage(offset_voltage_saved: u16, offset_divisor: u16) -> i16 {
+        // Map divisor saved value to 1 - 12
+        let divisor: i16 = (((11.0 / 4095.0) * offset_divisor as f32) as i16 + 1).clamp(1, 12);
+        let offset = (offset_voltage_saved as f32 / 409.5) - 5.0; // in range -5.0 to +5.0V (-2047 to + 2047)
+        if divisor == 1 {
+            (roundf(offset) * V_PER_OCTAVE) as i16 // whole volt (ie. octave) steps
+        } else {
+            // Continuous offset, quantized by divisor
+            roundf(offset * V_PER_OCTAVE) as i16 / divisor
+        }
+    }
+
+    let faders_fut = async {
+        let mut latch = app.make_latch(fader.get_value());
+        loop {
+            fader.wait_for_change().await;
+
+            let latch_layer = glob_latch_layer.get();
+
+            let target_value = match latch_layer {
+                LatchLayer::Main => storage.query(|s| s.offset_voltage_saved),
+                LatchLayer::Alt => storage.query(|s| s.offset_divisor_saved),
+                LatchLayer::Third => 0,
+            };
+
+            if let Some(new_value) = latch.update(fader.get_value(), latch_layer, target_value) {
+                match latch_layer {
+                    LatchLayer::Main => {
+                        storage.modify_and_save(|s| s.offset_voltage_saved = new_value);
+                    }
+                    LatchLayer::Alt => {
+                        storage.modify_and_save(|s| s.offset_divisor_saved = new_value);
+                    }
+                    LatchLayer::Third => (),
+                }
+            }
+        }
+    };
+
+    let btn_fut = async {
+        loop {
+            buttons.wait_for_down(0).await;
+            if !buttons.is_shift_pressed() {
+                // First channel mute
+                let muted = storage.modify_and_save(|s| {
+                    s.channel_a_mute_saved = !s.channel_a_mute_saved;
+                    s.channel_a_mute_saved
+                });
+                channel_a_mute_glob.set(muted);
+                if muted {
+                    leds.unset(0, Led::Button);
+                } else {
+                    leds.set(0, Led::Button, led_color, Brightness::Mid);
+                }
+            } else {
+                // Second channel mute
+                let muted = storage.modify_and_save(|s| {
+                    s.channel_b_mute_saved = !s.channel_b_mute_saved;
+                    s.channel_b_mute_saved
+                });
+                channel_b_mute_glob.set(muted);
+                if muted {
+                    leds.unset(0, Led::Button);
+                } else {
+                    leds.set(0, Led::Button, led_color, Brightness::Mid);
+                }
+            }
+        }
+    };
+
+    let long_press_fut = async {
+        //long press
+
+        loop {
+            let (_, is_shift_pressed) = buttons.wait_for_any_long_press().await;
+
+            if !is_shift_pressed {
+                // Toggle offset on/off
+                storage.modify_and_save(|s| {
+                    s.offset_enabled_saved = !s.offset_enabled_saved;
+                    s.offset_enabled_saved
+                });
+            }
+        }
+    };
+
+    let scene_handler = async {
+        loop {
+            match app.wait_for_scene_event().await {
+                SceneEvent::LoadScene(scene) => {
+                    storage.load_from_scene(scene).await;
+                    channel_a_mute_glob.set(storage.query(|s| s.channel_a_mute_saved));
+                    channel_b_mute_glob.set(storage.query(|s| s.channel_b_mute_saved));
+                }
+
+                SceneEvent::SaveScene(scene) => {
+                    storage.save_to_scene(scene).await;
+                }
+            }
+        }
+    };
+
+    join5(main_fut, faders_fut, btn_fut, long_press_fut, scene_handler).await;
+}

--- a/faderpunk/src/apps/gatecombine.rs
+++ b/faderpunk/src/apps/gatecombine.rs
@@ -1,0 +1,433 @@
+//! # Gate Combine app
+//!
+//! Combines two other output gates or triggers from other apps into a single combined gate signal, using binary logic.
+//! The combined gate signal is then passed through a probabilistic gate that is controlled by the app's fader.
+//! If the combined signal goes high, and the probablistic gate allows it through, the output gate will go high,
+//! and stay high until the combined signal goes low, else the output will be low.
+//!
+//! Created by Richard Smith (@phommed on Faderpunk Discord) in February 2026.
+//!
+use embassy_futures::{
+    join::join5,
+    select::{select, select3},
+};
+use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
+use heapless::Vec;
+use libfp::{
+    ext::FromValue, latch::LatchLayer, AppIcon, Brightness, Color, Config, Param, Value,
+    APP_MAX_PARAMS, GLOBAL_CHANNELS,
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::app::{App, AppParams, AppStorage, Led, ManagedStorage, ParamStore, SceneEvent};
+
+pub const CHANNELS: usize = 1;
+pub const PARAMS: usize = 6;
+
+const LED_BRIGHTNESS: Brightness = Brightness::High;
+
+// Sampled input gate jack changed state must remain the same state for given number of milliseconds to change Gate Combine output
+// Intention is to smooth out micro-timing differences between sampled output gates, or when chaining successive Gate Combine apps
+const LATCHED_GATE_CHANGE_MILLIS: u32 = 3;
+
+// App configuration visible to the configurator
+pub static CONFIG: Config<PARAMS> = Config::new(
+    "Gate Combine",
+    "Adds two gate or trigger outputs from other channels together using binary logic",
+    Color::SkyBlue,
+    AppIcon::KnobRound,
+)
+.add_param(Param::bool {
+    name: "Enable Channel A",
+})
+.add_param(Param::i32 {
+    name: "Channel A Jack",
+    min: 1,
+    max: 16,
+})
+.add_param(Param::bool {
+    name: "Enable Channel B",
+})
+.add_param(Param::i32 {
+    name: "Channel B Jack",
+    min: 1,
+    max: 16,
+})
+.add_param(Param::Color {
+    name: "Color",
+    variants: &[
+        Color::Blue,
+        Color::Green,
+        Color::Rose,
+        Color::Orange,
+        Color::Cyan,
+        Color::Pink,
+        Color::Violet,
+        Color::Yellow,
+    ],
+})
+.add_param(Param::Enum {
+    name: "Combine Mode",
+    variants: &["OR", "AND", "XOR", "NOR", "NAND", "XNOR"],
+});
+
+pub struct Params {
+    // Will be added if = true
+    channel_a_enabled: bool,
+    // Output jack number 1 - GLOBAL_CHANNELS to be sampled
+    channel_a_gate_jack_num: i32,
+    // Will be added if = true
+    channel_b_enabled: bool,
+    // Output jack number 1 - GLOBAL_CHANNELS to be sampled
+    channel_b_gate_jack_num: i32,
+    // LED colour
+    color: Color,
+    // Output combination mode
+    combine_mode: usize,
+}
+
+impl Default for Params {
+    fn default() -> Self {
+        Self {
+            channel_a_enabled: false,
+            channel_a_gate_jack_num: 1,
+            channel_b_enabled: false,
+            channel_b_gate_jack_num: 1,
+            color: Color::Yellow,
+            combine_mode: 0, // OR
+        }
+    }
+}
+
+impl AppParams for Params {
+    fn from_values(values: &[Value]) -> Option<Self> {
+        if values.len() < PARAMS {
+            return None;
+        }
+        Some(Self {
+            channel_a_enabled: bool::from_value(values[0]),
+            channel_a_gate_jack_num: i32::from_value(values[1]),
+            channel_b_enabled: bool::from_value(values[2]),
+            channel_b_gate_jack_num: i32::from_value(values[3]),
+            color: Color::from_value(values[4]),
+            combine_mode: usize::from_value(values[5]),
+        })
+    }
+
+    fn to_values(&self) -> Vec<Value, APP_MAX_PARAMS> {
+        let mut vec = Vec::new();
+        vec.push(self.channel_a_enabled.into()).unwrap();
+        vec.push(self.channel_a_gate_jack_num.into()).unwrap();
+        vec.push(self.channel_b_enabled.into()).unwrap();
+        vec.push(self.channel_b_gate_jack_num.into()).unwrap();
+        vec.push(self.color.into()).unwrap();
+        vec.push(self.combine_mode.into()).unwrap();
+        vec
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Storage {
+    channel_a_mute_saved: bool,
+    channel_b_mute_saved: bool,
+    prob_saved: u16,
+}
+impl Default for Storage {
+    fn default() -> Self {
+        Self {
+            channel_a_mute_saved: false,
+            channel_b_mute_saved: false,
+            prob_saved: 4096,
+        }
+    }
+}
+
+impl AppStorage for Storage {}
+
+// Wrapper task - required for all apps
+#[embassy_executor::task(pool_size = 16/CHANNELS)]
+pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMutex, bool>) {
+    let param_store = ParamStore::<Params>::new(app.app_id, app.layout_id, Params::default());
+    let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
+
+    param_store.load().await;
+    storage.load().await;
+
+    let app_loop = async {
+        loop {
+            select3(
+                run(&app, &param_store, &storage),
+                param_store.param_handler(),
+                storage.saver_task(),
+            )
+            .await;
+        }
+    };
+
+    select(app_loop, app.exit_handler(exit_signal)).await;
+}
+
+// Main app logic
+pub async fn run(
+    app: &App<CHANNELS>,
+    params: &ParamStore<Params>,
+    storage: &ManagedStorage<Storage>,
+) {
+    // first_channel and second_channel params are converted to usize in range 0 - (GLOBAL_CHANNELS-1)
+    let (
+        channel_a_enabled,
+        channel_a_gate_jack_num,
+        channel_b_enabled,
+        channel_b_gate_jack_num,
+        led_color,
+        combine_mode,
+    ) = params.query(|p| {
+        (
+            p.channel_a_enabled,
+            p.channel_a_gate_jack_num,
+            p.channel_b_enabled,
+            p.channel_b_gate_jack_num,
+            p.color,
+            p.combine_mode,
+        )
+    });
+
+    let channel_a_safe = (channel_a_gate_jack_num.clamp(1, GLOBAL_CHANNELS as i32) - 1) as usize;
+    let channel_b_safe = (channel_b_gate_jack_num.clamp(1, GLOBAL_CHANNELS as i32) - 1) as usize;
+
+    let output = app.make_gate_jack(0, 4095).await;
+    let fader = app.use_faders();
+    let buttons = app.use_buttons();
+    let leds = app.use_leds();
+    let die = app.use_die();
+
+    let channel_a_mute_glob = app.make_global(storage.query(|s| s.channel_a_mute_saved));
+    let channel_b_mute_glob = app.make_global(storage.query(|s| s.channel_b_mute_saved));
+    let glob_latch_layer = app.make_global(LatchLayer::Main);
+
+    // Set up initial state of LED button
+    if channel_a_mute_glob.get() {
+        leds.unset(0, Led::Button);
+    } else {
+        leds.set(0, Led::Button, led_color, Brightness::Mid);
+    }
+
+    let mut old_out_gate_was_high = false;
+
+    let main_fut = async {
+        let mut gate_a_unchanged_counter = 0u32;
+        let mut gate_b_unchanged_counter = 0u32;
+        let mut last_gate_a_is_high = false;
+        let mut last_gate_b_is_high = false;
+        let mut latched_gate_a_is_high = false;
+        let mut latched_gate_b_is_high = false;
+
+        loop {
+            app.delay_millis(1).await;
+
+            latched_gate_change(
+                channel_a_safe,
+                &mut gate_a_unchanged_counter,
+                &mut last_gate_a_is_high,
+                &mut latched_gate_a_is_high,
+            );
+            latched_gate_change(
+                channel_b_safe,
+                &mut gate_b_unchanged_counter,
+                &mut last_gate_b_is_high,
+                &mut latched_gate_b_is_high,
+            );
+
+            let channel_a_active = channel_a_enabled && !channel_a_mute_glob.get();
+            let channel_b_active = channel_b_enabled && !channel_b_mute_glob.get();
+            let channel_a_use = channel_a_active && app.start_channel != channel_a_safe;
+            let channel_b_use = channel_b_active && app.start_channel != channel_b_safe;
+            let a_is_high = if channel_a_use {
+                latched_gate_a_is_high
+            } else {
+                false
+            };
+            let b_is_high = if channel_b_use {
+                latched_gate_b_is_high
+            } else {
+                false
+            };
+            let mut out_is_high: bool = if combine_mode == 0 {
+                // OR
+                a_is_high | b_is_high
+            } else if combine_mode == 1 {
+                // AND
+                a_is_high & b_is_high
+            } else if combine_mode == 2 {
+                // XOR
+                a_is_high ^ b_is_high
+            } else if combine_mode == 3 {
+                // NOR
+                !(a_is_high | b_is_high)
+            } else if combine_mode == 4 {
+                // NAND
+                !(a_is_high & b_is_high)
+            } else if combine_mode == 5 {
+                // XNOR
+                !(a_is_high ^ b_is_high)
+            } else {
+                false
+            };
+
+            // Apply probabilistic gate
+
+            let prob = storage.query(|s| s.prob_saved); // Get gate probability from fader 0 - 4095
+            if out_is_high && !old_out_gate_was_high {
+                // Combined output has just gone high.
+
+                let rand_val = die.roll();
+                // The higher the probability fader, more chance there is of gate pasing through
+                if rand_val >= prob {
+                    // bad luck, gate must stay low this time
+                    out_is_high = false;
+                }
+            }
+
+            old_out_gate_was_high = out_is_high;
+
+            if out_is_high {
+                output.set_high().await;
+                leds.set(0, Led::Top, led_color, LED_BRIGHTNESS);
+            } else {
+                output.set_low().await;
+                leds.unset(0, Led::Top);
+            }
+
+            // Update bottom LED to show trigger probability when on main latch layer
+            match glob_latch_layer.get() {
+                LatchLayer::Main => {
+                    let pos: u8 = (prob / 8).clamp(0, 255) as u8;
+                    leds.set(0, Led::Bottom, Color::Blue, Brightness::Custom(pos));
+                }
+                _ => {
+                    leds.unset(0, Led::Bottom);
+                }
+            };
+        }
+    };
+
+    let fader_fut = async {
+        let mut latch = app.make_latch(fader.get_value());
+        loop {
+            fader.wait_for_change_at(0).await;
+
+            let latch_layer = glob_latch_layer.get();
+
+            let target_value = match latch_layer {
+                LatchLayer::Main => storage.query(|s| s.prob_saved),
+                LatchLayer::Alt => 0,
+                LatchLayer::Third => 0,
+            };
+
+            if let Some(new_value) = latch.update(fader.get_value(), latch_layer, target_value) {
+                match latch_layer {
+                    LatchLayer::Main => {
+                        storage.modify_and_save(|s| s.prob_saved = new_value);
+                    }
+                    LatchLayer::Alt => {}
+                    LatchLayer::Third => {}
+                }
+            }
+        }
+    };
+
+    let btn_fut = async {
+        loop {
+            buttons.wait_for_down(0).await;
+            if !buttons.is_shift_pressed() {
+                // First channel mute
+                let muted = storage.modify_and_save(|s| {
+                    s.channel_a_mute_saved = !s.channel_a_mute_saved;
+                    s.channel_a_mute_saved
+                });
+                channel_a_mute_glob.set(muted);
+                if muted {
+                    leds.unset(0, Led::Button);
+                } else {
+                    leds.set(0, Led::Button, led_color, Brightness::Mid);
+                }
+            } else {
+                // Second channel mute
+                let muted = storage.modify_and_save(|s| {
+                    s.channel_b_mute_saved = !s.channel_b_mute_saved;
+                    s.channel_b_mute_saved
+                });
+                channel_b_mute_glob.set(muted);
+                if muted {
+                    leds.unset(0, Led::Button);
+                } else {
+                    leds.set(0, Led::Button, led_color, Brightness::Mid);
+                }
+            }
+        }
+    };
+
+    let shift_fut = async {
+        loop {
+            app.delay_millis(1).await;
+
+            glob_latch_layer.set(LatchLayer::from(buttons.is_shift_pressed()));
+
+            // Change state of button when shift is pressed or released to show correct active state of first or second added channels
+            if !buttons.is_shift_pressed() {
+                let muted = storage.query(|s| s.channel_a_mute_saved);
+                if muted {
+                    leds.unset(0, Led::Button);
+                } else {
+                    leds.set(0, Led::Button, led_color, Brightness::Mid);
+                }
+            } else {
+                let muted = storage.query(|s| s.channel_b_mute_saved);
+                if muted {
+                    leds.unset(0, Led::Button);
+                } else {
+                    leds.set(0, Led::Button, led_color, Brightness::Mid);
+                }
+            }
+        }
+    };
+
+    let scene_handler = async {
+        loop {
+            match app.wait_for_scene_event().await {
+                SceneEvent::LoadScene(scene) => {
+                    storage.load_from_scene(scene).await;
+                    channel_a_mute_glob.set(storage.query(|s| s.channel_a_mute_saved));
+                    channel_b_mute_glob.set(storage.query(|s| s.channel_b_mute_saved));
+                }
+
+                SceneEvent::SaveScene(scene) => {
+                    storage.save_to_scene(scene).await;
+                }
+            }
+        }
+    };
+
+    join5(main_fut, fader_fut, btn_fut, shift_fut, scene_handler).await;
+}
+
+fn latched_gate_change(
+    channel_safe: usize,
+    gate_unchanged_counter: &mut u32,
+    last_gate_is_high: &mut bool,
+    latched_gate_is_high: &mut bool,
+) {
+    let jack_is_now_high = App::<CHANNELS>::get_out_global_gate_jack_is_high(channel_safe);
+    if *last_gate_is_high == jack_is_now_high {
+        *gate_unchanged_counter += 1;
+    } else {
+        *last_gate_is_high = !*last_gate_is_high;
+        *gate_unchanged_counter = 0;
+    }
+    if *latched_gate_is_high != jack_is_now_high
+        && *gate_unchanged_counter > LATCHED_GATE_CHANGE_MILLIS
+    {
+        *latched_gate_is_high = jack_is_now_high;
+    }
+}

--- a/faderpunk/src/apps/mod.rs
+++ b/faderpunk/src/apps/mod.rs
@@ -26,4 +26,6 @@ register_apps!(
     25 => automator,
     26 => genseq,
     27 => bernoulli,
+    44 => cvcombine,
+    45 => gatecombine,
 );

--- a/faderpunk/src/state.rs
+++ b/faderpunk/src/state.rs
@@ -1,8 +1,12 @@
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
+use libfp::GLOBAL_CHANNELS;
 use minicbor::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
-use crate::storage;
+use crate::{
+    app::{GateJack, InJack, OutJack},
+    storage,
+};
 
 /// Persisted to FRAM as CBOR. Adding/removing fields is migration-free as long
 /// as every field carries `#[cbor(default)]` and a fresh `#[n(N)]`. See the
@@ -50,4 +54,55 @@ where
 
 pub async fn is_clock_running() -> bool {
     STATE.lock().await.clock_is_running
+}
+
+/// Runtime-only registry of which jack is currently configured on each global
+/// channel. Rebuilt every time apps spawn (each app re-registers its jacks on
+/// init) — never persisted to FRAM, unlike `RuntimeState`.
+struct JackRegistry {
+    out_jacks: [Option<OutJack>; GLOBAL_CHANNELS],
+    in_jacks: [Option<InJack>; GLOBAL_CHANNELS],
+    gate_jacks: [Option<GateJack>; GLOBAL_CHANNELS],
+}
+
+static JACKS: Mutex<CriticalSectionRawMutex, JackRegistry> = Mutex::new(JackRegistry {
+    out_jacks: [None; GLOBAL_CHANNELS],
+    in_jacks: [None; GLOBAL_CHANNELS],
+    gate_jacks: [None; GLOBAL_CHANNELS],
+});
+
+pub async fn register_out_jack(global_chan: usize, jack: OutJack) {
+    JACKS.lock().await.out_jacks[global_chan] = Some(jack);
+}
+
+pub async fn register_in_jack(global_chan: usize, jack: InJack) {
+    JACKS.lock().await.in_jacks[global_chan] = Some(jack);
+}
+
+pub async fn register_gate_jack(global_chan: usize, jack: GateJack) {
+    JACKS.lock().await.gate_jacks[global_chan] = Some(jack);
+}
+
+/// Clears any registered jack for the given global channel. Called when an
+/// app exits so a despawned app's jack doesn't outlive it in the registry.
+pub async fn clear_jacks(global_chan: usize) {
+    let mut jacks = JACKS.lock().await;
+    jacks.out_jacks[global_chan] = None;
+    jacks.in_jacks[global_chan] = None;
+    jacks.gate_jacks[global_chan] = None;
+}
+
+/// Gets configured set of each CV out app jack
+pub async fn get_out_jacks() -> [Option<OutJack>; GLOBAL_CHANNELS] {
+    JACKS.lock().await.out_jacks
+}
+
+/// Gets configured set of each input app jack
+pub async fn get_in_jacks() -> [Option<InJack>; GLOBAL_CHANNELS] {
+    JACKS.lock().await.in_jacks
+}
+
+/// Gets configured set of each gate out app jack
+pub async fn get_gate_jacks() -> [Option<GateJack>; GLOBAL_CHANNELS] {
+    JACKS.lock().await.gate_jacks
 }

--- a/gen-bindings/Cargo.lock
+++ b/gen-bindings/Cargo.lock
@@ -324,7 +324,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libfp"
-version = "0.10.5-beta.0"
+version = "0.10.5-beta.1"
 dependencies = [
  "embassy-time",
  "enum-ordinalize",

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -1189,6 +1189,21 @@ impl Range {
     pub fn is_bipolar(&self) -> bool {
         *self == Range::_Neg5_5V
     }
+
+    /// Converts a normalised jack signal value (in range 0 - 4095) to signed voltage value
+    /// e.g. convert from an InJack get_value() method call, or from a DAC output value
+    /// If Range 0-10V, output in range 0 - 4095
+    /// If Range 0-5V, output in range 0 - 2047
+    /// If Range -5 - 5V, output in range -2048 - 2047
+    /// Useful for simulating real-world voltage math (e.g. Precision Adders)
+    pub fn jack_value_to_voltage_value(&self, value: u16) -> i16 {
+        let value = value.clamp(0, 4095) as i16;
+        match self {
+            Range::_0_10V => value,
+            Range::_0_5V => value / 2,
+            Range::_Neg5_5V => value - 2048,
+        }
+    }
 }
 
 impl From<Range> for DACRANGE {


### PR DESCRIPTION
## Summary

Rebases and squashes #474 (CV Combine / Gate Combine apps by @rjsmith) onto current `main`. The original PR branch had drifted far enough from `main` that a normal commit-by-commit rebase wasn't practical, so this reapplies the net diff and adapts it to API changes on `main` since the PR forked:

- Replaces the deleted `MAX_TRIGGERS_GPO` (removed by the clock refactor) with a small `GATE_LEVELS` atomic array, giving Gate Combine a way to read another channel's current gate output.
- Adds a non-persisted `JackRegistry` in `state.rs` (instead of the original approach of storing jack configs in the FRAM-persisted `RuntimeState`, which would have exceeded that struct's 64-byte FRAM budget and broken `clock_is_running` persistence).
- Fixes a gate-jack registry indexing bug and adds cleanup of registry/gate-level state on app despawn (both present in the original PR).
- Adapts quantizer calls to the new `VoltPerOct`/bypass API, and `ParamStore::new`'s added `initial` argument.

See `PR-474-REVIEW.md` (added in this branch) for a `/code-review` pass done after the rebase — includes a few logic bugs in the original app code (probability-gate re-roll, a combine-mode math bug, etc.) and gaps in the new registry mechanism, none of which are fixed yet.

Draft while those findings get triaged.

## Test plan

- [ ] Flash to hardware, configure a **CV Combine** app; verify each combine mode (A+B, A-B, Max, Min, Average) against two known CV sources
- [ ] Verify CV Combine's octave/semitone offset fader and quantize toggle
- [ ] Configure a **Gate Combine** app; verify each logic mode (OR/AND/XOR/NOR/NAND/XNOR) against two gate/trigger sources
- [ ] Verify Gate Combine's probability fader (see known issue in `PR-474-REVIEW.md` #1)
- [ ] Despawn/respawn apps on sampled channels and confirm Combine apps don't keep reading stale jack state