### PR TITLE
fix: never block the clock gatekeeper on a full pubsub

### DIFF
--- a/faderpunk/src/tasks/clock.rs
+++ b/faderpunk/src/tasks/clock.rs
@@ -275,10 +275,11 @@ async fn send_analog_ticks(spawner: &Spawner, config: &GlobalConfig, counters: &
         }
     }
     if !ports.is_empty() {
-        MAX_CHANNEL
+        // try_send for the same reason: a full MAX queue must not stall the
+        // clock gatekeeper. A dropped analog tick is better than a dead clock.
+        let _ = MAX_CHANNEL
             .sender()
-            .send(MaxCmd::GpoSetHighMany(ports.clone()))
-            .await;
+            .try_send(MaxCmd::GpoSetHighMany(ports.clone()));
         spawner.spawn(analog_tick_release(ports, 5)).ok();
     }
 }
@@ -291,10 +292,11 @@ async fn send_analog_reset(spawner: &Spawner, config: &GlobalConfig) {
         }
     }
     if !ports.is_empty() {
-        MAX_CHANNEL
+        // try_send for the same reason: a full MAX queue must not stall the
+        // clock gatekeeper. A dropped analog tick is better than a dead clock.
+        let _ = MAX_CHANNEL
             .sender()
-            .send(MaxCmd::GpoSetHighMany(ports.clone()))
-            .await;
+            .try_send(MaxCmd::GpoSetHighMany(ports.clone()));
         spawner.spawn(analog_tick_release(ports, 10)).ok();
     }
 }
@@ -302,10 +304,7 @@ async fn send_analog_reset(spawner: &Spawner, config: &GlobalConfig) {
 #[embassy_executor::task(pool_size = 4)]
 async fn analog_tick_release(ports: heapless::Vec<Port, 4>, trigger_len: u64) {
     Timer::after_millis(trigger_len).await;
-    MAX_CHANNEL
-        .sender()
-        .send(MaxCmd::GpoSetLowMany(ports))
-        .await;
+    let _ = MAX_CHANNEL.sender().try_send(MaxCmd::GpoSetLowMany(ports));
 }
 
 #[embassy_executor::task]
@@ -400,9 +399,12 @@ async fn run_clock_gatekeeper() {
                             || matches!(source, ClockSrc::Atom | ClockSrc::Meteor | ClockSrc::Cube)
                         {
                             tick_counter = tick_counter.wrapping_add(1);
-                            clock_publisher
-                                .publish(ClockEvent::Tick(tick_counter))
-                                .await;
+                            // Never await on the tick path: a subscriber that
+                            // sleeps while holding its slot fills the queue,
+                            // and a blocked gatekeeper stops the whole device
+                            // clock. Overwriting the oldest tick only costs a
+                            // lagged subscriber a beat.
+                            clock_publisher.publish_immediate(ClockEvent::Tick(tick_counter));
                             send_analog_ticks(&spawner, &config, &mut analog_tick_counters).await;
                         }
                     }

--- a/faderpunk/src/tasks/clock.rs
+++ b/faderpunk/src/tasks/clock.rs
@@ -304,7 +304,13 @@ async fn send_analog_reset(spawner: &Spawner, config: &GlobalConfig) {
 #[embassy_executor::task(pool_size = 4)]
 async fn analog_tick_release(ports: heapless::Vec<Port, 4>, trigger_len: u64) {
     Timer::after_millis(trigger_len).await;
-    let _ = MAX_CHANNEL.sender().try_send(MaxCmd::GpoSetLowMany(ports));
+    // This task runs off the gatekeeper's path, so blocking here only delays
+    // this release, never the clock: awaiting a queue slot is safe, and the
+    // port is guaranteed to eventually go low instead of getting stuck high.
+    MAX_CHANNEL
+        .sender()
+        .send(MaxCmd::GpoSetLowMany(ports))
+        .await;
 }
 
 #[embassy_executor::task]

--- a/faderpunk/src/tasks/clock.rs
+++ b/faderpunk/src/tasks/clock.rs
@@ -275,10 +275,11 @@ async fn send_analog_ticks(spawner: &Spawner, config: &GlobalConfig, counters: &
         }
     }
     if !ports.is_empty() {
-        MAX_CHANNEL
+        // try_send for the same reason: a full MAX queue must not stall the
+        // clock gatekeeper. A dropped analog tick is better than a dead clock.
+        let _ = MAX_CHANNEL
             .sender()
-            .send(MaxCmd::GpoSetHighMany(ports.clone()))
-            .await;
+            .try_send(MaxCmd::GpoSetHighMany(ports.clone()));
         spawner.spawn(analog_tick_release(ports, 5)).ok();
     }
 }
