### PR TITLE
fix(max): eliminate SharedMax mutex starvation causing gate jitter

### DIFF
--- a/faderpunk/src/tasks/max.rs
+++ b/faderpunk/src/tasks/max.rs
@@ -1,4 +1,5 @@
 use embassy_executor::Spawner;
+use embassy_futures::yield_now;
 use embassy_rp::{
     gpio::{Level, Output},
     peripherals::{PIN_12, PIN_13, PIN_14, PIN_15, PIN_17, PIO0, SPI0},
@@ -222,6 +223,11 @@ async fn read_fader(
         let mut burst = [0u16; FADER_BURST_READS];
         for slot in burst.iter_mut() {
             *slot = fader_port.get_value().await.unwrap();
+            // Give message_loop a fair chance at SharedMax between reads:
+            // back-to-back re-locks here would otherwise always win the
+            // race (embassy-sync's Mutex has no FIFO fairness), starving
+            // gate output for the length of the whole burst.
+            yield_now().await;
         }
         let mut sorted = burst;
         sorted.sort_unstable();
@@ -332,6 +338,14 @@ async fn process_channel_values(
                 }
                 _ => {}
             }
+            // Release the lock and yield before the next iteration re-locks.
+            // Without this, dropping `max` and immediately calling
+            // `lock().await` again happens in the same synchronous
+            // continuation, so this loop always wins the race against
+            // message_loop (embassy-sync's Mutex has no FIFO fairness) and
+            // can starve gate output for the length of an entire sweep.
+            drop(max);
+            yield_now().await;
         }
     }
 }


### PR DESCRIPTION
## Summary
- `process_channel_values`'s 19-port sweep and `read_fader`'s 5-read burst each re-acquire `SharedMax` back-to-back with no yield between iterations. Since `embassy-sync`'s `Mutex` has no FIFO fairness (single-slot waker, `wake()` only schedules, doesn't yield), dropping and immediately re-locking in the same synchronous continuation always wins the race against `message_loop`, starving gate output for up to a whole sweep/burst.
- Insert `embassy_futures::yield_now().await` between lock cycles in both loops so `message_loop` gets a fair scheduling chance each iteration instead of once per sweep/burst.
- Root-caused via a source-level audit (not measurement-only): traced the exact mechanism through `embassy-sync 0.7.2`'s `mutex.rs` and confirmed the fader burst-read loop (landed in v1.12.0-beta.0 via #556/#628) introduced a second instance of the same pattern, explaining the reported v1.12 regression.

## Test plan
- [x] Confirmed on hardware by reporter: external precision MIDI clock into DIN input, single gate app (seq8/tp3o) on an otherwise empty layout, gate output recorded directly — jitter no longer reproduces.
- [ ] Reviewer: confirm CV/gate input sampling and fader responsiveness haven't regressed noticeably (the added yields lengthen sweep/burst wall-clock time slightly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)