### PR TITLE
fix: improve I2C control and panner output

### DIFF
--- a/.github/scripts/pr-scope-check.sh
+++ b/.github/scripts/pr-scope-check.sh
@@ -241,7 +241,7 @@ BANNED_PATTERNS=(
   'migrate_fram' 'factory_reset'
   'MAX_CHANNEL' 'MaxCmd' 'MaxSender' 'crate::tasks::max' 'super::tasks::max'
   'APP_MIDI_CHANNEL' 'MIDI_CHANNEL' 'MIDI_USB_PUBSUB' 'MIDI_DIN_PUBSUB' 'crate::tasks::midi'
-  'I2C_LEADER_CHANNEL' 'I2C_FOLLOWER_CHANNEL' 'crate::tasks::i2c'
+  'I2C_LEADER_PUBLISHER' 'I2C_LEADER_CHANNEL' 'I2C_FOLLOWER_CHANNEL' 'crate::tasks::i2c'
   'BUTTON_PRESSED' 'crate::tasks::buttons'
   'CLOCK_PUBSUB' 'TICK_COUNTER' 'CLOCK_IN_CHANNEL' 'TRANSPORT_CMD_CHANNEL' 'SYNC_ENGINE_CHANNEL' 'crate::tasks::clock'
   'GLOBAL_CONFIG_WATCH' 'set_global_config_via_chan' 'crate::tasks::global_config'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,9 @@ has unit tests (`cargo test --lib -p libfp`) — run them when you touch it.
 - **Command Channels**: Apps send commands to hardware tasks via async channels:
   - `MAX_CHANNEL` - Control CV jacks (ADC/DAC configuration, set values)
   - `APP_MIDI_CHANNEL` - Send MIDI messages
-  - `I2C_LEADER_CHANNEL` - Send I2C messages
+  - `I2C_LEADER_PUBLISHER` - Publish I2C controller values; not a queue — each
+    physical channel keeps only its latest unsent value, so a newer publish
+    overwrites an older one that hasn't gone out yet
 - **Watch Channels**: Global state synchronization:
   - `LAYOUT_WATCH` - Current channel layout
   - `GLOBAL_CONFIG_WATCH` - Device configuration

--- a/README.md
+++ b/README.md
@@ -287,9 +287,12 @@ Apps implement scene save/load by serializing their state with `postcard`.
 - Full MIDI message support via `midly` crate
 
 ### I2C
-- 16n faderbank protocol support
-- Eurorack module integration
-- Configurable addressing
+- External 400 kHz leader bus for Ansible, ER-301-compatible, and TXo devices
+- disting NT controller support when its configurable follower address is set to `0x31`
+- Latest-value delivery for Control and Panner app outputs
+
+See [I²C integration](docs/i2c.md) for wiring requirements, recognized addresses,
+message formats, app behavior, and startup discovery details.
 
 ### WebUSB
 - COBS framing for reliable packet transmission

--- a/configurator/src/components/manual/Configurator.tsx
+++ b/configurator/src/components/manual/Configurator.tsx
@@ -289,9 +289,20 @@ export const Configurator = () => (
     <H4 id="settings-i2c">I²C Configuration</H4>
     <p>
       Faderpunk can operate as either a <strong>Leader</strong> or{" "}
-      <strong>Follower</strong> on the I²C bus.
-      <br />
-      You can set this behavior in the Settings tab.
+      <strong>Follower</strong> on the I²C bus. You can set this behavior in the
+      Settings tab; reboot Faderpunk after changing it.
+    </p>
+    <p>
+      Leader mode discovers supported followers once, 10 seconds after startup,
+      and requires pull-up resistors on SDA and SCL. Only apps with an I²C
+      output—currently <strong>Control</strong> and <strong>Panner</strong>—send
+      controller values; faders are not broadcast automatically.
+    </p>
+    <p>
+      To control a disting NT, configure the NT&apos;s follower address as{" "}
+      <code>0x31</code>. Faderpunk then uses the ER-301-compatible{" "}
+      <code>0x11</code> controller message supported by the NT. The NT address
+      is configurable and is not always <code>0x31</code>.
     </p>
 
     <H4 id="settings-aux">AUX Jacks</H4>

--- a/docs/i2c.md
+++ b/docs/i2c.md
@@ -1,0 +1,75 @@
+# I²C integration
+
+Faderpunk uses its external I²C bus as a leader by default. The bus runs at
+400 kHz on GPIO 21 (SCL) and GPIO 20 (SDA). This bus is separate from the
+internal I²C bus used for FRAM storage.
+
+## Electrical requirements
+
+I²C requires pull-up resistors on both SDA and SCL. Enable one suitable set of
+pull-ups on the bus—for example, the configurable pull-ups on a disting NT—if
+no other connected device supplies them. Missing pull-ups can cause intermittent
+messages, NACKs, or a stuck bus.
+
+Power followers before Faderpunk. In leader mode, Faderpunk waits 10 seconds
+and then scans the bus once. Devices connected or enabled after that scan are
+not discovered until Faderpunk is rebooted.
+
+Changing the I²C mode in the configurator is persisted immediately, but the bus
+mode is selected only at startup, so the change requires a reboot.
+
+## Recognized follower addresses
+
+Faderpunk probes the complete normal I²C address range but sends controller
+updates only when it discovers a recognized address:
+
+| Address | Compatibility |
+| --- | --- |
+| `0x20` | monome Ansible |
+| `0x31` | ER-301-compatible controller messages |
+| `0x60`–`0x67` | TXo/Telexo device range |
+
+For its 16 channels, current TXo routing sends to addresses `0x60`–`0x63`, with
+four controller ports per address.
+
+### disting NT compatibility
+
+A disting NT can use the ER-301-compatible path. Configure the NT's follower
+address as `0x31`, then map its I²C controllers to the desired parameters.
+Faderpunk sends this four-byte payload to that address:
+
+```text
+0x11 <controller> <value MSB> <value LSB>
+```
+
+The disting NT documents `0x11` as “set I²C controller X to value Y,” so it
+accepts the same message that Faderpunk sends for an ER-301. The NT's follower
+address is configurable: `0x31` is the compatibility setting used here, not an
+address permanently assigned to every NT. Do not place another `0x31` follower
+on the same bus.
+
+Controller numbers are zero-based physical Faderpunk channel numbers. Values
+are scaled from Faderpunk's `0`–`4095` range to `0`–`16383`.
+
+## Apps that produce controller messages
+
+I²C leader mode does not automatically transmit every physical fader. Apps must
+explicitly publish an I²C output:
+
+- **Control** sends its processed controller value on its physical channel.
+- **Panner** sends its processed left and right outputs on its two physical
+  channels. This includes pan modulation, attenuation, mute, and slew.
+
+Other apps do not currently produce I²C controller messages.
+
+Continuous controller updates use latest-value semantics. Each physical channel
+has at most one pending value; a newer value replaces an older value that has
+not yet been transmitted. This prevents stale movement from playing out after
+the fader stops and ensures that the final position is not discarded merely
+because an update queue filled.
+
+## Other modes
+
+Normal follower mode at address `0x56` is currently unimplemented. Calibration
+mode is a separate follower protocol at address `0x57`, using Postcard-encoded
+commands for ADC, DAC, and calibration operations.

--- a/docs/i2c.md
+++ b/docs/i2c.md
@@ -48,8 +48,10 @@ address is configurable: `0x31` is the compatibility setting used here, not an
 address permanently assigned to every NT. Do not place another `0x31` follower
 on the same bus.
 
-Controller numbers are zero-based physical Faderpunk channel numbers. Values
-are scaled from Faderpunk's `0`–`4095` range to `0`–`16383`.
+For the ER-301/TXo path, controller numbers are zero-based physical Faderpunk
+channel numbers, and values are scaled from Faderpunk's `0`–`4095` range to
+`0`–`16383`. Ansible's addressing and value scaling differ and are not yet
+documented here.
 
 ## Apps that produce controller messages
 

--- a/faderpunk/src/app.rs
+++ b/faderpunk/src/app.rs
@@ -25,7 +25,7 @@ use crate::{
         buttons::{is_channel_button_pressed, is_shift_button_pressed},
         clock::{ClockSubscriber, CLOCK_PUBSUB},
         global_config::get_global_config,
-        i2c::{I2cLeaderMessage, I2cLeaderSender},
+        i2c::I2cLeaderPublisher,
         leds::{set_led_mode, LedMsg},
         max::{MaxCmd, MaxSender, MAX_CHANNEL, MAX_VALUES_ADC, MAX_VALUES_DAC, MAX_VALUES_FADER},
         midi::{
@@ -340,24 +340,22 @@ pub enum SceneEvent {
 
 #[derive(Clone, Copy)]
 pub struct I2cOutput<const N: usize> {
-    i2c_sender: I2cLeaderSender,
+    i2c_publisher: I2cLeaderPublisher,
     start_channel: usize,
 }
 
 impl<const N: usize> I2cOutput<N> {
-    pub fn new(start_channel: usize, i2c_sender: I2cLeaderSender) -> Self {
+    pub fn new(start_channel: usize, i2c_publisher: I2cLeaderPublisher) -> Self {
         Self {
-            i2c_sender,
+            i2c_publisher,
             start_channel,
         }
     }
 
     pub fn send_fader_value(&self, chan: usize, value: u16, range: Range) {
         let chan = chan.clamp(0, N - 1);
-        let msg = I2cLeaderMessage::FaderValue(self.start_channel + chan, value, range);
-        // Use try_send to avoid blocking the caller if the I2C channel is full.
-        // Dropping occasional updates is fine — the next update will send the current value.
-        let _ = self.i2c_sender.try_send(msg);
+        self.i2c_publisher
+            .publish(self.start_channel + chan, value, range);
     }
 }
 
@@ -675,7 +673,7 @@ pub struct App<const N: usize> {
     pub start_channel: usize,
     pub layout_id: u8,
     event_pubsub: &'static EventPubSubChannel,
-    i2c_sender: I2cLeaderSender,
+    i2c_publisher: I2cLeaderPublisher,
     max_sender: MaxSender,
     midi_sender: AppMidiSender,
     midi_din_pubsub: &'static MidiPubSubChannel,
@@ -689,7 +687,7 @@ impl<const N: usize> App<N> {
         start_channel: usize,
         layout_id: u8,
         event_pubsub: &'static EventPubSubChannel,
-        i2c_sender: I2cLeaderSender,
+        i2c_publisher: I2cLeaderPublisher,
         max_sender: MaxSender,
         midi_sender: AppMidiSender,
         midi_din_pubsub: &'static MidiPubSubChannel,
@@ -698,7 +696,7 @@ impl<const N: usize> App<N> {
         Self {
             app_id,
             event_pubsub,
-            i2c_sender,
+            i2c_publisher,
             layout_id,
             max_sender,
             midi_sender,
@@ -827,7 +825,7 @@ impl<const N: usize> App<N> {
     }
 
     pub fn use_i2c_output(&self) -> I2cOutput<N> {
-        I2cOutput::new(self.start_channel, self.i2c_sender)
+        I2cOutput::new(self.start_channel, self.i2c_publisher)
     }
 
     pub async fn wait_for_scene_event(&self) -> SceneEvent {

--- a/faderpunk/src/apps/panner.rs
+++ b/faderpunk/src/apps/panner.rs
@@ -6,6 +6,7 @@ use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
 use heapless::Vec;
 use libfp::{
     ext::FromValue,
+    i2c_proto::OutputChangeTracker,
     latch::LatchLayer,
     utils::{attenuate_bipolar, clickless, midi_gate, slew_exp, split_unsigned_value, SlewState},
     AppIcon, Brightness, Color, MidiCc, MidiChannel, MidiOut, Waveform, APP_MAX_PARAMS,
@@ -212,7 +213,6 @@ pub async fn run(
     let i2c = app.use_i2c_output();
 
     let muted_glob = app.make_global(storage.query(|s| s.muted));
-    let output_glob = app.make_global(0);
     let latch_layer_glob = app.make_global(LatchLayer::Main);
     let glob_lfo_speed = app.make_global(0.0682);
 
@@ -249,6 +249,7 @@ pub async fn run(
         let mut out_r = SlewState::new();
         let mut out_l = SlewState::new();
         let mut last_out: [u16; 2] = [u16::MAX, u16::MAX];
+        let mut i2c_changes = OutputChangeTracker::<2>::new();
 
         let mut val_left = 0;
         let mut val_right = 0;
@@ -373,6 +374,16 @@ pub async fn run(
             // Output to jacks
             jacks[0].set_value(out_l_val);
             jacks[1].set_value(out_r_val);
+
+            for (channel, value) in i2c_changes
+                .changed([out_l_val, out_r_val])
+                .into_iter()
+                .enumerate()
+            {
+                if let Some(value) = value {
+                    i2c.send_fader_value(channel, value, range);
+                }
+            }
 
             if midi_out.is_some() {
                 let gate_l = midi_gate(out_l_val, nrpn);
@@ -519,18 +530,9 @@ pub async fn run(
         let mut latch = app.make_latch(faders.get_value_at(1));
         loop {
             let chan = faders.wait_for_any_change().await;
-            if chan == 0 {
-                match latch_layer_glob.get() {
-                    LatchLayer::Main => {
-                        let out = output_glob.get();
-                        i2c.send_fader_value(0, out, range);
-                    }
-                    LatchLayer::Alt => {
-                        // Now we commit to storage
-                        storage.save().await;
-                    }
-                    LatchLayer::Third => {}
-                }
+            if chan == 0 && latch_layer_glob.get() == LatchLayer::Alt {
+                // Now we commit to storage
+                storage.save().await;
             }
             if chan == 1 {
                 let target_value = match latch_layer_glob.get() {

--- a/faderpunk/src/macros.rs
+++ b/faderpunk/src/macros.rs
@@ -10,7 +10,7 @@ macro_rules! register_apps {
         };
 
         use libfp::ConfigMeta;
-        use crate::{I2C_LEADER_CHANNEL, MAX_CHANNEL, APP_MIDI_CHANNEL};
+        use crate::{I2C_LEADER_PUBLISHER, MAX_CHANNEL, APP_MIDI_CHANNEL};
         use crate::{app::App, events::EVENT_PUBSUB, tasks::midi::{MIDI_DIN_PUBSUB, MIDI_USB_PUBSUB}};
         use embassy_executor::Spawner;
 
@@ -41,7 +41,7 @@ macro_rules! register_apps {
                             start_channel,
                             layout_id,
                             &EVENT_PUBSUB,
-                            I2C_LEADER_CHANNEL.sender(),
+                            I2C_LEADER_PUBLISHER,
                             MAX_CHANNEL.sender(),
                             APP_MIDI_CHANNEL.sender(),
                             &MIDI_DIN_PUBSUB,

--- a/faderpunk/src/main.rs
+++ b/faderpunk/src/main.rs
@@ -52,7 +52,7 @@ use tasks::{
     buttons::{is_channel_button_pressed, is_scene_button_pressed},
     fram::MAX_DATA_LEN,
     global_config::GLOBAL_CONFIG_WATCH,
-    i2c::I2C_LEADER_CHANNEL,
+    i2c::I2C_LEADER_PUBLISHER,
     max::MAX_CHANNEL,
     midi::{midi_distributor, APP_MIDI_CHANNEL},
 };

--- a/faderpunk/src/tasks/i2c.rs
+++ b/faderpunk/src/tasks/i2c.rs
@@ -24,10 +24,10 @@ use portable_atomic::Ordering;
 use libfp::{
     i2c_proto::{
         DeviceStatus, ErrorCode, FaderUpdate, PendingFaderUpdates, Response, WriteCommand,
-        WriteReadCommand, I2C_FADER_CHANNELS, MAX_MESSAGE_SIZE,
+        WriteReadCommand, MAX_MESSAGE_SIZE,
     },
     types::{RegressionValuesInput, RegressionValuesOutput},
-    I2cMode, Range, I2C_ADDRESS_CALIBRATION,
+    I2cMode, Range, GLOBAL_CHANNELS, I2C_ADDRESS_CALIBRATION,
 };
 use postcard::{from_bytes, to_slice};
 
@@ -69,7 +69,7 @@ impl I2cLeaderPublisher {
     }
 }
 
-fn take_pending_updates() -> [Option<FaderUpdate>; I2C_FADER_CHANNELS] {
+fn take_pending_updates() -> [Option<FaderUpdate>; GLOBAL_CHANNELS] {
     I2C_PENDING_UPDATES.lock(|pending| pending.borrow_mut().take_all())
 }
 

--- a/faderpunk/src/tasks/i2c.rs
+++ b/faderpunk/src/tasks/i2c.rs
@@ -1,11 +1,17 @@
+use core::cell::RefCell;
+
 use defmt::{error, info};
 use embassy_executor::Spawner;
 use embassy_rp::i2c::{self, Async};
 use embassy_rp::i2c_slave::{self, Command, I2cSlave};
 use embassy_rp::peripherals::{I2C0, PIN_20, PIN_21};
 use embassy_rp::Peri;
-use embassy_sync::blocking_mutex::raw::{CriticalSectionRawMutex, ThreadModeRawMutex};
+use embassy_sync::blocking_mutex::{
+    raw::{CriticalSectionRawMutex, ThreadModeRawMutex},
+    Mutex,
+};
 use embassy_sync::channel::{Channel, Receiver, Sender};
+use embassy_sync::signal::Signal;
 use embassy_time::Timer;
 use embedded_hal_async::i2c::I2c;
 use max11300::config::{ConfigMode5, ConfigMode7, Mode, Port, AVR, NSAMPLES};
@@ -17,7 +23,8 @@ use portable_atomic::Ordering;
 
 use libfp::{
     i2c_proto::{
-        DeviceStatus, ErrorCode, Response, WriteCommand, WriteReadCommand, MAX_MESSAGE_SIZE,
+        DeviceStatus, ErrorCode, FaderUpdate, PendingFaderUpdates, Response, WriteCommand,
+        WriteReadCommand, I2C_FADER_CHANNELS, MAX_MESSAGE_SIZE,
     },
     types::{RegressionValuesInput, RegressionValuesOutput},
     I2cMode, Range, I2C_ADDRESS_CALIBRATION,
@@ -42,20 +49,29 @@ pub enum I2cFollowerMessage {
     ChannelUpdate(usize),
 }
 
-pub enum I2cLeaderMessage {
-    FaderValue(usize, u16, Range),
-}
-
-const I2C_LEADER_CHANNEL_SIZE: usize = 16;
 const I2C_FOLLOWER_CHANNEL_SIZE: usize = 8;
 
-pub static I2C_LEADER_CHANNEL: Channel<
-    CriticalSectionRawMutex,
-    I2cLeaderMessage,
-    I2C_LEADER_CHANNEL_SIZE,
-> = Channel::new();
-pub type I2cLeaderSender =
-    Sender<'static, CriticalSectionRawMutex, I2cLeaderMessage, I2C_LEADER_CHANNEL_SIZE>;
+static I2C_PENDING_UPDATES: Mutex<CriticalSectionRawMutex, RefCell<PendingFaderUpdates>> =
+    Mutex::new(RefCell::new(PendingFaderUpdates::new()));
+static I2C_UPDATE_SIGNAL: Signal<CriticalSectionRawMutex, ()> = Signal::new();
+
+#[derive(Clone, Copy)]
+pub struct I2cLeaderPublisher;
+
+pub const I2C_LEADER_PUBLISHER: I2cLeaderPublisher = I2cLeaderPublisher;
+
+impl I2cLeaderPublisher {
+    pub fn publish(&self, channel: usize, value: u16, range: Range) {
+        I2C_PENDING_UPDATES.lock(|pending| {
+            pending.borrow_mut().publish(channel, value, range);
+        });
+        I2C_UPDATE_SIGNAL.signal(());
+    }
+}
+
+fn take_pending_updates() -> [Option<FaderUpdate>; I2C_FADER_CHANNELS] {
+    I2C_PENDING_UPDATES.lock(|pending| pending.borrow_mut().take_all())
+}
 
 pub static I2C_FOLLOWER_CHANNEL: Channel<
     ThreadModeRawMutex,
@@ -326,7 +342,11 @@ async fn run_i2c_leader(mut i2c: i2c::I2c<'static, I2C0, Async>) {
     let mut compat16n = Compat16N::new(&mut i2c).await;
 
     loop {
-        let I2cLeaderMessage::FaderValue(chan, value, range) = I2C_LEADER_CHANNEL.receive().await;
-        compat16n.handle_fader_update(chan, value, range).await;
+        I2C_UPDATE_SIGNAL.wait().await;
+        for update in take_pending_updates().into_iter().flatten() {
+            compat16n
+                .handle_fader_update(update.channel, update.value, update.range)
+                .await;
+        }
     }
 }

--- a/libfp/src/i2c_proto.rs
+++ b/libfp/src/i2c_proto.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     types::{RegressionValuesInput, RegressionValuesOutput},
-    Range,
+    Range, GLOBAL_CHANNELS,
 };
 
 /// Maximum size of a serialized message in bytes.
@@ -68,8 +68,6 @@ pub enum ErrorCode {
     MeasurementFailed,
 }
 
-pub const I2C_FADER_CHANNELS: usize = 16;
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct FaderUpdate {
     pub channel: usize,
@@ -88,13 +86,13 @@ impl FaderUpdate {
 }
 
 pub struct PendingFaderUpdates {
-    updates: [Option<FaderUpdate>; I2C_FADER_CHANNELS],
+    updates: [Option<FaderUpdate>; GLOBAL_CHANNELS],
 }
 
 impl PendingFaderUpdates {
     pub const fn new() -> Self {
         Self {
-            updates: [None; I2C_FADER_CHANNELS],
+            updates: [None; GLOBAL_CHANNELS],
         }
     }
 
@@ -104,8 +102,8 @@ impl PendingFaderUpdates {
         }
     }
 
-    pub fn take_all(&mut self) -> [Option<FaderUpdate>; I2C_FADER_CHANNELS] {
-        core::mem::replace(&mut self.updates, [None; I2C_FADER_CHANNELS])
+    pub fn take_all(&mut self) -> [Option<FaderUpdate>; GLOBAL_CHANNELS] {
+        core::mem::replace(&mut self.updates, [None; GLOBAL_CHANNELS])
     }
 }
 

--- a/libfp/src/i2c_proto.rs
+++ b/libfp/src/i2c_proto.rs
@@ -67,3 +67,79 @@ pub enum ErrorCode {
     InvalidChannel,
     MeasurementFailed,
 }
+
+pub const I2C_FADER_CHANNELS: usize = 16;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FaderUpdate {
+    pub channel: usize,
+    pub value: u16,
+    pub range: Range,
+}
+
+impl FaderUpdate {
+    pub const fn new(channel: usize, value: u16, range: Range) -> Self {
+        Self {
+            channel,
+            value,
+            range,
+        }
+    }
+}
+
+pub struct PendingFaderUpdates {
+    updates: [Option<FaderUpdate>; I2C_FADER_CHANNELS],
+}
+
+impl PendingFaderUpdates {
+    pub const fn new() -> Self {
+        Self {
+            updates: [None; I2C_FADER_CHANNELS],
+        }
+    }
+
+    pub fn publish(&mut self, channel: usize, value: u16, range: Range) {
+        if let Some(slot) = self.updates.get_mut(channel) {
+            *slot = Some(FaderUpdate::new(channel, value, range));
+        }
+    }
+
+    pub fn take_all(&mut self) -> [Option<FaderUpdate>; I2C_FADER_CHANNELS] {
+        core::mem::replace(&mut self.updates, [None; I2C_FADER_CHANNELS])
+    }
+}
+
+impl Default for PendingFaderUpdates {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pending_fader_updates_keep_only_the_latest_value_per_channel() {
+        let mut pending = PendingFaderUpdates::new();
+
+        pending.publish(3, 100, Range::_0_10V);
+        pending.publish(3, 900, Range::_Neg5_5V);
+
+        let updates = pending.take_all();
+        assert_eq!(updates[3], Some(FaderUpdate::new(3, 900, Range::_Neg5_5V)));
+        assert!(pending.take_all().iter().all(Option::is_none));
+    }
+
+    #[test]
+    fn pending_fader_updates_retain_different_channels_independently() {
+        let mut pending = PendingFaderUpdates::new();
+
+        pending.publish(2, 200, Range::_0_10V);
+        pending.publish(11, 1100, Range::_0_5V);
+
+        let updates = pending.take_all();
+        assert_eq!(updates[2], Some(FaderUpdate::new(2, 200, Range::_0_10V)));
+        assert_eq!(updates[11], Some(FaderUpdate::new(11, 1100, Range::_0_5V)));
+    }
+}

--- a/libfp/src/i2c_proto.rs
+++ b/libfp/src/i2c_proto.rs
@@ -115,6 +115,35 @@ impl Default for PendingFaderUpdates {
     }
 }
 
+pub struct OutputChangeTracker<const N: usize> {
+    previous: [Option<u16>; N],
+}
+
+impl<const N: usize> OutputChangeTracker<N> {
+    pub const fn new() -> Self {
+        Self {
+            previous: [None; N],
+        }
+    }
+
+    pub fn changed(&mut self, values: [u16; N]) -> [Option<u16>; N] {
+        core::array::from_fn(|index| {
+            if self.previous[index] == Some(values[index]) {
+                None
+            } else {
+                self.previous[index] = Some(values[index]);
+                Some(values[index])
+            }
+        })
+    }
+}
+
+impl<const N: usize> Default for OutputChangeTracker<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -141,5 +170,14 @@ mod tests {
         let updates = pending.take_all();
         assert_eq!(updates[2], Some(FaderUpdate::new(2, 200, Range::_0_10V)));
         assert_eq!(updates[11], Some(FaderUpdate::new(11, 1100, Range::_0_5V)));
+    }
+
+    #[test]
+    fn output_change_tracker_reports_both_panner_outputs_and_suppresses_duplicates() {
+        let mut tracker = OutputChangeTracker::<2>::new();
+
+        assert_eq!(tracker.changed([1200, 2800]), [Some(1200), Some(2800)]);
+        assert_eq!(tracker.changed([1200, 2800]), [None, None]);
+        assert_eq!(tracker.changed([1300, 2800]), [Some(1300), None]);
     }
 }


### PR DESCRIPTION
## Category

- [ ] New app
- [ ] App fix
- [x] Firmware core
- [ ] Configurator
- [ ] Protocol (libfp)
- [ ] Docs
- [ ] CI / tooling
- [ ] Other (explain below)

## Type

- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Description

Faderpunk currently stores I2C controller changes in a 16-message FIFO. During continuous movement, that queue can fill with positions that are already obsolete. The result can be delayed movement after the fader has stopped, while the final—and most useful—position may be dropped.

This PR replaces that FIFO with one pending value per physical channel. If a channel changes again before its previous value is sent, the newer value replaces it. Different channels remain independent, so continuous controls stay responsive without replaying stale movement.

It also finishes Panner's existing I2C output. Panner previously read a shared value that was initialized to zero and never updated, so it always transmitted zero. It now sends its processed left and right outputs on its two physical channels, including manual pan, autopan, attenuation, mute, and slew.

The documentation now explains the electrical requirements, one-time startup discovery, recognized addresses, and app-specific output behavior. It also documents disting NT compatibility accurately: the NT's follower address is configurable, and setting it to `0x31` lets Faderpunk use the ER-301-compatible `0x11` controller message that the NT supports.

### Scope

The primary category is firmware core. The PR also touches Panner as an existing consumer, `libfp` to keep the coalescing policy host-testable, and the user-facing I2C documentation. Panner continues to access I2C exclusively through the `App<N>` facade; it does not reach into the hardware task directly.

Bus recovery after an electrical fault is not changed here.

## Scope acknowledgement

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)'s PR Scope Categories table. The related cross-category changes are explained above.

## Verification

- [x] Tested on actual hardware / in the configurator with a live device

Automated checks:

- `cargo fmt --all -- --check`
- `cargo clippy --bin faderpunk --target thumbv8m.main-none-eabihf -- -D warnings`
- `cargo clippy -p libfp -- -D warnings`
- `cargo test --lib -p libfp`
- `pnpm -C configurator lint`
- `pnpm -C configurator build`

Hardware verification with a disting NT configured as an I2C follower at `0x31`:

- Rapid Control movement reaches the latest position without stale catch-up.
- Panner sends both processed outputs.
- Manual pan and autopan modulation update the mapped NT parameters.
