### PR TITLE
refactor(app): re-export LedMode so apps never import task internals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,6 +358,7 @@ manually in a Chromium browser with a live device connection.
 7. **Atomic ordering**: Use `Ordering::Relaxed` for non-synchronized state, `Acquire`/`Release` for synchronized.
 8. **Web MIDI requirements**: Browser must support Web MIDI with SysEx (Chromium, Firefox); HTTPS required for non-localhost. The user must grant the MIDI/SysEx permission.
 9. **Commit trailers**: One-line conventional-commit messages; do not add a `Co-authored-by: Claude` trailer.
+10. **App-facing types not re-exported**: if a new `App<N>`/`Leds<N>`/etc. method takes or returns a type from `crate::tasks::*`, add it to `app.rs`'s `pub use crate::{…}` re-export block in the same change — otherwise apps have to reach around the facade with a direct `crate::tasks::` import.
 
 ## File Structure Summary
 

--- a/faderpunk/src/app.rs
+++ b/faderpunk/src/app.rs
@@ -26,7 +26,7 @@ use crate::{
         clock::{ClockSubscriber, CLOCK_PUBSUB},
         global_config::get_global_config,
         i2c::{I2cLeaderMessage, I2cLeaderSender},
-        leds::{set_led_mode, LedMode, LedMsg},
+        leds::{set_led_mode, LedMsg},
         max::{MaxCmd, MaxSender, MAX_CHANNEL, MAX_VALUES_ADC, MAX_VALUES_DAC, MAX_VALUES_FADER},
         midi::{
             AppMidiSender, MidiEvent, MidiEventSource, MidiMsg, MidiPubSubChannel,
@@ -38,7 +38,10 @@ use crate::{
 
 pub use crate::{
     storage::{AppParams, AppStorage, Arr, ManagedStorage, ParamStore},
-    tasks::{clock::ClockEvent, leds::Led},
+    tasks::{
+        clock::ClockEvent,
+        leds::{Led, LedMode},
+    },
 };
 
 #[derive(Clone, Copy)]

--- a/faderpunk/src/apps/lfo.rs
+++ b/faderpunk/src/apps/lfo.rs
@@ -14,10 +14,8 @@ use libfp::{
     Range, Value, Waveform, APP_MAX_PARAMS,
 };
 
-use crate::{
-    app::{App, AppStorage, ClockEvent, Led, ManagedStorage, SceneEvent},
-    storage::{AppParams, ParamStore},
-    tasks::leds::LedMode,
+use crate::app::{
+    App, AppParams, AppStorage, ClockEvent, Led, LedMode, ManagedStorage, ParamStore, SceneEvent,
 };
 
 pub const CHANNELS: usize = 1;

--- a/faderpunk/src/apps/lfo_plus.rs
+++ b/faderpunk/src/apps/lfo_plus.rs
@@ -14,10 +14,8 @@ use libfp::{
     Range, Value, Waveform, APP_MAX_PARAMS,
 };
 
-use crate::{
-    app::{App, AppStorage, ClockEvent, Led, ManagedStorage, SceneEvent},
-    storage::{AppParams, ParamStore},
-    tasks::leds::LedMode,
+use crate::app::{
+    App, AppParams, AppStorage, ClockEvent, Led, LedMode, ManagedStorage, ParamStore, SceneEvent,
 };
 
 pub const CHANNELS: usize = 2;

--- a/faderpunk/src/apps/tb3po.rs
+++ b/faderpunk/src/apps/tb3po.rs
@@ -17,10 +17,9 @@ use libfp::{
 };
 
 use crate::app::{
-    pitch_as_counts, App, AppParams, AppStorage, ClockEvent, Global, Led, ManagedStorage,
+    pitch_as_counts, App, AppParams, AppStorage, ClockEvent, Global, Led, LedMode, ManagedStorage,
     ParamStore, SceneEvent,
 };
-use crate::tasks::leds::LedMode;
 
 pub const CHANNELS: usize = 3;
 pub const PARAMS: usize = 4;
@@ -703,7 +702,12 @@ pub async fn run(
             if in_res_mode {
                 // Show resolution index as brightness on Top (0–7 → dim to bright)
                 let res_idx = (res_saved as usize / 512).min(7) as u8;
-                leds.set(0, Led::Top, Color::Cyan, Brightness::Custom(res_idx * 32 + 16));
+                leds.set(
+                    0,
+                    Led::Top,
+                    Color::Cyan,
+                    Brightness::Custom(res_idx * 32 + 16),
+                );
             } else {
                 leds.set(
                     0,
@@ -723,7 +727,11 @@ pub async fn run(
             };
             leds.set(1, Led::Bottom, led_color, Brightness::Custom(progress));
             if gate_active {
-                let gate_color = if slide_active { Color::White } else { led_color };
+                let gate_color = if slide_active {
+                    Color::White
+                } else {
+                    led_color
+                };
                 leds.set(1, Led::Top, gate_color, Brightness::High);
             } else {
                 leds.unset(1, Led::Top);
@@ -732,7 +740,11 @@ pub async fn run(
                 1,
                 Led::Button,
                 led_color,
-                if no_accents { Brightness::Low } else { Brightness::Mid },
+                if no_accents {
+                    Brightness::Low
+                } else {
+                    Brightness::Mid
+                },
             );
 
             // Ch 2: accent on Top, transpose position on Bottom (always visible)


### PR DESCRIPTION
## Summary
- Apps must only reach hardware-task internals through the `App<N>` facade in `app.rs`, never by importing `crate::tasks::*` directly — this closes the one confirmed gap in that boundary.
- `app.rs` re-exported `leds::Led` but not `leds::LedMode`, even though `Leds::set_mode()` requires it — three apps (`tb3po`, `lfo`, `lfo_plus`) had worked around this with a direct `use crate::tasks::leds::LedMode` import to use LED effects.
- Add `LedMode` to `app.rs`'s existing re-export block, and update those three apps to pull it (and, for `lfo`/`lfo_plus`, `AppParams`/`ParamStore`) through `crate::app::` only.
- Note in `AGENTS.md` that any new `App<N>` method taking/returning a `crate::tasks::*` type must re-export it in the same change, so this doesn't recur.

No behavior change — this only moves import paths and widens a re-export.

## Test plan
- [ ] On hardware: TB-3PO reseed button flash (channel 0 button) still shows the white flash-then-static LED effect
- [ ] On hardware: LFO / LFO+ still display correctly, no LED regressions
- [ ] `cargo fmt --all -- --check`, `cargo clippy --bin faderpunk --target thumbv8m.main-none-eabihf -- -D warnings`, `cargo clippy -p libfp -- -D warnings`, `cargo test --lib -p libfp` all pass (already verified locally)