@@ -291,10 +292,11 @@ async fn send_analog_reset(spawner: &Spawner, config: &GlobalConfig) {
         }
     }
     if !ports.is_empty() {
-        MAX_CHANNEL
+        // try_send for the same reason: a full MAX queue must not stall the
+        // clock gatekeeper. A dropped analog tick is better than a dead clock.
+        let _ = MAX_CHANNEL
             .sender()
-            .send(MaxCmd::GpoSetHighMany(ports.clone()))
-            .await;
+            .try_send(MaxCmd::GpoSetHighMany(ports.clone()));
         spawner.spawn(analog_tick_release(ports, 10)).ok();
     }
 }
@@ -302,10 +304,7 @@ async fn send_analog_reset(spawner: &Spawner, config: &GlobalConfig) {
 #[embassy_executor::task(pool_size = 4)]
 async fn analog_tick_release(ports: heapless::Vec<Port, 4>, trigger_len: u64) {
     Timer::after_millis(trigger_len).await;
-    MAX_CHANNEL
-        .sender()
-        .send(MaxCmd::GpoSetLowMany(ports))
-        .await;
+    let _ = MAX_CHANNEL.sender().try_send(MaxCmd::GpoSetLowMany(ports));
 }
 
 #[embassy_executor::task]
@@ -399,9 +398,12 @@ async fn run_clock_gatekeeper() {
                             || matches!(source, ClockSrc::Atom | ClockSrc::Meteor | ClockSrc::Cube)
                         {
                             tick_counter = tick_counter.wrapping_add(1);
-                            clock_publisher
-                                .publish(ClockEvent::Tick(tick_counter))
-                                .await;
+                            // Never await on the tick path: a subscriber that
+                            // sleeps while holding its slot fills the queue,
+                            // and a blocked gatekeeper stops the whole device
+                            // clock. Overwriting the oldest tick only costs a
+                            // lagged subscriber a beat.
+                            clock_publisher.publish_immediate(ClockEvent::Tick(tick_counter));
                             send_analog_ticks(&spawner, &config, &mut analog_tick_counters).await;
                         }
                     }


### PR DESCRIPTION
The clock gatekeeper publishes ticks with `publish().await`. A subscriber that
sleeps while holding its slot (the metronome does, for the beat flash) lets the
shared `CLOCK_PUBSUB` queue fill up. Once it is full the gatekeeper blocks,
`CLOCK_IN` backs up behind it, and the whole device clock stops — apps go silent
after a few bars while USB and the UI still look healthy.

Ticks now use `publish_immediate`, so a lagging subscriber loses a beat instead
of stalling the publisher. The analog tick/reset writes switch from
`send().await` to `try_send` for the same reason: a full MAX queue must not be
able to pin the gatekeeper either.

Transport events (Start/Stop/Reset) keep `publish().await`. They are rare,
one-shot, and worth delivering reliably; with ticks no longer able to wedge the
publisher, waiting there is bounded.

Note: #631 touches the same two files (it adds the dedicated realtime queue) but
does not change the gatekeeper's blocking publish, so the two are complementary.
Whichever lands second needs a small rebase.

## Test plan

- [ ] Run a dense layout (several clocked apps at fine divisions, e.g. 1/16-1/32) for
      a few minutes on hardware and confirm the clock keeps running and apps keep
      sounding.
- [ ] Confirm the Scene LED beat flash still tracks the beat.
- [ ] With an AUX jack set to Clock Out / Reset Out, confirm analog ticks and reset
      pulses still fire.
- [ ] Start/Stop/Continue from an external clock source still behave.

Made with [Cursor](https://cursor.com)