### PR TITLE
feat: let apps write back their own params and notify the host

### DIFF
--- a/faderpunk/src/storage.rs
+++ b/faderpunk/src/storage.rs
@@ -709,6 +709,28 @@ impl<P: AppParams> ParamStore<P> {
         accessor(&*guard)
     }
 
+    /// Change a param from inside the app, persist it, and tell the host.
+    ///
+    /// Params normally travel host→device. An app that lets the user pick a
+    /// value on the hardware has to close the loop itself, otherwise the
+    /// configurator keeps showing the old value until the app restarts.
+    #[allow(dead_code)]
+    pub async fn update<F>(&self, modifier: F)
+    where
+        F: FnOnce(&mut P),
+    {
+        {
+            let mut inner = self.inner.borrow_mut();
+            modifier(&mut inner);
+        }
+        self.save().await;
+        let values = {
+            let guard = self.inner.borrow();
+            guard.to_values()
+        };
+        let _ = crate::tasks::configure::APP_PARAM_PUSH_CHANNEL.try_send((self.layout_id, values));
+    }
+
     pub async fn param_handler(&self) {
         APP_PARAM_SIGNALS[self.layout_id as usize].reset();
         loop {

--- a/faderpunk/src/tasks/configure.rs
+++ b/faderpunk/src/tasks/configure.rs
@@ -59,6 +59,17 @@ pub static APP_PARAM_CHANNEL: Channel<
     GLOBAL_CHANNELS,
 > = Channel::new();
 
+/// Unsolicited app→host param updates, e.g. a gesture that picks a genre on
+/// the device. Forwarded as `AppState` while the config loop is idle so hosts
+/// track on-device edits live. Kept separate from [`APP_PARAM_CHANNEL`], which
+/// carries request/response replies only — a push queued there would be
+/// drained as a stale reply and never reach the host.
+pub static APP_PARAM_PUSH_CHANNEL: Channel<
+    CriticalSectionRawMutex,
+    (u8, Vec<Value, APP_MAX_PARAMS>),
+    4,
+> = Channel::new();
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, defmt::Format)]
 pub enum ProtocolError {
     BufferTooSmall,
@@ -76,10 +87,18 @@ pub async fn start_config_loop<'a>(usb_tx: &'a SharedUsbSender<'a>) {
     let mut layout = layout_receiver.get().await;
     let mut pending_voct_eviction: Option<(u8, EvictedApp)> = None;
     loop {
-        let msg = match proto.read_msg().await {
-            Ok(msg) => msg,
-            Err(err) => {
+        // Cancel-safe: read_msg awaits on the frame channel, so no partial
+        // frame state is lost when the select flips to a push.
+        let msg = match select(proto.read_msg(), APP_PARAM_PUSH_CHANNEL.receive()).await {
+            Either::First(Ok(msg)) => msg,
+            Either::First(Err(err)) => {
                 defmt::warn!("Dropping invalid config frame: {}", err);
+                continue;
+            }
+            Either::Second((id, values)) => {
+                if let Err(err) = proto.send_msg(ConfigMsgOut::AppState(id, &values)).await {
+                    defmt::warn!("Failed to push AppState({}): {}", id, err);
+                }
                 continue;
             }
         };


### PR DESCRIPTION
Params travel host→device: the configurator sets them, the app reads them. An
app that lets the user pick a value on the hardware (a gesture that cycles a
genre or a voice, say) has no way to close the loop — the value is neither
persisted nor reflected, so the configurator keeps showing the old one until
the app task restarts.

Adds `ParamStore::update()`, which mutates, saves, and pushes the new values to
the host.

The push needs its own channel. `APP_PARAM_CHANNEL` carries request/response
replies, and an unsolicited push queued there gets drained as a stale reply to
a later `GetAppParams` — the host would see the wrong layout's state. So
`APP_PARAM_PUSH_CHANNEL` is separate, and the config loop selects on it while
idle. The select is cancel-safe: `read_msg` awaits on the frame channel, so no
partial frame is lost when the select flips.

`#[allow(dead_code)]` because the first callers are the WIP app branches
(#633, #604), which cannot compile against `main` without this.

Note for review: `cargo clippy -D warnings` currently fails on `main` itself
with a `chunks_exact` lint in `tasks/midi.rs`, unrelated to this change.

## Test checklist (hardware)

- [ ] Configurator open, change a param on the device (Bassment genre gesture):
      the configurator updates live without a reconnect
- [ ] The changed value survives a power cycle
- [ ] `GetAppParams` for another layout still returns that layout's own state
      (no stale reply crossover)

Made with [Cursor](https://cursor.com)