### PR TITLE
feat: add clock_ticker for apps that only need the tick count

### DIFF
--- a/faderpunk/src/app.rs
+++ b/faderpunk/src/app.rs
@@ -23,7 +23,7 @@ use crate::{
     events::{EventPubSubChannel, InputEvent},
     tasks::{
         buttons::{is_channel_button_pressed, is_shift_button_pressed},
-        clock::{ClockSubscriber, CLOCK_PUBSUB},
+        clock::{ClockSubscriber, CLOCK_PUBSUB, TICK_COUNTER},
         global_config::get_global_config,
         i2c::{I2cLeaderMessage, I2cLeaderSender},
         leds::{set_led_mode, LedMode, LedMsg},
@@ -795,6 +795,18 @@ impl<const N: usize> App<N> {
         Clock::new()
     }
 
+    /// Poll the current tick instead of subscribing to the clock.
+    ///
+    /// For apps that derive everything from the tick number and never react to
+    /// Start/Stop/Reset. Unlike [`Self::use_clock`] this costs no subscriber
+    /// slot, and an app that falls behind cannot back up the shared clock
+    /// queue. Returns `u64::MAX` before the first tick; the counter going
+    /// backwards means the clock was restarted or reset.
+    #[allow(dead_code)] // first users are the WIP app branches
+    pub fn clock_ticker(&self) -> fn() -> u64 {
+        ticks
+    }
+
     pub fn use_quantizer(&self, range: Range, vpo: VoltPerOct, bypass: bool) -> Quantizer {
         Quantizer::new(range, vpo, bypass)
     }
@@ -869,4 +881,9 @@ pub fn pitch_as_counts(pitch: Pitch, range: Range, vpo: VoltPerOct) -> u16 {
 /// from the live global config.
 pub fn vpo_counts_per_oct(vpo: VoltPerOct) -> i16 {
     get_global_config().vpo_counts_per_oct(vpo)
+}
+
+#[allow(dead_code)] // see App::clock_ticker
+fn ticks() -> u64 {
+    TICK_COUNTER.load(Ordering::Relaxed)
 }

--- a/faderpunk/src/tasks/clock.rs
+++ b/faderpunk/src/tasks/clock.rs
@@ -15,7 +15,7 @@ use embassy_sync::{
 use embassy_time::{Duration, Instant, Timer};
 use heapless::Deque;
 use midly::live::SystemRealtime;
-use portable_atomic::{AtomicBool, Ordering};
+use portable_atomic::{AtomicBool, AtomicU64, Ordering};
 
 use libfp::{
     utils::bpm_to_clock_duration, AuxJackMode, ClockSrc, GlobalConfig, MidiOut, MidiOutConfig,
@@ -45,6 +45,14 @@ const INTERNAL_PPQN: u8 = 24;
 const METRONOME_HIGH_MS: u64 = 25;
 
 pub static METRONOME_HIGH: AtomicBool = AtomicBool::new(true);
+
+/// Current gatekeeper tick, mirrored for readers that only need the count.
+///
+/// A [`CLOCK_PUBSUB`] subscription costs a queue slot and obliges the reader to
+/// keep draining it; anything that only wants "which tick is it" can poll this
+/// instead and never influence the gatekeeper. `u64::MAX` means "not started" —
+/// the first tick after a Start/Reset is 0.
+pub static TICK_COUNTER: AtomicU64 = AtomicU64::new(u64::MAX);
 
 type AuxInputs = (
     Peri<'static, PIN_1>,
@@ -399,6 +407,7 @@ async fn run_clock_gatekeeper() {
                             || matches!(source, ClockSrc::Atom | ClockSrc::Meteor | ClockSrc::Cube)
                         {
                             tick_counter = tick_counter.wrapping_add(1);
+                            TICK_COUNTER.store(tick_counter, Ordering::Relaxed);
                             clock_publisher
                                 .publish(ClockEvent::Tick(tick_counter))
                                 .await;
@@ -422,6 +431,7 @@ async fn run_clock_gatekeeper() {
                     // (Re-)start the clock. Full phase reset
                     ClockInEvent::Start(_) => {
                         tick_counter = u64::MAX;
+                        TICK_COUNTER.store(u64::MAX, Ordering::Relaxed);
                         is_running = true;
                         clock_publisher.publish(ClockEvent::Reset).await;
                         clock_publisher.publish(ClockEvent::Start).await;
@@ -438,6 +448,7 @@ async fn run_clock_gatekeeper() {
                     // Reset the phase without affecting the run state
                     ClockInEvent::Reset(_) => {
                         tick_counter = u64::MAX;
+                        TICK_COUNTER.store(u64::MAX, Ordering::Relaxed);
                         clock_publisher.publish(ClockEvent::Reset).await;
                         analog_tick_counters = [0; 3];
                         send_analog_reset(&spawner, &config).await;


### PR DESCRIPTION
Split out of #638 at Arthur's request: `clock_ticker` is additive API and has nothing to do with the pubsub/metronome fix.

`App::clock_ticker()` hands an app a plain `fn() -> u64` that reads the current 24 PPQN tick out of `TICK_COUNTER`. Apps that derive everything from the tick number and never react to Start/Stop/Reset can use it instead of `use_clock()`: it costs no `CLOCK_PUBSUB` subscriber slot, and an app that falls behind cannot back up the shared clock queue. `u64::MAX` means “not started”; the counter going backwards means the clock was restarted or reset.

It is `#[allow(dead_code)]` on `main` — the first users are the WIP app branches, where a clocked app that also awaits a MAX write or a MIDI send inside its loop is exactly the subscriber that used to stall the gatekeeper.

Stacked on #638 (which is itself stacked on #636), because `TICK_COUNTER` is introduced there. Cross-repo PRs can only target `main`, so this diff shows all three commits; merge #636 and #638 first and it shrinks to the `app.rs` change alone.

No test checklist: this adds an unused accessor and changes no behaviour on its own.

_Opened by an AI coding agent on @kosmar's behalf._
