### PR TITLE
fix: support current Rust toolchains

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,32 +70,32 @@ Follow this for **every** task, in order. Do not skip steps.
 
 ## Environment & Toolchain
 
-The toolchain (Rust nightly, Node, pnpm, picotool, probe-rs) is provided by
+Project commands use Rust, Node, pnpm, picotool, and probe-rs through
 **devenv** via **direnv** (`devenv.nix`, `.envrc`). A plain shell does not have
-it on PATH. Run project commands through the environment:
+the complete toolchain on PATH. Run project commands through the environment:
 
 ```bash
 direnv exec . <command>      # preferred (needs `direnv allow` once)
 devenv shell -- <command>    # equivalent fallback
 ```
 
-The firmware targets `thumbv8m.main-none-eabihf` and uses nightly features
-(`build-std`). `faderpunk/.cargo/config.toml` sets this target by default, so a
-bare `cargo build` works **from inside `faderpunk/`**. From the repo root you
-must pass `--bin faderpunk --target thumbv8m.main-none-eabihf` explicitly (this
-is what CI does, and it works on stable since the package-local `.cargo/config`
-is not in scope from root).
+The firmware targets `thumbv8m.main-none-eabihf` and builds on stable Rust.
+`faderpunk/.cargo/config.toml` sets this target by default, so
+`cargo +stable build` works **from inside `faderpunk/`**. From the repo root
+you must pass `--bin faderpunk --target thumbv8m.main-none-eabihf` explicitly
+(this is what CI does). `gen-bindings.sh` is the only build command that
+requires nightly, and selects it explicitly with `cargo +nightly`.
 
 ## Build Commands
 
 ### Firmware (Embedded Rust)
 
 ```bash
-# Build firmware from the package dir (uses configured target + build-std)
-cargo build --release            # run from faderpunk/
+# Build firmware from the package dir (uses configured target on stable)
+cargo +stable build --release    # run from faderpunk/
 
-# Build firmware from root (CI-equivalent; stable, no build-std)
-cargo build --bin faderpunk --release --target thumbv8m.main-none-eabihf
+# Build firmware from root (CI-equivalent; CI installs stable)
+cargo +stable build --bin faderpunk --release --target thumbv8m.main-none-eabihf
 
 # Build the flashable UF2 (wraps the above + picotool, from root)
 ./build-uf2.sh                   # → target/thumbv8m.main-none-eabihf/release/faderpunk.uf2

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Executes user-facing apps:
 - USB cable for programming and power
 
 #### Software
-- Rust toolchain (nightly recommended)
+- Rust stable toolchain (nightly is only required by `./gen-bindings.sh`)
 - `picotool` for UF2 conversion
 - Chromium-based browser for WebUSB configurator
 
@@ -75,7 +75,7 @@ Executes user-facing apps:
 
 You will need:
 - `rustup`
-- Rust (1.89 or newer) with `thumbv8m.main-none-eabihf` target (`rustup target add thumbv8m.main-none-eabihf`)
+- Rust stable (1.89 or newer) with the firmware target (`rustup target add --toolchain stable thumbv8m.main-none-eabihf`)
 - [picotool](https://github.com/raspberrypi/picotool)
 
 ## Building and Flashing
@@ -84,7 +84,7 @@ You will need:
 
 ```bash
 cd faderpunk # important, not in root
-cargo build --release
+cargo +stable build --release
 ```
 
 ### Create UF2 File

--- a/build-uf2.sh
+++ b/build-uf2.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-cd faderpunk
-cargo build --release
-cd ..
+set -euo pipefail
+cd -- "$(dirname -- "$0")"
+
+cargo +stable build --bin faderpunk --release --target thumbv8m.main-none-eabihf
 cp target/thumbv8m.main-none-eabihf/release/faderpunk target/thumbv8m.main-none-eabihf/release/faderpunk.elf
 picotool uf2 convert target/thumbv8m.main-none-eabihf/release/faderpunk.elf target/thumbv8m.main-none-eabihf/release/faderpunk.uf2

--- a/faderpunk/.cargo/config.toml
+++ b/faderpunk/.cargo/config.toml
@@ -8,7 +8,3 @@ target = "thumbv8m.main-none-eabihf"
 
 [env]
 DEFMT_LOG = "debug"
-
-[unstable]
-build-std = ["core"]
-build-std-features = ["panic_immediate_abort"]

--- a/faderpunk/src/tasks/midi.rs
+++ b/faderpunk/src/tasks/midi.rs
@@ -517,7 +517,7 @@ pub async fn midi_in_task<'a>(
                     if len == 0 {
                         continue;
                     }
-                    let packets = usb_rx_buf[..len].chunks_exact(4);
+                    let (packets, _) = usb_rx_buf[..len].as_chunks::<4>();
                     for packet in packets {
                         let cable = packet[0] >> 4;
                         let msg_len = len_from_cin(packet[0]);


### PR DESCRIPTION
## Summary
- migrate package-local build-std configuration to the current nightly immediate-abort panic strategy
- keep the workspace manifest compatible with stable Cargo used by CI and releases
- fix the current-nightly MIDI packet Clippy lint

Supersedes #611.

## Verification
- latest nightly: formatting, firmware/libfp Clippy, libfp tests, firmware release build, and UF2 generation
- latest stable: formatting, firmware/libfp Clippy, libfp tests, and firmware release build

## Hardware test
- [ ] Flash firmware and confirm the firmware boots normally