### PR TITLE
fix: drop unconsumed docs/apps manual-entry format from PR scope policy

### DIFF
--- a/.github/scripts/pr-scope-check.sh
+++ b/.github/scripts/pr-scope-check.sh
@@ -125,10 +125,13 @@ fi
 
 is_app_file() { [[ "$1" == faderpunk/src/apps/*.rs && "$1" != faderpunk/src/apps/mod.rs ]]; }
 is_manual_file() {
+  # docs/apps/*/manual.{md,json} is deliberately NOT accepted here — see
+  # faderpunk issue #656: nothing in the configurator actually consumes that
+  # format, so a PR that only touches it still needs the missing-manual-entry
+  # soft-flag below, not a silent pass.
   case "$1" in
     configurator/src/components/ManualTab.tsx|configurator/src/components/manual/Apps.tsx| \
     configurator/src/components/manual/ManualApp.tsx|configurator/src/components/manual/Md.tsx) return 0 ;;
-    docs/apps/*/manual.md|docs/apps/*/manual.json) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -325,7 +328,7 @@ fi
 
 if [[ ${#app_files_new[@]} -gt 0 ]]; then
   [[ "$touches_mod_rs" == false ]] && SOFT_FLAGS+=("New app file added but \`faderpunk/src/apps/mod.rs\` isn't touched — app won't be registered.")
-  [[ "$touches_manual" == false ]] && SOFT_FLAGS+=("New app file added but no manual entry found (neither \`ManualTab.tsx\`/\`manual/Apps.tsx\` nor \`docs/apps/*/manual.*\`).")
+  [[ "$touches_manual" == false ]] && SOFT_FLAGS+=("New app file added but no manual entry found in \`ManualTab.tsx\`/\`manual/Apps.tsx\` — this is the only format the configurator actually renders (see issue #656).")
 fi
 
 total_net=0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Every PR is automatically classified by what it touches, not by what you say it 
 
 | Category | What it may touch |
 |---|---|
-| **New app** | One new file under `faderpunk/src/apps/`, the one-line registration in `faderpunk/src/apps/mod.rs`, and its manual entry (`configurator/src/components/ManualTab.tsx` / `manual/Apps.tsx`, or `docs/apps/<id>-<name>/manual.{md,json}`) |
+| **New app** | One new file under `faderpunk/src/apps/`, the one-line registration in `faderpunk/src/apps/mod.rs`, and its manual entry (`configurator/src/components/ManualTab.tsx` / `manual/Apps.tsx`) |
 | **App fix** | Only the existing app's own file(s) under `faderpunk/src/apps/` |
 | **Firmware core** | Core firmware files outside `apps/` (e.g. `app.rs`, `layout.rs`, `tasks/*`, `memory.x`, `.cargo/config.toml`) |
 | **Configurator** | Files under `configurator/` |


### PR DESCRIPTION
## Summary
Closes #656.

`CONTRIBUTING.md`'s "New app" category and `pr-scope-check.sh`'s `is_manual_file()` both accepted `docs/apps/<id>-<name>/manual.{md,json}` as a sanctioned alternative to a `ManualTab.tsx`/`manual/Apps.tsx` entry. That was based on an unverified assumption (kosmar was using this shape across many PRs, so it looked like an intentional convention shift) — it isn't. `docs/apps/` doesn't exist on `main`, and nothing in the configurator (no generator, no build step, no component) reads `manual.json`/`manual.md`. Confirmed live against `#606`: it only has a `docs/apps/32-super-lfo/manual.*` entry and is invisible on the configurator's `/#/manual` page as a result.

Removed the option from both places. `ManualTab.tsx`/`manual/Apps.tsx` is now the only sanctioned path — matching the *original* spec from this policy's first ground-truth example (`#573`).

## Validation
- Full 16-fixture regression suite (`pr-scope-check.test.sh`) still passes.
- Re-checked the real `#629` fixture (which uses `docs/apps/40-venn/manual.*`): now correctly soft-flags "no manual entry found" instead of silently passing.

## Follow-up, not part of this PR
Contributors using the `docs/apps/*` shape (kosmar, ~18 PRs) will need to either add a proper `ManualTab.tsx` entry or wait — that's a separate conversation with them, not something this PR does.