### PR TITLE
fix: turing mute ignores gate/MIDI outputs

### DIFF
--- a/faderpunk/src/apps/clkturing.rs
+++ b/faderpunk/src/apps/clkturing.rs
@@ -243,10 +243,9 @@ pub async fn run(
                     * curve.at(storage.query(|s| s.att_saved)) as u32
                     / 4095) as u16;
 
-                let out = quantizer.get_quantized_note(att_reg).await;
-
                 let muted = glob_muted.get();
                 if !muted {
+                    let out = quantizer.get_quantized_note(att_reg).await;
                     output.set_value(pitch_as_counts(out, range, vpo));
                     leds.set(
                         0,
@@ -342,6 +341,9 @@ pub async fn run(
                     });
                     if muted {
                         leds.unset(1, Led::Button);
+                        if midi_mode == MidiMode::Note {
+                            midi.send_note_off(midi_note.get()).await;
+                        }
                     } else {
                         leds.set(1, Led::Button, led_color, Brightness::Mid);
                     }

--- a/faderpunk/src/apps/turing.rs
+++ b/faderpunk/src/apps/turing.rs
@@ -314,49 +314,52 @@ pub async fn run(
                             * curve.at(storage.query(|s| s.att_saved)) as u32)
                             / 4095) as u16;
 
+                        let muted = glob_muted.get();
                         if gate_out {
-                            let gate_fires = if storage.query(|s| s.gate_threshold_mode) {
-                                register_scaled < storage.query(|s| s.att_saved)
-                            } else {
-                                gate_bit
-                            };
-                            if gate_fires {
-                                gate_jack.as_ref().unwrap().set_high().await;
-                                leds.set(0, Led::Top, led_color, Brightness::High);
-                            } else {
+                            if muted {
                                 gate_jack.as_ref().unwrap().set_low().await;
                                 leds.set(0, Led::Top, led_color, Brightness::Off);
-                            }
-                            match midi_mode {
-                                MidiMode::Note => {
-                                    if gate_fires {
-                                        let note = midi_note.set(base_note);
-                                        midi.send_note_on(note, 4095).await;
-                                    }
+                            } else {
+                                let gate_fires = if storage.query(|s| s.gate_threshold_mode) {
+                                    register_scaled < storage.query(|s| s.att_saved)
+                                } else {
+                                    gate_bit
+                                };
+                                if gate_fires {
+                                    gate_jack.as_ref().unwrap().set_high().await;
+                                    leds.set(0, Led::Top, led_color, Brightness::High);
+                                } else {
+                                    gate_jack.as_ref().unwrap().set_low().await;
+                                    leds.set(0, Led::Top, led_color, Brightness::Off);
                                 }
-                                MidiMode::Cc => {
-                                    midi.send_cc(midi_cc, att_reg).await;
-                                }
-                            }
-                        } else {
-                            let out = quantizer.get_quantized_note(att_reg).await;
-                            let muted = glob_muted.get();
-                            if !muted {
-                                cv_jack.as_ref().unwrap().set_value(pitch_as_counts(out, range, vpo));
-                                leds.set(
-                                    0,
-                                    Led::Top,
-                                    led_color,
-                                    Brightness::Custom((register_scaled / 16) as u8),
-                                );
                                 match midi_mode {
                                     MidiMode::Note => {
-                                        let note = midi_note.set(out.as_midi() + base_note);
-                                        midi.send_note_on(note, 4095).await;
+                                        if gate_fires {
+                                            let note = midi_note.set(base_note);
+                                            midi.send_note_on(note, 4095).await;
+                                        }
                                     }
                                     MidiMode::Cc => {
                                         midi.send_cc(midi_cc, att_reg).await;
                                     }
+                                }
+                            }
+                        } else if !muted {
+                            let out = quantizer.get_quantized_note(att_reg).await;
+                            cv_jack.as_ref().unwrap().set_value(pitch_as_counts(out, range, vpo));
+                            leds.set(
+                                0,
+                                Led::Top,
+                                led_color,
+                                Brightness::Custom((register_scaled / 16) as u8),
+                            );
+                            match midi_mode {
+                                MidiMode::Note => {
+                                    let note = midi_note.set(out.as_midi() + base_note);
+                                    midi.send_note_on(note, 4095).await;
+                                }
+                                MidiMode::Cc => {
+                                    midi.send_cc(midi_cc, att_reg).await;
                                 }
                             }
                         }
@@ -448,6 +451,13 @@ pub async fn run(
                     });
                     if muted {
                         leds.unset(0, Led::Button);
+                        if gate_out {
+                            gate_jack.as_ref().unwrap().set_low().await;
+                            leds.set(0, Led::Top, led_color, Brightness::Off);
+                        }
+                        if midi_mode == MidiMode::Note {
+                            midi.send_note_off(midi_note.get()).await;
+                        }
                     } else {
                         leds.set(0, Led::Button, led_color, Brightness::Mid);
                     }


### PR DESCRIPTION
## Summary
- Mute only wrapped the CV pitch path; with Gate Out enabled, gates and MIDI kept firing while the button LED showed muted.
- Gate Out now respects mute (forces gate low while muted), and muting immediately releases a held gate / note-off.

## Test plan
- [ ] Load Turing, enable Gate Out, short-press mute — gate jack stays low and MIDI notes stop
- [ ] Mute in CV mode — no new pitch/MIDI on clock; unmute resumes
- [ ] Mute while a gate is high — gate drops and note-off fires immediately


Made with [Cursor](https://cursor.com)