### PR TITLE
feat: add non-blocking note and CC senders for voice engines

### DIFF
--- a/faderpunk/src/app.rs
+++ b/faderpunk/src/app.rs
@@ -448,6 +448,12 @@ impl MidiOutput {
     /// notes inside a tight clock step want the opposite trade: lose one note
     /// rather than delay every later one. Being sync also lets them fire from
     /// closures where `.await` is not available.
+    ///
+    /// There is deliberately no `try_send_note_off` counterpart: a dropped
+    /// NoteOn is silence, but a dropped NoteOff is a note that hangs until
+    /// something else happens to end it, and `APP_MIDI_CHANNEL` is shared by
+    /// all 16 channels, so a busy neighbour can cause the drop. Send the
+    /// matching NoteOff with [`Self::send_note_off`] from an async voice task.
     #[allow(dead_code)]
     pub fn try_send_note_on(&self, note_number: MidiNote, velocity: u16) {
         let event = LiveEvent::Midi {
@@ -455,23 +461,6 @@ impl MidiOutput {
             message: MidiMessage::NoteOn {
                 key: note_number.into(),
                 vel: scale_bits_12_7(velocity),
-            },
-        };
-        let msg = MidiMsg::new(event, self.midi_out, MidiEventSource::Local);
-        let _ = self.midi_sender.try_send((self.start_channel, msg));
-    }
-
-    /// Non-blocking, non-async NoteOff — see [`Self::try_send_note_on`].
-    ///
-    /// Pair it with `try_send_note_on`: an engine that can drop a NoteOn must
-    /// be able to drop the matching NoteOff without stalling.
-    #[allow(dead_code)]
-    pub fn try_send_note_off(&self, note_number: MidiNote) {
-        let event = LiveEvent::Midi {
-            channel: self.midi_channel,
-            message: MidiMessage::NoteOff {
-                key: note_number.into(),
-                vel: 0.into(),
             },
         };
         let msg = MidiMsg::new(event, self.midi_out, MidiEventSource::Local);

--- a/faderpunk/src/app.rs
+++ b/faderpunk/src/app.rs
@@ -445,6 +445,12 @@ impl MidiOutput {
     /// notes inside a tight clock step want the opposite trade: lose one note
     /// rather than delay every later one. Being sync also lets them fire from
     /// closures where `.await` is not available.
+    ///
+    /// There is deliberately no `try_send_note_off` counterpart: a dropped
+    /// NoteOn is silence, but a dropped NoteOff is a note that hangs until
+    /// something else happens to end it, and `APP_MIDI_CHANNEL` is shared by
+    /// all 16 channels, so a busy neighbour can cause the drop. Send the
+    /// matching NoteOff with [`Self::send_note_off`] from an async voice task.
     #[allow(dead_code)]
     pub fn try_send_note_on(&self, note_number: MidiNote, velocity: u16) {
         let event = LiveEvent::Midi {
@@ -452,23 +458,6 @@ impl MidiOutput {
             message: MidiMessage::NoteOn {
                 key: note_number.into(),
                 vel: scale_bits_12_7(velocity),
-            },
-        };
-        let msg = MidiMsg::new(event, self.midi_out, MidiEventSource::Local);
-        let _ = self.midi_sender.try_send((self.start_channel, msg));
-    }
-
-    /// Non-blocking, non-async NoteOff — see [`Self::try_send_note_on`].
-    ///
-    /// Pair it with `try_send_note_on`: an engine that can drop a NoteOn must
-    /// be able to drop the matching NoteOff without stalling.
-    #[allow(dead_code)]
-    pub fn try_send_note_off(&self, note_number: MidiNote) {
-        let event = LiveEvent::Midi {
-            channel: self.midi_channel,
-            message: MidiMessage::NoteOff {
-                key: note_number.into(),
-                vel: 0.into(),
             },
         };
         let msg = MidiMsg::new(event, self.midi_out, MidiEventSource::Local);

--- a/faderpunk/src/app.rs
+++ b/faderpunk/src/app.rs
@@ -387,12 +387,17 @@ impl MidiOutput {
         }
     }
 
-    async fn send_midi_msg(&self, msg: MidiMessage) {
+    /// Wraps a `MidiMessage` as a local `MidiMsg` ready for either sender.
+    fn wrap_midi_msg(&self, message: MidiMessage) -> MidiMsg {
         let event = LiveEvent::Midi {
             channel: self.midi_channel,
-            message: msg,
+            message,
         };
-        let msg = MidiMsg::new(event, self.midi_out, MidiEventSource::Local);
+        MidiMsg::new(event, self.midi_out, MidiEventSource::Local)
+    }
+
+    async fn send_midi_msg(&self, msg: MidiMessage) {
+        let msg = self.wrap_midi_msg(msg);
         self.midi_sender.send((self.start_channel, msg)).await;
     }
 
@@ -405,20 +410,7 @@ impl MidiOutput {
     /// update supersedes it anyway. Unlike note on/off, dropping here can't
     /// leave a stuck note.
     pub async fn send_cc(&self, cc: MidiCc, value: u16) {
-        if self.nrpn_mode {
-            let msg = MidiMsg::nrpn(self.midi_channel, cc.as_u16(), value, self.midi_out);
-            let _ = self.midi_sender.try_send((self.start_channel, msg));
-        } else {
-            let event = LiveEvent::Midi {
-                channel: self.midi_channel,
-                message: MidiMessage::Controller {
-                    controller: cc.into(),
-                    value: scale_bits_12_7(value),
-                },
-            };
-            let msg = MidiMsg::new(event, self.midi_out, MidiEventSource::Local);
-            let _ = self.midi_sender.try_send((self.start_channel, msg));
-        }
+        self.try_send_cc(cc, value);
     }
 
     /// Sends a MIDI NoteOn message.
@@ -456,14 +448,10 @@ impl MidiOutput {
     /// matching NoteOff with [`Self::send_note_off`] from an async voice task.
     #[allow(dead_code)]
     pub fn try_send_note_on(&self, note_number: MidiNote, velocity: u16) {
-        let event = LiveEvent::Midi {
-            channel: self.midi_channel,
-            message: MidiMessage::NoteOn {
-                key: note_number.into(),
-                vel: scale_bits_12_7(velocity),
-            },
-        };
-        let msg = MidiMsg::new(event, self.midi_out, MidiEventSource::Local);
+        let msg = self.wrap_midi_msg(MidiMessage::NoteOn {
+            key: note_number.into(),
+            vel: scale_bits_12_7(velocity),
+        });
         let _ = self.midi_sender.try_send((self.start_channel, msg));
     }
 
@@ -474,14 +462,10 @@ impl MidiOutput {
         let msg = if self.nrpn_mode {
             MidiMsg::nrpn(self.midi_channel, cc.as_u16(), value, self.midi_out)
         } else {
-            let event = LiveEvent::Midi {
-                channel: self.midi_channel,
-                message: MidiMessage::Controller {
-                    controller: cc.into(),
-                    value: scale_bits_12_7(value),
-                },
-            };
-            MidiMsg::new(event, self.midi_out, MidiEventSource::Local)
+            self.wrap_midi_msg(MidiMessage::Controller {
+                controller: cc.into(),
+                value: scale_bits_12_7(value),
+            })
         };
         let _ = self.midi_sender.try_send((self.start_channel, msg));
     }

--- a/faderpunk/src/app.rs
+++ b/faderpunk/src/app.rs
@@ -440,6 +440,63 @@ impl MidiOutput {
         self.send_midi_msg(msg).await;
     }
 
+    /// Non-blocking, non-async NoteOn — drops the note if the app MIDI queue
+    /// is full.
+    ///
+    /// [`Self::send_note_on`] awaits queue space, which parks the caller on
+    /// Core 1 and backs pressure up into USB TX. Voice engines that decide
+    /// notes inside a tight clock step want the opposite trade: lose one note
+    /// rather than delay every later one. Being sync also lets them fire from
+    /// closures where `.await` is not available.
+    #[allow(dead_code)]
+    pub fn try_send_note_on(&self, note_number: MidiNote, velocity: u16) {
+        let event = LiveEvent::Midi {
+            channel: self.midi_channel,
+            message: MidiMessage::NoteOn {
+                key: note_number.into(),
+                vel: scale_bits_12_7(velocity),
+            },
+        };
+        let msg = MidiMsg::new(event, self.midi_out, MidiEventSource::Local);
+        let _ = self.midi_sender.try_send((self.start_channel, msg));
+    }
+
+    /// Non-blocking, non-async NoteOff — see [`Self::try_send_note_on`].
+    ///
+    /// Pair it with `try_send_note_on`: an engine that can drop a NoteOn must
+    /// be able to drop the matching NoteOff without stalling.
+    #[allow(dead_code)]
+    pub fn try_send_note_off(&self, note_number: MidiNote) {
+        let event = LiveEvent::Midi {
+            channel: self.midi_channel,
+            message: MidiMessage::NoteOff {
+                key: note_number.into(),
+                vel: 0.into(),
+            },
+        };
+        let msg = MidiMsg::new(event, self.midi_out, MidiEventSource::Local);
+        let _ = self.midi_sender.try_send((self.start_channel, msg));
+    }
+
+    /// Non-blocking, non-async CC — same payload as [`Self::send_cc`], usable
+    /// from sync code.
+    #[allow(dead_code)]
+    pub fn try_send_cc(&self, cc: MidiCc, value: u16) {
+        let msg = if self.nrpn_mode {
+            MidiMsg::nrpn(self.midi_channel, cc.as_u16(), value, self.midi_out)
+        } else {
+            let event = LiveEvent::Midi {
+                channel: self.midi_channel,
+                message: MidiMessage::Controller {
+                    controller: cc.into(),
+                    value: scale_bits_12_7(value),
+                },
+            };
+            MidiMsg::new(event, self.midi_out, MidiEventSource::Local)
+        };
+        let _ = self.midi_sender.try_send((self.start_channel, msg));
+    }
+
     /// Sends a MIDI Aftertouch message.
     /// velocity is normalized to a range of 0-4095
     #[allow(dead_code)]

--- a/faderpunk/src/app.rs
+++ b/faderpunk/src/app.rs
@@ -437,6 +437,63 @@ impl MidiOutput {
         self.send_midi_msg(msg).await;
     }
 
+    /// Non-blocking, non-async NoteOn — drops the note if the app MIDI queue
+    /// is full.
+    ///
+    /// [`Self::send_note_on`] awaits queue space, which parks the caller on
+    /// Core 1 and backs pressure up into USB TX. Voice engines that decide
+    /// notes inside a tight clock step want the opposite trade: lose one note
+    /// rather than delay every later one. Being sync also lets them fire from
+    /// closures where `.await` is not available.
+    #[allow(dead_code)]
+    pub fn try_send_note_on(&self, note_number: MidiNote, velocity: u16) {
+        let event = LiveEvent::Midi {
+            channel: self.midi_channel,
+            message: MidiMessage::NoteOn {
+                key: note_number.into(),
+                vel: scale_bits_12_7(velocity),
+            },
+        };
+        let msg = MidiMsg::new(event, self.midi_out, MidiEventSource::Local);
+        let _ = self.midi_sender.try_send((self.start_channel, msg));
+    }
+
+    /// Non-blocking, non-async NoteOff — see [`Self::try_send_note_on`].
+    ///
+    /// Pair it with `try_send_note_on`: an engine that can drop a NoteOn must
+    /// be able to drop the matching NoteOff without stalling.
+    #[allow(dead_code)]
+    pub fn try_send_note_off(&self, note_number: MidiNote) {
+        let event = LiveEvent::Midi {
+            channel: self.midi_channel,
+            message: MidiMessage::NoteOff {
+                key: note_number.into(),
+                vel: 0.into(),
+            },
+        };
+        let msg = MidiMsg::new(event, self.midi_out, MidiEventSource::Local);
+        let _ = self.midi_sender.try_send((self.start_channel, msg));
+    }
+
+    /// Non-blocking, non-async CC — same payload as [`Self::send_cc`], usable
+    /// from sync code.
+    #[allow(dead_code)]
+    pub fn try_send_cc(&self, cc: MidiCc, value: u16) {
+        let msg = if self.nrpn_mode {
+            MidiMsg::nrpn(self.midi_channel, cc.as_u16(), value, self.midi_out)
+        } else {
+            let event = LiveEvent::Midi {
+                channel: self.midi_channel,
+                message: MidiMessage::Controller {
+                    controller: cc.into(),
+                    value: scale_bits_12_7(value),
+                },
+            };
+            MidiMsg::new(event, self.midi_out, MidiEventSource::Local)
+        };
+        let _ = self.midi_sender.try_send((self.start_channel, msg));
+    }
+
     /// Sends a MIDI Aftertouch message.
     /// velocity is normalized to a range of 0-4095
     #[allow(dead_code)]


### PR DESCRIPTION
`send_note_on` / `send_note_off` await space in the app MIDI queue. For a voice
engine that decides notes inside a clock step that is the wrong trade: the task
parks on Core 1, pressure backs up into USB TX, and every later note is delayed
too. Losing a single note is cheaper.

Adds sync, non-blocking variants alongside the existing ones:

- `try_send_note_on` / `try_send_note_off` — drop instead of awaiting
- `try_send_cc` — same payload as `send_cc` (already non-blocking), but callable
  from sync code

Being non-async matters as much as being non-blocking: these fire from closures
inside tight clock loops where `.await` is not available.

Nothing existing changes behaviour — the blocking senders stay as they are, and
apps opt in. The `#[allow(dead_code)]` is because the first callers are the WIP
app branches (#634, #633, #604, #609), which cannot compile against `main`
without this.

Note for review: `cargo clippy -D warnings` currently fails on `main` itself
with a `chunks_exact` lint in `tasks/midi.rs` (toolchain drift, unrelated to
this change).

Made with [Cursor](https://cursor.com)

**Update after review:** `try_send_note_off` has been dropped — a dropped NoteOff has no future message to correct it, and `APP_MIDI_CHANNEL` is shared across all 16 channels, so the drop is not something a voice engine can avoid. NoteOff goes through the blocking `send_note_off` from the async voice tasks. Only `try_send_note_on` and `try_send_cc` remain.
