### PR TITLE
feat: ParamStore::update polyfill without host push

### DIFF
--- a/faderpunk/src/storage.rs
+++ b/faderpunk/src/storage.rs
@@ -709,6 +709,25 @@ impl<P: AppParams> ParamStore<P> {
         accessor(&*guard)
     }
 
+    /// Change a param from inside the app and persist it to FRAM.
+    ///
+    /// Same call shape as the full AppParams writeback (#640), but without the
+    /// host push: the configurator stays stale until that lands. Apps can call
+    /// this now; swapping in the real #640 implementation later is a drop-in.
+    #[allow(dead_code)]
+    pub async fn update<F>(&self, modifier: F)
+    where
+        F: FnOnce(&mut P),
+    {
+        {
+            let mut inner = self.inner.borrow_mut();
+            modifier(&mut inner);
+        }
+        self.save().await;
+        // #640 adds: try_send AppState on APP_PARAM_PUSH_CHANNEL so the host
+        // tracks on-device edits live.
+    }
+
     pub async fn param_handler(&self) {
         APP_PARAM_SIGNALS[self.layout_id as usize].reset();
         loop {


### PR DESCRIPTION
## Summary
- Adds `ParamStore::update` with the same mutate+FRAM-save call shape as #640, so WIP apps can persist on-device param edits now.
- Omits the unsolicited host `AppState` push (`APP_PARAM_PUSH_CHANNEL`). The configurator stays stale until the full writeback in #640 lands; swapping that in later is a drop-in on this method.
- Intended as the non-blocking slice so app PRs are not stacked on the UX discussion in #640.

## Test plan
- [ ] `cargo clippy --bin faderpunk --target thumbv8m.main-none-eabihf -- -D warnings`
- [ ] `cargo test --lib -p libfp`
- [ ] On hardware (any app that calls `params.update`, e.g. Manifold mode cycle): value persists across app restart; configurator still shows the old param until reconnect/pull (expected until #640)


Made with [Cursor](https://cursor.com)