### PR TITLE
fix: read USB MIDI packets with as_chunks to satisfy clippy

### DIFF
--- a/faderpunk/src/tasks/midi.rs
+++ b/faderpunk/src/tasks/midi.rs
@@ -517,7 +517,7 @@ pub async fn midi_in_task<'a>(
                     if len == 0 {
                         continue;
                     }
-                    let packets = usb_rx_buf[..len].chunks_exact(4);
+                    let (packets, _) = usb_rx_buf[..len].as_chunks::<4>();
                     for packet in packets {
                         let cable = packet[0] >> 4;
                         let msg_len = len_from_cin(packet[0]);


### PR DESCRIPTION
`clippy::chunks_exact_to_as_chunks` fires on the constant chunk size in the USB
RX loop of `tasks/midi.rs`. CI runs clippy with `-D warnings`, so on a current
toolchain `main` does not pass its own gate — and several open feature branches
have been carrying this exact one-line fix inside unrelated app commits just to
stay green.

`as_chunks::<4>()` yields `&[[u8; 4]]`, so the packet indexing below is
unchanged. Discarding the remainder matches the previous behaviour: `chunks_exact`
dropped a trailing partial packet as well, and a USB MIDI bulk transfer is always
a multiple of four bytes.

Verified with `cargo clippy --bin faderpunk --target thumbv8m.main-none-eabihf -- -D warnings`,
which is clean on this branch and fails on `main`.

Authored by an AI coding agent on behalf of @kosmar.

Made with [Cursor](https://cursor.com)