### PR TITLE
feat(routing): internal digital patchbay and routing engine

### DIFF
--- a/configurator/src/components/ConfiguratorPage.tsx
+++ b/configurator/src/components/ConfiguratorPage.tsx
@@ -15,6 +15,8 @@ import { SettingsTab } from "./SettingsTab";
 import { EditLayoutModal } from "./EditLayoutModal";
 import { ManualTab } from "./ManualTab";
 
+import { PatchbayTab } from "./PatchbayTab";
+
 const ConfiguratorPageContent = () => {
   const { apps, config, setLayout, layout, device, isSimulator } = useStore();
   const { modalConfig, setModalConfig } = useModalContext();
@@ -69,6 +71,9 @@ const ConfiguratorPageContent = () => {
         >
           <Tab key="device" title="Device">
             <DeviceTab layout={layout} />
+          </Tab>
+          <Tab key="patchbay" title="Patchbay">
+            <PatchbayTab />
           </Tab>
           <Tab key="apps" title="Apps">
             <AppsTab apps={apps} layout={layout} />

--- a/configurator/src/components/ManualTab.tsx
+++ b/configurator/src/components/ManualTab.tsx
@@ -1666,6 +1666,9 @@ export const ManualTab = () => {
                 <Link to="#apps-tab">Apps Tab</Link>
               </li>
               <li>
+                <Link to="#patchbay-tab">Patchbay Tab</Link>
+              </li>
+              <li>
                 <Link to="#settings-tab">Settings Tab</Link>
                 <List>
                   <li>

--- a/configurator/src/components/PatchbayTab.tsx
+++ b/configurator/src/components/PatchbayTab.tsx
@@ -12,6 +12,7 @@ import { Slider } from "@heroui/slider";
 import { Switch } from "@heroui/switch";
 import { Tabs, Tab } from "@heroui/tabs";
 import { useStore } from "../store";
+import type { AppSlot } from "../utils/types";
 import { routing } from "@atov/fp-config";
 
 type DestCategory = "PhysicalDac" | "AppInput" | "AppFader";
@@ -28,9 +29,13 @@ const COMBINE_MODES: { label: string; modeTag: routing.CombineMode["tag"] }[] =
     { label: "Replace / Override", modeTag: "Replace" },
   ];
 
+// App IDs known to process software CV/gate input signals
+const INPUT_CAPABLE_APP_IDS = [1, 5, 6, 14, 18, 21, 22, 23, 24, 28, 29, 30];
+
 export const PatchbayTab = () => {
   const { routing: routingState, setRouting, layout } = useStore();
   const [destCategory, setDestCategory] = useState<DestCategory>("PhysicalDac");
+  const [showAllChannels, setShowAllChannels] = useState<boolean>(false);
   const [selectedRouteIdx, setSelectedRouteIdx] = useState<number | null>(null);
   const [editingRoute, setEditingRoute] = useState<routing.Route | null>(null);
 
@@ -39,12 +44,66 @@ export const PatchbayTab = () => {
     | undefined
   )[];
 
+  const getSlotForChannel = (channel: number): AppSlot | undefined => {
+    if (!layout) return undefined;
+    return layout.find(
+      (s) =>
+        s.startChannel <= channel &&
+        channel < s.startChannel + Number(s.app?.channels ?? 1),
+    );
+  };
+
   const getAppName = (channel: number) => {
-    if (!layout) return `Ch ${channel + 1}`;
-    const slot = layout.find((s) => s.startChannel === channel);
+    const slot = getSlotForChannel(channel);
     return slot?.app
       ? `${slot.app.name} (Ch ${channel + 1})`
       : `Ch ${channel + 1}`;
+  };
+
+  const appHasVirtualInput = (channel: number) => {
+    const slot = getSlotForChannel(channel);
+    if (!slot?.app) return false;
+    return INPUT_CAPABLE_APP_IDS.includes(slot.app.appId);
+  };
+
+  const getActiveSourceChannels = (): number[] => {
+    if (showAllChannels || !layout)
+      return Array.from({ length: 16 }, (_, i) => i);
+    return Array.from({ length: 16 }, (_, i) => i).filter((ch) => {
+      const slot = getSlotForChannel(ch);
+      return Boolean(slot?.app);
+    });
+  };
+
+  const getActiveDestChannels = (category: DestCategory): number[] => {
+    if (category === "PhysicalDac") {
+      // Physical CV Out jacks 1..16 are always available
+      return Array.from({ length: 16 }, (_, i) => i);
+    }
+    if (showAllChannels || !layout)
+      return Array.from({ length: 16 }, (_, i) => i);
+
+    return Array.from({ length: 16 }, (_, i) => i).filter((ch) => {
+      const slot = getSlotForChannel(ch);
+      if (!slot?.app) return false;
+      if (category === "AppInput") {
+        return appHasVirtualInput(ch);
+      }
+      return true; // AppFader (Fader Mod) is available for all occupied app channels
+    });
+  };
+
+  const isForbiddenRoute = (
+    src: routing.RouteSource,
+    dest: routing.RouteDestination,
+  ) => {
+    if (
+      src.tag === "AppOutput" &&
+      (dest.tag === "AppInput" || dest.tag === "AppFader")
+    ) {
+      return src.value.channel === dest.value.channel;
+    }
+    return false;
   };
 
   const isSameSource = (a: routing.RouteSource, b: routing.RouteSource) => {
@@ -78,6 +137,8 @@ export const PatchbayTab = () => {
     src: routing.RouteSource,
     dest: routing.RouteDestination,
   ) => {
+    if (isForbiddenRoute(src, dest)) return;
+
     const existingIdx = routeList.findIndex(
       (r) =>
         r && isSameSource(r.source, src) && isSameDest(r.destination, dest),
@@ -151,7 +212,7 @@ export const PatchbayTab = () => {
   const getColHeaderLabel = (category: DestCategory, destChan: number) => {
     switch (category) {
       case "PhysicalDac":
-        return `CV Out ${destChan + 1}`;
+        return `Jack ${destChan + 1}`;
       case "AppInput":
         return `App ${destChan + 1} In`;
       case "AppFader":
@@ -159,6 +220,8 @@ export const PatchbayTab = () => {
     }
   };
 
+  const activeSourceChannels = getActiveSourceChannels();
+  const activeDestChannels = getActiveDestChannels(destCategory);
   const activeCount = routeList.filter((r) => Boolean(r)).length;
 
   return (
@@ -173,18 +236,29 @@ export const PatchbayTab = () => {
             physical CV outputs, and faders.
           </p>
         </div>
-        <Button
-          color="danger"
-          variant="flat"
-          size="sm"
-          onPress={() =>
-            setRouting({
-              routes: new Array(32).fill(undefined) as unknown,
-            } as routing.RoutingConfig)
-          }
-        >
-          Clear All Routes
-        </Button>
+        <div className="flex items-center gap-4">
+          <Switch
+            size="sm"
+            isSelected={showAllChannels}
+            onValueChange={setShowAllChannels}
+          >
+            <span className="text-xs text-neutral-400">
+              Show All 16 Channels
+            </span>
+          </Switch>
+          <Button
+            color="danger"
+            variant="flat"
+            size="sm"
+            onPress={() =>
+              setRouting({
+                routes: new Array(32).fill(undefined) as unknown,
+              } as routing.RoutingConfig)
+            }
+          >
+            Clear All Routes
+          </Button>
+        </div>
       </div>
 
       {/* Target Category Selector Tabs */}
@@ -213,19 +287,27 @@ export const PatchbayTab = () => {
 
         {/* Matrix Grid */}
         <div className="overflow-x-auto pt-2">
-          <div className="min-w-[750px]">
+          <div className="min-w-[650px]">
             {/* Header row */}
-            <div className="grid grid-cols-[180px_repeat(16,minmax(32px,1fr))] gap-1 border-b border-neutral-800 pb-2 text-center text-[11px] font-semibold text-neutral-300">
+            <div
+              className="grid gap-1 border-b border-neutral-800 pb-2 text-center text-[11px] font-semibold text-neutral-300"
+              style={{
+                gridTemplateColumns: `180px repeat(${activeDestChannels.length}, minmax(36px, 1fr))`,
+              }}
+            >
               <div className="pl-2 text-left">Signal Source \ Target</div>
-              {Array.from({ length: 16 }, (_, i) => (
-                <div key={i} title={getColHeaderLabel(destCategory, i)}>
-                  {getColHeaderLabel(destCategory, i)}
+              {activeDestChannels.map((destChan) => (
+                <div
+                  key={destChan}
+                  title={getColHeaderLabel(destCategory, destChan)}
+                >
+                  {getColHeaderLabel(destCategory, destChan)}
                 </div>
               ))}
             </div>
 
             {/* Source Rows */}
-            {Array.from({ length: 16 }, (_, srcChan) => {
+            {activeSourceChannels.map((srcChan) => {
               const src: routing.RouteSource = {
                 tag: "AppOutput",
                 value: { channel: srcChan },
@@ -233,7 +315,10 @@ export const PatchbayTab = () => {
               return (
                 <div
                   key={srcChan}
-                  className="grid grid-cols-[180px_repeat(16,minmax(32px,1fr))] items-center gap-1 rounded-sm py-1 hover:bg-neutral-800/40"
+                  className="grid items-center gap-1 rounded-sm py-1 hover:bg-neutral-800/40"
+                  style={{
+                    gridTemplateColumns: `180px repeat(${activeDestChannels.length}, minmax(36px, 1fr))`,
+                  }}
                 >
                   <div
                     className="truncate pl-2 text-xs font-medium text-neutral-300"
@@ -241,8 +326,9 @@ export const PatchbayTab = () => {
                   >
                     {srcChan + 1}. {getAppName(srcChan)}
                   </div>
-                  {Array.from({ length: 16 }, (_, destChan) => {
+                  {activeDestChannels.map((destChan) => {
                     const dest = createDestForCategory(destCategory, destChan);
+                    const forbidden = isForbiddenRoute(src, dest);
                     const activeRoute = routeList.find(
                       (r) =>
                         r &&
@@ -250,6 +336,18 @@ export const PatchbayTab = () => {
                         isSameSource(r.source, src) &&
                         isSameDest(r.destination, dest),
                     );
+
+                    if (forbidden) {
+                      return (
+                        <div
+                          key={destChan}
+                          className="flex h-7 w-7 cursor-not-allowed items-center justify-center rounded border border-neutral-900 bg-neutral-950/80 text-[10px] text-neutral-800"
+                          title="Self-routing (Ch X → Ch X) is disabled to prevent feedback loops"
+                        >
+                          ×
+                        </div>
+                      );
+                    }
 
                     return (
                       <button
@@ -273,6 +371,14 @@ export const PatchbayTab = () => {
                 </div>
               );
             })}
+
+            {activeSourceChannels.length === 0 && (
+              <div className="py-8 text-center text-sm text-neutral-500">
+                No active app channels in layout. Install apps on channels in
+                the Layout Editor or enable &quot;Show All 16 Channels&quot;
+                above.
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/configurator/src/components/PatchbayTab.tsx
+++ b/configurator/src/components/PatchbayTab.tsx
@@ -299,6 +299,7 @@ export const PatchbayTab = () => {
               {activeDestChannels.map((destChan) => (
                 <div
                   key={destChan}
+                  className="flex items-center justify-center text-center"
                   title={getColHeaderLabel(destCategory, destChan)}
                 >
                   {getColHeaderLabel(destCategory, destChan)}
@@ -337,35 +338,36 @@ export const PatchbayTab = () => {
                         isSameDest(r.destination, dest),
                     );
 
-                    if (forbidden) {
-                      return (
-                        <div
-                          key={destChan}
-                          className="flex h-7 w-7 cursor-not-allowed items-center justify-center rounded border border-neutral-900 bg-neutral-950/80 text-[10px] text-neutral-800"
-                          title="Self-routing (Ch X → Ch X) is disabled to prevent feedback loops"
-                        >
-                          ×
-                        </div>
-                      );
-                    }
-
                     return (
-                      <button
+                      <div
                         key={destChan}
-                        onClick={() => handleCellClick(src, dest)}
-                        className={`flex h-7 w-7 items-center justify-center rounded border text-[10px] font-bold transition-all ${
-                          activeRoute
-                            ? "border-cyan-400 bg-cyan-500/30 text-cyan-200 shadow-[0_0_8px_rgba(6,182,212,0.4)]"
-                            : "border-neutral-800 bg-neutral-950/40 text-neutral-600 hover:border-neutral-600 hover:text-neutral-300"
-                        }`}
-                        title={
-                          activeRoute
-                            ? `Route Active: ${formatSourceLabel(src)} → ${formatDestLabel(dest)} (${activeRoute.mode.tag})`
-                            : `Connect ${formatSourceLabel(src)} to ${formatDestLabel(dest)}`
-                        }
+                        className="flex items-center justify-center"
                       >
-                        {activeRoute ? "●" : "+"}
-                      </button>
+                        {forbidden ? (
+                          <div
+                            className="flex h-7 w-7 cursor-not-allowed items-center justify-center rounded border border-neutral-900 bg-neutral-950/80 text-[10px] text-neutral-800"
+                            title="Self-routing (Ch X → Ch X) is disabled to prevent feedback loops"
+                          >
+                            ×
+                          </div>
+                        ) : (
+                          <button
+                            onClick={() => handleCellClick(src, dest)}
+                            className={`flex h-7 w-7 items-center justify-center rounded border text-[10px] font-bold transition-all ${
+                              activeRoute
+                                ? "border-cyan-400 bg-cyan-500/30 text-cyan-200 shadow-[0_0_8px_rgba(6,182,212,0.4)]"
+                                : "border-neutral-800 bg-neutral-950/40 text-neutral-600 hover:border-neutral-600 hover:text-neutral-300"
+                            }`}
+                            title={
+                              activeRoute
+                                ? `Route Active: ${formatSourceLabel(src)} → ${formatDestLabel(dest)} (${activeRoute.mode.tag})`
+                                : `Connect ${formatSourceLabel(src)} to ${formatDestLabel(dest)}`
+                            }
+                          >
+                            {activeRoute ? "●" : "+"}
+                          </button>
+                        )}
+                      </div>
                     );
                   })}
                 </div>

--- a/configurator/src/components/PatchbayTab.tsx
+++ b/configurator/src/components/PatchbayTab.tsx
@@ -1,0 +1,443 @@
+import { useState } from "react";
+import { Button } from "@heroui/button";
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/modal";
+import { Select, SelectItem } from "@heroui/select";
+import { Slider } from "@heroui/slider";
+import { Switch } from "@heroui/switch";
+import { Tabs, Tab } from "@heroui/tabs";
+import { useStore } from "../store";
+import { routing } from "@atov/fp-config";
+
+type DestCategory = "PhysicalDac" | "AppInput" | "AppFader";
+
+const COMBINE_MODES: { label: string; modeTag: routing.CombineMode["tag"] }[] =
+  [
+    { label: "Sum (A + B)", modeTag: "Sum" },
+    { label: "Average ((A + B) / 2)", modeTag: "Average" },
+    { label: "Max (Highest)", modeTag: "Max" },
+    { label: "Min (Lowest)", modeTag: "Min" },
+    { label: "Logic OR", modeTag: "Or" },
+    { label: "Logic AND", modeTag: "And" },
+    { label: "Logic XOR", modeTag: "Xor" },
+    { label: "Replace / Override", modeTag: "Replace" },
+  ];
+
+export const PatchbayTab = () => {
+  const { routing: routingState, setRouting, layout } = useStore();
+  const [destCategory, setDestCategory] = useState<DestCategory>("PhysicalDac");
+  const [selectedRouteIdx, setSelectedRouteIdx] = useState<number | null>(null);
+  const [editingRoute, setEditingRoute] = useState<routing.Route | null>(null);
+
+  const routeList = Array.from(routingState?.routes || []) as (
+    | routing.Route
+    | undefined
+  )[];
+
+  const getAppName = (channel: number) => {
+    if (!layout) return `Ch ${channel + 1}`;
+    const slot = layout.find((s) => s.startChannel === channel);
+    return slot?.app
+      ? `${slot.app.name} (Ch ${channel + 1})`
+      : `Ch ${channel + 1}`;
+  };
+
+  const isSameSource = (a: routing.RouteSource, b: routing.RouteSource) => {
+    if (a.tag === "AppOutput" && b.tag === "AppOutput")
+      return a.value.channel === b.value.channel;
+    if (a.tag === "PhysicalAdc" && b.tag === "PhysicalAdc")
+      return a.value.channel === b.value.channel;
+    if (a.tag === "AppMidi" && b.tag === "AppMidi")
+      return a.value.channel === b.value.channel;
+    if (a.tag === "Constant" && b.tag === "Constant")
+      return a.value.value === b.value.value;
+    return false;
+  };
+
+  const isSameDest = (
+    a: routing.RouteDestination,
+    b: routing.RouteDestination,
+  ) => {
+    if (a.tag === "AppInput" && b.tag === "AppInput")
+      return a.value.channel === b.value.channel;
+    if (a.tag === "PhysicalDac" && b.tag === "PhysicalDac")
+      return a.value.channel === b.value.channel;
+    if (a.tag === "AppFader" && b.tag === "AppFader")
+      return a.value.channel === b.value.channel;
+    if (a.tag === "AppLayer" && b.tag === "AppLayer")
+      return a.value.channel === b.value.channel;
+    return false;
+  };
+
+  const handleCellClick = (
+    src: routing.RouteSource,
+    dest: routing.RouteDestination,
+  ) => {
+    const existingIdx = routeList.findIndex(
+      (r) =>
+        r && isSameSource(r.source, src) && isSameDest(r.destination, dest),
+    );
+
+    if (existingIdx >= 0 && routeList[existingIdx]) {
+      setSelectedRouteIdx(existingIdx);
+      setEditingRoute({ ...routeList[existingIdx]! });
+    } else {
+      const emptyIdx = routeList.findIndex((r) => !r);
+      const targetIdx = emptyIdx >= 0 ? emptyIdx : 0;
+      setSelectedRouteIdx(targetIdx);
+      setEditingRoute({
+        source: src,
+        destination: dest,
+        mode: { tag: "Sum" },
+        attenuation_percent: 100,
+        offset: 0,
+        enabled: true,
+      });
+    }
+  };
+
+  const handleSaveRoute = () => {
+    if (selectedRouteIdx === null || !editingRoute) return;
+    const newRoutes = [...routeList];
+    newRoutes[selectedRouteIdx] = editingRoute;
+    setRouting({ routes: newRoutes as unknown } as routing.RoutingConfig);
+    setSelectedRouteIdx(null);
+    setEditingRoute(null);
+  };
+
+  const handleDeleteRoute = (idx: number) => {
+    const newRoutes = [...routeList];
+    newRoutes[idx] = undefined;
+    setRouting({ routes: newRoutes as unknown } as routing.RoutingConfig);
+  };
+
+  const formatSourceLabel = (src: routing.RouteSource) => {
+    if (src.tag === "AppOutput")
+      return `App Out: ${getAppName(src.value.channel)}`;
+    if (src.tag === "PhysicalAdc") return `ADC In: Ch ${src.value.channel + 1}`;
+    if (src.tag === "Constant") return `Const: ${src.value.value}`;
+    return "Source";
+  };
+
+  const formatDestLabel = (dest: routing.RouteDestination) => {
+    if (dest.tag === "PhysicalDac")
+      return `Physical CV Out: Jack ${dest.value.channel + 1}`;
+    if (dest.tag === "AppInput")
+      return `App Input: ${getAppName(dest.value.channel)}`;
+    if (dest.tag === "AppFader")
+      return `Fader Mod: Ch ${dest.value.channel + 1}`;
+    return "Destination";
+  };
+
+  const createDestForCategory = (
+    category: DestCategory,
+    destChan: number,
+  ): routing.RouteDestination => {
+    switch (category) {
+      case "PhysicalDac":
+        return { tag: "PhysicalDac", value: { channel: destChan } };
+      case "AppInput":
+        return { tag: "AppInput", value: { channel: destChan } };
+      case "AppFader":
+        return { tag: "AppFader", value: { channel: destChan } };
+    }
+  };
+
+  const getColHeaderLabel = (category: DestCategory, destChan: number) => {
+    switch (category) {
+      case "PhysicalDac":
+        return `CV Out ${destChan + 1}`;
+      case "AppInput":
+        return `App ${destChan + 1} In`;
+      case "AppFader":
+        return `Fad ${destChan + 1} Mod`;
+    }
+  };
+
+  const activeCount = routeList.filter((r) => Boolean(r)).length;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight text-white">
+            Internal Digital Patchbay
+          </h2>
+          <p className="text-sm text-neutral-400">
+            Digitally connect, combine, or modulate signals between apps,
+            physical CV outputs, and faders.
+          </p>
+        </div>
+        <Button
+          color="danger"
+          variant="flat"
+          size="sm"
+          onPress={() =>
+            setRouting({
+              routes: new Array(32).fill(undefined) as unknown,
+            } as routing.RoutingConfig)
+          }
+        >
+          Clear All Routes
+        </Button>
+      </div>
+
+      {/* Target Category Selector Tabs */}
+      <div className="flex flex-col gap-3 rounded-xl border border-neutral-800 bg-neutral-900/60 p-4 backdrop-blur-md">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-white">
+              Select Destination Target Type
+            </h3>
+            <p className="text-xs text-neutral-400">
+              Choose what destination you want to patch signals into:
+            </p>
+          </div>
+          <Tabs
+            selectedKey={destCategory}
+            onSelectionChange={(key) => setDestCategory(key as DestCategory)}
+            variant="solid"
+            color="primary"
+            size="sm"
+          >
+            <Tab key="PhysicalDac" title="⚡ Physical CV Out Jacks" />
+            <Tab key="AppInput" title="🎛️ App Software Inputs" />
+            <Tab key="AppFader" title="🎚️ Fader Position Modulation" />
+          </Tabs>
+        </div>
+
+        {/* Matrix Grid */}
+        <div className="overflow-x-auto pt-2">
+          <div className="min-w-[750px]">
+            {/* Header row */}
+            <div className="grid grid-cols-[180px_repeat(16,minmax(32px,1fr))] gap-1 border-b border-neutral-800 pb-2 text-center text-[11px] font-semibold text-neutral-300">
+              <div className="pl-2 text-left">Signal Source \ Target</div>
+              {Array.from({ length: 16 }, (_, i) => (
+                <div key={i} title={getColHeaderLabel(destCategory, i)}>
+                  {getColHeaderLabel(destCategory, i)}
+                </div>
+              ))}
+            </div>
+
+            {/* Source Rows */}
+            {Array.from({ length: 16 }, (_, srcChan) => {
+              const src: routing.RouteSource = {
+                tag: "AppOutput",
+                value: { channel: srcChan },
+              };
+              return (
+                <div
+                  key={srcChan}
+                  className="grid grid-cols-[180px_repeat(16,minmax(32px,1fr))] items-center gap-1 rounded-sm py-1 hover:bg-neutral-800/40"
+                >
+                  <div
+                    className="truncate pl-2 text-xs font-medium text-neutral-300"
+                    title={getAppName(srcChan)}
+                  >
+                    {srcChan + 1}. {getAppName(srcChan)}
+                  </div>
+                  {Array.from({ length: 16 }, (_, destChan) => {
+                    const dest = createDestForCategory(destCategory, destChan);
+                    const activeRoute = routeList.find(
+                      (r) =>
+                        r &&
+                        r.enabled &&
+                        isSameSource(r.source, src) &&
+                        isSameDest(r.destination, dest),
+                    );
+
+                    return (
+                      <button
+                        key={destChan}
+                        onClick={() => handleCellClick(src, dest)}
+                        className={`flex h-7 w-7 items-center justify-center rounded border text-[10px] font-bold transition-all ${
+                          activeRoute
+                            ? "border-cyan-400 bg-cyan-500/30 text-cyan-200 shadow-[0_0_8px_rgba(6,182,212,0.4)]"
+                            : "border-neutral-800 bg-neutral-950/40 text-neutral-600 hover:border-neutral-600 hover:text-neutral-300"
+                        }`}
+                        title={
+                          activeRoute
+                            ? `Route Active: ${formatSourceLabel(src)} → ${formatDestLabel(dest)} (${activeRoute.mode.tag})`
+                            : `Connect ${formatSourceLabel(src)} to ${formatDestLabel(dest)}`
+                        }
+                      >
+                        {activeRoute ? "●" : "+"}
+                      </button>
+                    );
+                  })}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Active Routes List Summary */}
+      <div className="rounded-xl border border-neutral-800 bg-neutral-900/60 p-4">
+        <div className="pb-3">
+          <h3 className="text-lg font-semibold text-white">
+            Active Connections ({activeCount} / 32)
+          </h3>
+        </div>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+          {routeList.map((r, idx) => {
+            if (!r) return null;
+            return (
+              <div
+                key={idx}
+                className="flex items-center justify-between rounded-md border border-neutral-800 bg-neutral-950 p-3 transition-all hover:border-neutral-700"
+              >
+                <div className="flex min-w-0 flex-col gap-1 pr-2">
+                  <div className="flex items-center gap-2 truncate text-xs font-semibold text-cyan-400">
+                    <span>{formatSourceLabel(r.source)}</span>
+                    <span>→</span>
+                    <span>{formatDestLabel(r.destination)}</span>
+                  </div>
+                  <div className="text-[11px] text-neutral-400">
+                    Mode:{" "}
+                    <span className="font-medium text-white">{r.mode.tag}</span>{" "}
+                    | Att: {r.attenuation_percent}% | Offset: {r.offset}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Switch
+                    size="sm"
+                    isSelected={r.enabled}
+                    onValueChange={(val) => {
+                      const newRoutes = [...routeList];
+                      newRoutes[idx] = { ...r, enabled: val };
+                      setRouting({
+                        routes: newRoutes as unknown,
+                      } as routing.RoutingConfig);
+                    }}
+                  />
+                  <Button
+                    size="sm"
+                    isIconOnly
+                    color="danger"
+                    variant="light"
+                    onPress={() => handleDeleteRoute(idx)}
+                  >
+                    ×
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+          {activeCount === 0 && (
+            <div className="col-span-full py-8 text-center text-sm text-neutral-500">
+              No active routing connections. Select a target category above and
+              click any matrix node to patch signals.
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Route Edit Modal */}
+      {editingRoute && (
+        <Modal
+          isOpen={selectedRouteIdx !== null}
+          onClose={() => setSelectedRouteIdx(null)}
+          backdrop="blur"
+          radius="sm"
+        >
+          <ModalContent className="border border-neutral-800 bg-neutral-900 text-white">
+            <ModalHeader className="flex flex-col gap-1">
+              <h3>Configure Route Connection</h3>
+              <p className="text-xs text-neutral-400">
+                {formatSourceLabel(editingRoute.source)} →{" "}
+                {formatDestLabel(editingRoute.destination)}
+              </p>
+            </ModalHeader>
+            <ModalBody className="flex flex-col gap-4">
+              <div>
+                <label className="mb-1 block text-xs text-neutral-300">
+                  Combine Mode
+                </label>
+                <Select
+                  selectedKeys={[editingRoute.mode.tag]}
+                  onSelectionChange={(keys) => {
+                    const tag = Array.from(
+                      keys,
+                    )[0] as routing.CombineMode["tag"];
+                    if (tag)
+                      setEditingRoute({
+                        ...editingRoute,
+                        mode: { tag } as routing.CombineMode,
+                      });
+                  }}
+                  className="rounded-md border border-neutral-800 bg-neutral-950"
+                >
+                  {COMBINE_MODES.map((m) => (
+                    <SelectItem key={m.modeTag}>{m.label}</SelectItem>
+                  ))}
+                </Select>
+              </div>
+
+              <div>
+                <Slider
+                  label="Gain / Attenuation (%)"
+                  step={5}
+                  minValue={-200}
+                  maxValue={200}
+                  value={editingRoute.attenuation_percent}
+                  onChange={(val) =>
+                    setEditingRoute({
+                      ...editingRoute,
+                      attenuation_percent: val as number,
+                    })
+                  }
+                  className="max-w-md"
+                />
+              </div>
+
+              <div>
+                <Slider
+                  label="Bipolar Offset (DAC counts)"
+                  step={16}
+                  minValue={-2048}
+                  maxValue={2047}
+                  value={editingRoute.offset}
+                  onChange={(val) =>
+                    setEditingRoute({
+                      ...editingRoute,
+                      offset: val as number,
+                    })
+                  }
+                  className="max-w-md"
+                />
+              </div>
+
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-neutral-300">Enable Route</span>
+                <Switch
+                  isSelected={editingRoute.enabled}
+                  onValueChange={(val) =>
+                    setEditingRoute({ ...editingRoute, enabled: val })
+                  }
+                />
+              </div>
+            </ModalBody>
+            <ModalFooter>
+              <Button
+                color="danger"
+                variant="flat"
+                onPress={() => setSelectedRouteIdx(null)}
+              >
+                Cancel
+              </Button>
+              <Button color="primary" onPress={handleSaveRoute}>
+                Save Route
+              </Button>
+            </ModalFooter>
+          </ModalContent>
+        </Modal>
+      )}
+    </div>
+  );
+};

--- a/configurator/src/components/manual/Configurator.tsx
+++ b/configurator/src/components/manual/Configurator.tsx
@@ -43,7 +43,7 @@ export const Configurator = () => (
     </p>
     <p>
       Once connected, you'll be greeted by the Configurator interface, which
-      consists of <strong>three tabs</strong>:
+      consists of <strong>four tabs</strong>:
     </p>
     <List>
       <li>
@@ -52,6 +52,11 @@ export const Configurator = () => (
       </li>
       <li>
         <strong>Apps Tab</strong> – Choose which apps to include in your layout.
+      </li>
+      <li>
+        <strong>Patchbay Tab</strong> – Interconnect channels digitally,
+        modulate faders, and sum CV signals internally without physical patch
+        cables.
       </li>
       <li>
         <strong>Settings Tab</strong> – Modify global configurations of the
@@ -159,6 +164,138 @@ export const Configurator = () => (
     <p>
       In this case, you can rearrange or delete apps just as you would in the
       Edit Layout pop-up.
+    </p>
+
+    <H3 id="patchbay-tab">Patchbay Tab</H3>
+    <p>
+      The <strong>Patchbay tab</strong> introduces an internal virtual routing
+      matrix for Faderpunk. It allows you to digitally interconnect channels,
+      route LFOs/CV outputs to other apps, perform digital fader modulation, and
+      sum CV signals together—all internally inside the device without using
+      physical patch cables.
+    </p>
+
+    <H4>Routing Matrix Structure</H4>
+    <p>The patchbay is organized as an interactive grid connecting:</p>
+    <List>
+      <li>
+        <strong>Sources (Rows)</strong>:
+        <List>
+          <li>
+            <strong>Physical CV Inputs (🔌)</strong> – Hardware input jacks on
+            Channels 1–16.
+          </li>
+          <li>
+            <strong>App Outputs (🌊)</strong> – Live internal CV/waveform
+            outputs produced by loaded apps (LFOs, Turing Machines, Sequencers,
+            etc.).
+          </li>
+          <li>
+            <strong>Physical Fader Position (🎚️)</strong> – The physical
+            position of faders on Channels 1–16.
+          </li>
+        </List>
+      </li>
+      <li>
+        <strong>Destinations (Columns)</strong>:
+        <List>
+          <li>
+            <strong>Physical CV Outputs (⚡)</strong> – Physical DAC output
+            jacks on Channels 1–16.
+          </li>
+          <li>
+            <strong>App Software Inputs (🎛️)</strong> – Virtual software inputs
+            for input-capable apps (Quantizer, Slew, Follower, Panner, Mixer,
+            etc.).
+          </li>
+          <li>
+            <strong>Fader Modulation (🎚️)</strong> – Modulate another channel's
+            main fader digitally.
+          </li>
+        </List>
+      </li>
+    </List>
+
+    <H4>Dynamic Matrix Filtering</H4>
+    <p>To keep the matrix clean and easy to navigate:</p>
+    <List>
+      <li>
+        Unassigned or empty channel slots are automatically hidden from matrix
+        rows and columns.
+      </li>
+      <li>
+        The <strong>App Software Inputs</strong> section dynamically lists only
+        apps capable of receiving virtual inputs.
+      </li>
+      <li>
+        Direct self-routing (e.g. Channel 1 → Channel 1) is disabled to prevent
+        accidental feedback loops.
+      </li>
+      <li>
+        You can use the <strong>Show All 16 Channels</strong> toggle at the top
+        of the tab to expand the matrix to all 16 physical channels at any time.
+      </li>
+    </List>
+
+    <H4>Combine Modes & Signal Processing</H4>
+    <p>
+      When routing a signal to a destination that is already active (or when
+      routing multiple sources to the same destination), you can select how the
+      signals combine:
+    </p>
+    <List>
+      <li>
+        <strong>Sum (Default)</strong> – Adds the incoming routed signal to the
+        destination's existing value (e.g. summing LFO 1 onto LFO 8's physical
+        output, or combining multiple LFOs together).
+      </li>
+      <li>
+        <strong>Replace</strong> – Overrides and replaces the destination's
+        signal entirely with the routed source.
+      </li>
+      <li>
+        <strong>Average</strong> – Computes the arithmetic average of all active
+        sources and the destination's default value.
+      </li>
+      <li>
+        <strong>Max / Min</strong> – Outputs the highest or lowest voltage among
+        all active sources.
+      </li>
+      <li>
+        <strong>Logic (OR / AND / XOR)</strong> – Performs digital gate/trigger
+        logic operations between signals.
+      </li>
+    </List>
+
+    <H4>Per-Route Fine Tuning</H4>
+    <p>
+      Clicking on any active patch point node in the grid opens a pop-up menu
+      allowing you to:
+    </p>
+    <List>
+      <li>
+        Adjust <strong>Attenuation</strong> (0% to 100%).
+      </li>
+      <li>
+        Apply a <strong>DC Voltage Offset</strong> (-2048 to +2047 / -5V to
+        +5V).
+      </li>
+      <li>
+        <strong>Invert</strong> signal polarity.
+      </li>
+      <li>
+        <strong>Enable/Disable</strong> the route without deleting it.
+      </li>
+    </List>
+
+    <H4>Continuous Background Fader Modulation</H4>
+    <p>
+      When a route targets <strong>Fader Modulation</strong>, the modulation is
+      applied continuously in the background on the channel's{" "}
+      <strong>Main layer</strong>. Holding <strong>Shift</strong> allows you to
+      adjust secondary parameters (Alt layer) with 100% layer
+      isolation—releasing Shift seamlessly resumes main-layer fader modulation
+      without parameter dropouts or jumping.
     </p>
 
     <H3 id="settings-tab">Settings Tab</H3>

--- a/configurator/src/components/manual/Configurator.tsx
+++ b/configurator/src/components/manual/Configurator.tsx
@@ -182,17 +182,17 @@ export const Configurator = () => (
         <strong>Sources (Rows)</strong>:
         <List>
           <li>
-            <strong>App Outputs (🌊)</strong> – Live internal CV, gate, or
-            waveform outputs produced by loaded apps (LFOs, Turing Machines,
-            Sequencers, etc.).
+            <strong>App Outputs</strong> – Live internal CV, gate, or waveform
+            outputs produced by loaded apps (LFOs, Turing Machines, Sequencers,
+            etc.).
           </li>
           <li>
-            <strong>Physical CV Inputs (🔌)</strong> – Hardware analog input
-            signals coming from external patch cables connected to physical
-            input jacks 1–16.
+            <strong>Physical CV Inputs</strong> – Hardware analog input signals
+            coming from external patch cables connected to physical input jacks
+            1–16.
           </li>
           <li>
-            <strong>Constant DC Voltage (⚡)</strong> – Fixed DC offset voltage
+            <strong>Constant DC Voltage</strong> – Fixed DC offset voltage
             generator.
           </li>
         </List>
@@ -201,17 +201,16 @@ export const Configurator = () => (
         <strong>Destinations (Columns)</strong>:
         <List>
           <li>
-            <strong>Physical CV Outputs (⚡)</strong> – Physical DAC output
-            jacks on Channels 1–16.
+            <strong>Physical CV Outputs</strong> – Physical DAC output jacks on
+            Channels 1–16.
           </li>
           <li>
-            <strong>App Software Inputs (🎛️)</strong> – Virtual software inputs
-            for input-capable apps (Quantizer, Slew, Follower, Panner, Mixer,
-            etc.).
+            <strong>App Software Inputs</strong> – Virtual software inputs for
+            input-capable apps (Quantizer, Slew, Follower, Panner, Mixer, etc.).
           </li>
           <li>
-            <strong>Fader Modulation (🎚️)</strong> – Modulate another channel's
-            main fader digitally.
+            <strong>Fader Modulation</strong> – Modulate another channel's main
+            fader digitally.
           </li>
         </List>
       </li>
@@ -329,9 +328,9 @@ export const Configurator = () => (
       </li>
     </List>
     <p>
-      ⚠️ Currently, the only supported analog clock input resolution is{" "}
-      <strong>24 PPQN</strong>. We're actively working on supporting additional
-      resolutions.
+      <strong>Note:</strong> Currently, the only supported analog clock input
+      resolution is <strong>24 PPQN</strong>. We're actively working on
+      supporting additional resolutions.
     </p>
     <List>
       <li>

--- a/configurator/src/components/manual/Configurator.tsx
+++ b/configurator/src/components/manual/Configurator.tsx
@@ -182,17 +182,18 @@ export const Configurator = () => (
         <strong>Sources (Rows)</strong>:
         <List>
           <li>
-            <strong>Physical CV Inputs (🔌)</strong> – Hardware input jacks on
-            Channels 1–16.
+            <strong>App Outputs (🌊)</strong> – Live internal CV, gate, or
+            waveform outputs produced by loaded apps (LFOs, Turing Machines,
+            Sequencers, etc.).
           </li>
           <li>
-            <strong>App Outputs (🌊)</strong> – Live internal CV/waveform
-            outputs produced by loaded apps (LFOs, Turing Machines, Sequencers,
-            etc.).
+            <strong>Physical CV Inputs (🔌)</strong> – Hardware analog input
+            signals coming from external patch cables connected to physical
+            input jacks 1–16.
           </li>
           <li>
-            <strong>Physical Fader Position (🎚️)</strong> – The physical
-            position of faders on Channels 1–16.
+            <strong>Constant DC Voltage (⚡)</strong> – Fixed DC offset voltage
+            generator.
           </li>
         </List>
       </li>

--- a/configurator/src/components/manual/PunkBus.tsx
+++ b/configurator/src/components/manual/PunkBus.tsx
@@ -28,7 +28,7 @@ export const PunkBus = () => (
     <H3>Introduction</H3>
     <p>PunkBus connects all 19 Faderpunk jacks with a single cable.</p>
 
-    <H3>⚠️ Warning</H3>
+    <H3>Warning</H3>
     <p>
       The HDMI connector carries CV/gate signals, not video. Never connect
       PunkBus or Faderpunk to a TV, monitor, or other HDMI video equipment —

--- a/configurator/src/store.ts
+++ b/configurator/src/store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { Value, type GlobalConfig } from "@atov/fp-config";
+import { Value, type GlobalConfig, type routing } from "@atov/fp-config";
 
 import type { AllApps, AppLayout, AppSlot, ParamValues } from "./utils/types";
 import {
@@ -13,6 +13,8 @@ import {
   getAllApps,
   getGlobalConfig,
   getLayout,
+  getRouting,
+  setRoutingConfig as sendRoutingConfig,
   saveLayout,
   recoverLayout,
   serializeLayout,
@@ -67,12 +69,14 @@ interface State {
   connect: () => Promise<void>;
   connectSimulator: () => void;
   config: GlobalConfig | undefined;
+  routing: routing.RoutingConfig | undefined;
   disconnect: () => void;
   deviceVersion: string | undefined;
   isSimulator: boolean;
   layout: AppLayout | undefined;
   params: ParamValues | undefined;
   setConfig: (config: GlobalConfig) => void;
+  setRouting: (routing: routing.RoutingConfig) => void;
   setLayout: (layout: AppLayout) => void;
   setParams: (id: number, newParams: Value[]) => void;
   setAllParams: (newParams: ParamValues) => void;
@@ -88,6 +92,7 @@ interface State {
 const initialState = {
   apps: undefined,
   config: undefined,
+  routing: undefined,
   deviceVersion: undefined,
   isSimulator: false,
   layout: undefined,
@@ -110,8 +115,24 @@ export const useStore = create<State>((set, get) => ({
       const params = await getAllAppParams(device);
       const layout = await getLayout(device, apps);
       const config = await getGlobalConfig(device);
+      let routingState: routing.RoutingConfig | undefined;
+      try {
+        routingState = await getRouting(device);
+      } catch {
+        routingState = {
+          routes: new Array(32).fill(undefined),
+        } as unknown as routing.RoutingConfig;
+      }
 
-      set({ apps, config, deviceVersion, layout, params, device });
+      set({
+        apps,
+        config,
+        routing: routingState,
+        deviceVersion,
+        layout,
+        params,
+        device,
+      });
       return true;
     } catch (error) {
       console.error("Auto-connect failed:", error);
@@ -129,7 +150,23 @@ export const useStore = create<State>((set, get) => ({
       const params = await getAllAppParams(device);
       const layout = await getLayout(device, apps);
       const config = await getGlobalConfig(device);
-      set({ apps, config, deviceVersion, layout, params, device });
+      let routingState: routing.RoutingConfig | undefined;
+      try {
+        routingState = await getRouting(device);
+      } catch {
+        routingState = {
+          routes: new Array(32).fill(undefined),
+        } as unknown as routing.RoutingConfig;
+      }
+      set({
+        apps,
+        config,
+        routing: routingState,
+        deviceVersion,
+        layout,
+        params,
+        device,
+      });
     } catch (error) {
       console.error("Failed to connect to device:", error);
       // Reset state on failure
@@ -169,6 +206,15 @@ export const useStore = create<State>((set, get) => ({
     const { isSimulator, layout, params } = get();
     if (isSimulator && layout && params)
       persistSimulatorState(layout, params, config);
+  },
+  setRouting: (routing) => {
+    set({ routing });
+    const { device } = get();
+    if (device) {
+      sendRoutingConfig(device, routing).catch((err) =>
+        console.error("Failed to send routing config:", err),
+      );
+    }
   },
   setLayout: (layout) => {
     set({ layout });

--- a/configurator/src/utils/config.ts
+++ b/configurator/src/utils/config.ts
@@ -4,6 +4,7 @@ import type {
   Value,
   FixedLengthArray,
   ConfigMsgOut,
+  routing,
 } from "@atov/fp-config";
 
 import type {
@@ -29,6 +30,40 @@ import {
 } from "./validators";
 
 const LAYOUT_VERSION = 1;
+
+export const getRouting = async (
+  dev: FpMidiDevice,
+): Promise<routing.RoutingConfig> => {
+  const response = await sendAndReceive(dev, {
+    tag: "GetRouting",
+  });
+
+  if (response.tag !== "RoutingState") {
+    throw new Error(
+      `Could not fetch routing state. Unexpected response tag: ${response.tag}`,
+    );
+  }
+
+  return response.value;
+};
+
+export const setRoutingConfig = async (
+  dev: FpMidiDevice,
+  routingState: routing.RoutingConfig,
+) => {
+  const response = await sendAndReceive(dev, {
+    tag: "SetRouting",
+    value: routingState,
+  });
+
+  if (response.tag !== "RoutingState") {
+    throw new Error(
+      `Could not set routing state. Unexpected response tag: ${response.tag}`,
+    );
+  }
+
+  return response.value;
+};
 
 export const setGlobalConfig = async (
   dev: FpMidiDevice,

--- a/configurator/src/utils/midi-protocol.ts
+++ b/configurator/src/utils/midi-protocol.ts
@@ -163,6 +163,7 @@ async function findDevice(access: MIDIAccess): Promise<FpMidiDevice | null> {
       if (version === null) continue;
 
       const rx = attachInput(input);
+      rx.queue = [];
       const device: FpMidiDevice = { access, input, output, version, rx };
       access.onstatechange = (event: MIDIConnectionEvent) => {
         const port = event.port;

--- a/faderpunk/src/app.rs
+++ b/faderpunk/src/app.rs
@@ -12,7 +12,7 @@ use midly::{live::LiveEvent, num::u4, MidiMessage, PitchBend};
 use portable_atomic::Ordering;
 
 use libfp::{
-    latch::AnalogLatch,
+    latch::{AnalogLatch, LatchLayer},
     quantizer::{Pitch, QuantizerState},
     utils::{scale_bits_12_7, scale_bits_14_12},
     Brightness, ClockDivision, Color, Key, MidiCc, MidiChannel, MidiIn, MidiNote, MidiOut, Note,
@@ -101,10 +101,76 @@ impl InJack {
 
     pub fn get_value(&self) -> u16 {
         let val = MAX_VALUES_ADC[self.channel].load(Ordering::Relaxed);
+        let raw = match self.range {
+            Range::_0_5V => val.saturating_mul(2),
+            _ => val,
+        };
+        crate::routing_engine::get_input_value_sync(self.channel, raw)
+    }
+
+    #[allow(dead_code)]
+    pub fn get_physical_adc(&self) -> u16 {
+        let val = MAX_VALUES_ADC[self.channel].load(Ordering::Relaxed);
         match self.range {
             Range::_0_5V => val.saturating_mul(2),
             _ => val,
         }
+    }
+
+    #[allow(dead_code)]
+    pub fn is_routed(&self) -> bool {
+        crate::routing_engine::is_input_routed_sync(self.channel)
+    }
+}
+
+pub struct VirtualInJack {
+    channel: usize,
+}
+
+impl VirtualInJack {
+    #[allow(dead_code)]
+    pub fn get_value(&self) -> u16 {
+        crate::routing_engine::get_input_value_sync(self.channel, 0)
+    }
+}
+
+pub struct VirtualOutJack {
+    channel: usize,
+}
+
+impl VirtualOutJack {
+    #[allow(dead_code)]
+    pub fn set_value(&self, value: u16) {
+        crate::routing_engine::set_virtual_output(self.channel, value);
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct Routing<const N: usize> {
+    start_channel: usize,
+}
+
+impl<const N: usize> Routing<N> {
+    pub fn new(start_channel: usize) -> Self {
+        Self { start_channel }
+    }
+
+    #[allow(dead_code)]
+    pub fn is_input_routed(&self, chan: usize) -> bool {
+        let channel = self.start_channel + chan.clamp(0, N - 1);
+        crate::routing_engine::is_input_routed_sync(channel)
+    }
+
+    #[allow(dead_code)]
+    pub fn read_channel_output(&self, source_channel: usize) -> u16 {
+        let channel = source_channel.clamp(0, 15);
+        crate::routing_engine::get_virtual_output(channel)
+    }
+
+    #[allow(dead_code)]
+    pub fn set_virtual_output(&self, chan: usize, value: u16) {
+        let channel = self.start_channel + chan.clamp(0, N - 1);
+        crate::routing_engine::set_virtual_output(channel, value);
     }
 }
 
@@ -144,6 +210,7 @@ impl OutJack {
             _ => value,
         };
         MAX_VALUES_DAC[self.channel].store(val, Ordering::Relaxed);
+        crate::routing_engine::set_virtual_output(self.channel, value);
     }
 }
 
@@ -281,7 +348,22 @@ impl<const N: usize> Faders<N> {
 
     pub fn get_value_at(&self, chan: usize) -> u16 {
         let chan = chan.clamp(0, N - 1);
+        let physical = MAX_VALUES_FADER[self.start_channel + chan].load(Ordering::Relaxed);
+        let offset = crate::routing_engine::get_fader_offset_sync(self.start_channel + chan);
+        (physical as i32 + offset as i32).clamp(0, 4095) as u16
+    }
+
+    #[allow(dead_code)]
+    pub fn get_physical_value_at(&self, chan: usize) -> u16 {
+        let chan = chan.clamp(0, N - 1);
         MAX_VALUES_FADER[self.start_channel + chan].load(Ordering::Relaxed)
+    }
+
+    pub fn get_value_at_for_layer(&self, chan: usize, layer: LatchLayer) -> u16 {
+        match layer {
+            LatchLayer::Main => self.get_value_at(chan),
+            _ => self.get_physical_value_at(chan),
+        }
     }
 
     #[allow(dead_code)]
@@ -296,7 +378,14 @@ impl<const N: usize> Faders<N> {
 
 impl Faders<1> {
     pub fn get_value(&self) -> u16 {
-        MAX_VALUES_FADER[self.start_channel].load(Ordering::Relaxed)
+        self.get_value_at(0)
+    }
+
+    pub fn get_value_for_layer(&self, layer: LatchLayer) -> u16 {
+        match layer {
+            LatchLayer::Main => self.get_value_at(0),
+            _ => self.get_physical_value_at(0),
+        }
     }
 
     pub async fn wait_for_change(&self) {
@@ -826,6 +915,25 @@ impl<const N: usize> App<N> {
 
     pub fn use_i2c_output(&self) -> I2cOutput<N> {
         I2cOutput::new(self.start_channel, self.i2c_publisher)
+    }
+
+    #[allow(dead_code)]
+    pub fn use_routing(&self) -> Routing<N> {
+        Routing::new(self.start_channel)
+    }
+
+    #[allow(dead_code)]
+    pub fn make_virtual_in_jack(&self, chan: usize) -> VirtualInJack {
+        VirtualInJack {
+            channel: self.start_channel + chan.clamp(0, N - 1),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn make_virtual_out_jack(&self, chan: usize) -> VirtualOutJack {
+        VirtualOutJack {
+            channel: self.start_channel + chan.clamp(0, N - 1),
+        }
     }
 
     pub async fn wait_for_scene_event(&self) -> SceneEvent {

--- a/faderpunk/src/apps/control.rs
+++ b/faderpunk/src/apps/control.rs
@@ -277,8 +277,9 @@ pub async fn run(
                 LatchLayer::Third => 0,
             };
 
+            let fader_val = fader.get_value_for_layer(latch_active_layer);
             if let Some(new_value) =
-                latch.update(fader.get_value(), latch_active_layer, latch_target_value)
+                latch.update(fader_val, latch_active_layer, latch_target_value)
             {
                 match latch_active_layer {
                     LatchLayer::Main => {

--- a/faderpunk/src/apps/lfo.rs
+++ b/faderpunk/src/apps/lfo.rs
@@ -304,7 +304,8 @@ pub async fn run(
                 LatchLayer::Third => 0,
             };
 
-            if let Some(new_value) = latch.update(fader.get_value(), latch_layer, target_value) {
+            let fader_val = fader.get_value_for_layer(latch_layer);
+            if let Some(new_value) = latch.update(fader_val, latch_layer, target_value) {
                 match latch_layer {
                     LatchLayer::Main => {
                         storage.modify_and_save(|s| s.layer_speed = new_value);

--- a/faderpunk/src/apps/lfo_plus.rs
+++ b/faderpunk/src/apps/lfo_plus.rs
@@ -408,8 +408,9 @@ pub async fn run(
                     LatchLayer::Third => 0,
                 };
 
+                let fader_val = fader.get_value_at_for_layer(chan, latch_layer);
                 if let Some(new_value) =
-                    latch[chan].update(fader.get_value_at(chan), latch_layer, target_value)
+                    latch[chan].update(fader_val, latch_layer, target_value)
                 {
                     match latch_layer {
                         LatchLayer::Main => {
@@ -427,8 +428,9 @@ pub async fn run(
                     LatchLayer::Third => 0,
                 };
 
+                let fader_val = fader.get_value_at_for_layer(chan, latch_layer);
                 if let Some(new_value) =
-                    latch[chan].update(fader.get_value_at(chan), latch_layer, target_value)
+                    latch[chan].update(fader_val, latch_layer, target_value)
                 {
                     match latch_layer {
                         LatchLayer::Main => {

--- a/faderpunk/src/apps/mixer.rs
+++ b/faderpunk/src/apps/mixer.rs
@@ -14,7 +14,7 @@ pub const CHANNELS: usize = 1;
 pub const PARAMS: usize = 2;
 
 pub static CONFIG: Config<PARAMS> = Config::new(
-    "Combiner / Mixer",
+    "Combiner / Mixer (TODO)",
     "Combine and mix internal routes onto output",
     Color::Cyan,
     AppIcon::Attenuate,

--- a/faderpunk/src/apps/mixer.rs
+++ b/faderpunk/src/apps/mixer.rs
@@ -1,0 +1,126 @@
+use embassy_futures::select::{select, select3};
+use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};
+use heapless::Vec;
+use serde::{Deserialize, Serialize};
+
+use libfp::{
+    ext::FromValue,
+    AppIcon, Brightness, Color, CombineMode, Config, Param, Range, Value, APP_MAX_PARAMS,
+};
+
+use crate::app::{App, AppParams, AppStorage, Led, ManagedStorage, ParamStore};
+
+pub const CHANNELS: usize = 1;
+pub const PARAMS: usize = 2;
+
+pub static CONFIG: Config<PARAMS> = Config::new(
+    "Combiner / Mixer",
+    "Combine and mix internal routes onto output",
+    Color::Cyan,
+    AppIcon::Attenuate,
+)
+.add_param(Param::CombineMode {
+    name: "Mode",
+    variants: &[
+        CombineMode::Sum,
+        CombineMode::Average,
+        CombineMode::Max,
+        CombineMode::Min,
+        CombineMode::Or,
+        CombineMode::And,
+        CombineMode::Xor,
+    ],
+})
+.add_param(Param::Range {
+    name: "Range",
+    variants: &[Range::_0_10V, Range::_Neg5_5V],
+});
+
+#[derive(Clone, Copy)]
+pub struct Params {
+    mode: CombineMode,
+    range: Range,
+}
+
+impl AppParams for Params {
+    fn from_values(values: &[Value]) -> Option<Self> {
+        if values.len() < PARAMS {
+            return None;
+        }
+        Some(Self {
+            mode: CombineMode::from_value(values[0]),
+            range: Range::from_value(values[1]),
+        })
+    }
+
+    fn to_values(&self) -> Vec<Value, APP_MAX_PARAMS> {
+        let mut vec = Vec::new();
+        vec.push(self.mode.into()).unwrap();
+        vec.push(self.range.into()).unwrap();
+        vec
+    }
+}
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct Storage {
+    master_gain: u16,
+}
+
+impl AppStorage for Storage {}
+
+#[embassy_executor::task(pool_size = 16/CHANNELS)]
+pub async fn wrapper(app: App<CHANNELS>, exit_signal: &'static Signal<NoopRawMutex, bool>) {
+    let param_store = ParamStore::<Params>::new(
+        app.app_id,
+        app.layout_id,
+        Params {
+            mode: CombineMode::Sum,
+            range: Range::_0_10V,
+        },
+    );
+    let storage = ManagedStorage::<Storage>::new(app.app_id, app.layout_id);
+
+    param_store.load().await;
+    storage.load().await;
+
+    let app_loop = async {
+        loop {
+            select3(
+                run(&app, &param_store, &storage),
+                param_store.param_handler(),
+                storage.saver_task(),
+            )
+            .await;
+        }
+    };
+
+    select(app_loop, app.exit_handler(exit_signal)).await;
+}
+
+pub async fn run(
+    app: &App<CHANNELS>,
+    params: &ParamStore<Params>,
+    storage: &ManagedStorage<Storage>,
+) {
+    let faders = app.use_faders();
+    let leds = app.use_leds();
+
+    let range = params.query(|p| p.range);
+
+    let out_jack = app.make_out_jack(0, range).await;
+    let in_jack = app.make_in_jack(0, range).await;
+
+    leds.set(0, Led::Bottom, Color::Cyan, Brightness::High);
+
+    loop {
+        faders.wait_for_any_change().await;
+
+        let gain = faders.get_value_at(0);
+        storage.modify(|s| s.master_gain = gain);
+
+        let master_gain = storage.query(|s| s.master_gain);
+        let input_val = in_jack.get_value();
+        let output_val = ((input_val as u32 * master_gain as u32) / 4095) as u16;
+        out_jack.set_value(output_val);
+    }
+}

--- a/faderpunk/src/apps/mod.rs
+++ b/faderpunk/src/apps/mod.rs
@@ -26,4 +26,5 @@ register_apps!(
     25 => automator,
     26 => genseq,
     27 => bernoulli,
+    28 => mixer,
 );

--- a/faderpunk/src/main.rs
+++ b/faderpunk/src/main.rs
@@ -8,6 +8,7 @@ mod app;
 mod apps;
 mod events;
 mod layout;
+mod routing_engine;
 mod state;
 mod storage;
 mod tasks;
@@ -224,6 +225,8 @@ async fn main(spawner: Spawner) {
 
     let calibration_data = load_calibration_data().await;
     let mut global_config = load_global_config().await;
+    let routing_config = storage::load_routing().await;
+    routing_engine::set_routing_config(routing_config).await;
 
     if is_channel_button_pressed(0) && is_channel_button_pressed(1) {
         return factory_reset().await;

--- a/faderpunk/src/routing_engine.rs
+++ b/faderpunk/src/routing_engine.rs
@@ -11,41 +11,9 @@ pub static ROUTING_CONFIG: Mutex<CriticalSectionRawMutex, RefCell<RoutingConfig>
     Mutex::new(RefCell::new(RoutingConfig::new()));
 pub static IS_ROUTING_ACTIVE: AtomicBool = AtomicBool::new(false);
 
-fn notify_modulated_destinations(source_channel: usize) {
-    let src_chan = source_channel as u8;
-    ROUTING_CONFIG.lock(|cell| {
-        let config = cell.borrow();
-        for r in config.routes.iter().flatten() {
-            if r.enabled
-                && matches!(r.source, RouteSource::AppOutput { channel } if channel == src_chan)
-            {
-                match r.destination {
-                    RouteDestination::AppFader { channel }
-                    | RouteDestination::AppInput { channel } => {
-                        let target_chan = channel as usize;
-                        if !crate::tasks::buttons::is_shift_button_pressed()
-                            && !crate::tasks::buttons::is_channel_button_pressed(target_chan)
-                        {
-                            crate::events::EVENT_PUBSUB
-                                .immediate_publisher()
-                                .publish_immediate(crate::events::InputEvent::FaderChange(
-                                    target_chan,
-                                ));
-                        }
-                    }
-                    _ => {}
-                }
-            }
-        }
-    });
-}
-
 pub fn set_virtual_output(channel: usize, value: u16) {
     if channel < 16 {
-        let old = VIRTUAL_APP_OUTPUTS[channel].swap(value, Ordering::Relaxed);
-        if old != value && IS_ROUTING_ACTIVE.load(Ordering::Relaxed) {
-            notify_modulated_destinations(channel);
-        }
+        VIRTUAL_APP_OUTPUTS[channel].store(value, Ordering::Relaxed);
     }
 }
 
@@ -166,12 +134,6 @@ pub fn get_fader_offset_sync(channel: usize) -> i16 {
         return 0;
     }
 
-    if crate::tasks::buttons::is_shift_button_pressed()
-        || crate::tasks::buttons::is_channel_button_pressed(channel)
-    {
-        return 0;
-    }
-
     let target_chan = channel as u8;
     ROUTING_CONFIG.lock(|cell| {
         let config = cell.borrow();
@@ -217,6 +179,26 @@ pub async fn get_dac_value(channel: usize, default_dac: u16) -> u16 {
     get_dac_value_sync(channel, default_dac)
 }
 
+/// Check if any active route targets fader modulation on `channel`
+#[allow(dead_code)]
+pub fn is_fader_modulated_sync(channel: usize) -> bool {
+    if !IS_ROUTING_ACTIVE.load(Ordering::Relaxed) {
+        return false;
+    }
+
+    let target_chan = channel as u8;
+    ROUTING_CONFIG.lock(|cell| {
+        let config = cell.borrow();
+        config.routes.iter().flatten().any(|r| {
+            r.enabled
+                && matches!(
+                    r.destination,
+                    RouteDestination::AppFader { channel } if channel == target_chan
+                )
+        })
+    })
+}
+
 /// Returns the CV fader modulation offset for `channel` (-2048..2047)
 #[allow(dead_code)]
 pub async fn get_fader_offset(channel: usize) -> i16 {
@@ -238,7 +220,7 @@ fn evaluate_matching_routes(routes: &[&libfp::Route], default_val: u16) -> u16 {
             apply_attenuation_and_offset(src, last_route.attenuation_percent, last_route.offset)
         }
         CombineMode::Sum => {
-            let mut sum: i32 = 0;
+            let mut sum: i32 = default_val as i32;
             for r in routes {
                 let src = evaluate_source_value(r.source);
                 let val = apply_attenuation_and_offset(src, r.attenuation_percent, r.offset);
@@ -247,16 +229,16 @@ fn evaluate_matching_routes(routes: &[&libfp::Route], default_val: u16) -> u16 {
             sum.clamp(0, 4095) as u16
         }
         CombineMode::Average => {
-            let mut sum: i32 = 0;
+            let mut sum: i32 = default_val as i32;
             for r in routes {
                 let src = evaluate_source_value(r.source);
                 let val = apply_attenuation_and_offset(src, r.attenuation_percent, r.offset);
                 sum += val as i32;
             }
-            (sum / routes.len() as i32).clamp(0, 4095) as u16
+            (sum / (routes.len() + 1) as i32).clamp(0, 4095) as u16
         }
         CombineMode::Max => {
-            let mut max_val: u16 = 0;
+            let mut max_val: u16 = default_val;
             for r in routes {
                 let src = evaluate_source_value(r.source);
                 let val = apply_attenuation_and_offset(src, r.attenuation_percent, r.offset);
@@ -267,7 +249,7 @@ fn evaluate_matching_routes(routes: &[&libfp::Route], default_val: u16) -> u16 {
             max_val
         }
         CombineMode::Min => {
-            let mut min_val: u16 = 4095;
+            let mut min_val: u16 = default_val;
             for r in routes {
                 let src = evaluate_source_value(r.source);
                 let val = apply_attenuation_and_offset(src, r.attenuation_percent, r.offset);

--- a/faderpunk/src/routing_engine.rs
+++ b/faderpunk/src/routing_engine.rs
@@ -1,0 +1,355 @@
+use core::cell::RefCell;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::blocking_mutex::Mutex;
+use libfp::{CombineMode, RouteDestination, RouteSource, RoutingConfig};
+use portable_atomic::{AtomicBool, AtomicU16, Ordering};
+
+use crate::tasks::max::MAX_VALUES_ADC;
+
+pub static VIRTUAL_APP_OUTPUTS: [AtomicU16; 16] = [const { AtomicU16::new(0) }; 16];
+pub static ROUTING_CONFIG: Mutex<CriticalSectionRawMutex, RefCell<RoutingConfig>> =
+    Mutex::new(RefCell::new(RoutingConfig::new()));
+pub static IS_ROUTING_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+fn notify_modulated_destinations(source_channel: usize) {
+    let src_chan = source_channel as u8;
+    ROUTING_CONFIG.lock(|cell| {
+        let config = cell.borrow();
+        for r in config.routes.iter().flatten() {
+            if r.enabled
+                && matches!(r.source, RouteSource::AppOutput { channel } if channel == src_chan)
+            {
+                match r.destination {
+                    RouteDestination::AppFader { channel }
+                    | RouteDestination::AppInput { channel } => {
+                        let target_chan = channel as usize;
+                        if !crate::tasks::buttons::is_shift_button_pressed()
+                            && !crate::tasks::buttons::is_channel_button_pressed(target_chan)
+                        {
+                            crate::events::EVENT_PUBSUB
+                                .immediate_publisher()
+                                .publish_immediate(crate::events::InputEvent::FaderChange(
+                                    target_chan,
+                                ));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    });
+}
+
+pub fn set_virtual_output(channel: usize, value: u16) {
+    if channel < 16 {
+        let old = VIRTUAL_APP_OUTPUTS[channel].swap(value, Ordering::Relaxed);
+        if old != value && IS_ROUTING_ACTIVE.load(Ordering::Relaxed) {
+            notify_modulated_destinations(channel);
+        }
+    }
+}
+
+pub fn get_virtual_output(channel: usize) -> u16 {
+    if channel < 16 {
+        VIRTUAL_APP_OUTPUTS[channel].load(Ordering::Relaxed)
+    } else {
+        0
+    }
+}
+
+/// Evaluates a raw source value in counts (0..4095)
+fn evaluate_source_value(source: RouteSource) -> u16 {
+    match source {
+        RouteSource::AppOutput { channel } | RouteSource::AppMidi { channel } => {
+            get_virtual_output(channel as usize)
+        }
+        RouteSource::PhysicalAdc { channel } => {
+            if (channel as usize) < MAX_VALUES_ADC.len() {
+                MAX_VALUES_ADC[channel as usize].load(Ordering::Relaxed)
+            } else {
+                0
+            }
+        }
+        RouteSource::Constant { value } => value.clamp(0, 4095),
+    }
+}
+
+/// Applies gain attenuation percent (-200% to +200%) and offset to a raw sample
+fn apply_attenuation_and_offset(raw: u16, attenuation_percent: i16, offset: i16) -> u16 {
+    let scaled = (raw as i32 * attenuation_percent as i32) / 100 + offset as i32;
+    scaled.clamp(0, 4095) as u16
+}
+
+/// Check if any active route is targeted to an input channel (synchronous)
+pub fn is_input_routed_sync(channel: usize) -> bool {
+    if !IS_ROUTING_ACTIVE.load(Ordering::Relaxed) {
+        return false;
+    }
+    let target_chan = channel as u8;
+    ROUTING_CONFIG.lock(|cell| {
+        let config = cell.borrow();
+        config.routes.iter().flatten().any(|r| {
+            r.enabled
+                && matches!(
+                    r.destination,
+                    RouteDestination::AppInput { channel } if channel == target_chan
+                )
+        })
+    })
+}
+
+/// Returns the effective input value for `channel` (synchronous).
+/// If no internal routes target this input, returns `physical_adc`.
+pub fn get_input_value_sync(channel: usize, physical_adc: u16) -> u16 {
+    if !IS_ROUTING_ACTIVE.load(Ordering::Relaxed) {
+        return physical_adc;
+    }
+
+    let target_chan = channel as u8;
+    ROUTING_CONFIG.lock(|cell| {
+        let config = cell.borrow();
+        let matching_routes: heapless::Vec<_, 32> = config
+            .routes
+            .iter()
+            .flatten()
+            .filter(|r| {
+                r.enabled
+                    && matches!(
+                        r.destination,
+                        RouteDestination::AppInput { channel } if channel == target_chan
+                    )
+            })
+            .collect();
+
+        if matching_routes.is_empty() {
+            physical_adc
+        } else {
+            evaluate_matching_routes(&matching_routes, physical_adc)
+        }
+    })
+}
+
+/// Returns the effective DAC output value for `channel` (synchronous).
+/// If no internal routes target this DAC, returns `default_dac`.
+pub fn get_dac_value_sync(channel: usize, default_dac: u16) -> u16 {
+    if !IS_ROUTING_ACTIVE.load(Ordering::Relaxed) {
+        return default_dac;
+    }
+
+    let target_chan = channel as u8;
+    ROUTING_CONFIG.lock(|cell| {
+        let config = cell.borrow();
+        let matching_routes: heapless::Vec<_, 32> = config
+            .routes
+            .iter()
+            .flatten()
+            .filter(|r| {
+                r.enabled
+                    && matches!(
+                        r.destination,
+                        RouteDestination::PhysicalDac { channel } if channel == target_chan
+                    )
+            })
+            .collect();
+
+        if matching_routes.is_empty() {
+            default_dac
+        } else {
+            evaluate_matching_routes(&matching_routes, default_dac)
+        }
+    })
+}
+
+/// Returns the CV fader modulation offset for `channel` (-2048..2047) (synchronous).
+pub fn get_fader_offset_sync(channel: usize) -> i16 {
+    if !IS_ROUTING_ACTIVE.load(Ordering::Relaxed) {
+        return 0;
+    }
+
+    if crate::tasks::buttons::is_shift_button_pressed()
+        || crate::tasks::buttons::is_channel_button_pressed(channel)
+    {
+        return 0;
+    }
+
+    let target_chan = channel as u8;
+    ROUTING_CONFIG.lock(|cell| {
+        let config = cell.borrow();
+        let matching_routes: heapless::Vec<_, 32> = config
+            .routes
+            .iter()
+            .flatten()
+            .filter(|r| {
+                r.enabled
+                    && matches!(
+                        r.destination,
+                        RouteDestination::AppFader { channel } if channel == target_chan
+                    )
+            })
+            .collect();
+
+        if matching_routes.is_empty() {
+            0
+        } else {
+            let val = evaluate_matching_routes(&matching_routes, 2048);
+            (val as i32 - 2048).clamp(-2048, 2047) as i16
+        }
+    })
+}
+
+/// Check if any active route is targeted to an input channel
+#[allow(dead_code)]
+pub async fn is_input_routed(channel: usize) -> bool {
+    is_input_routed_sync(channel)
+}
+
+/// Returns the effective input value for `channel`.
+/// If no internal routes target this input, returns `physical_adc`.
+#[allow(dead_code)]
+pub async fn get_input_value(channel: usize, physical_adc: u16) -> u16 {
+    get_input_value_sync(channel, physical_adc)
+}
+
+/// Returns the effective DAC output value for `channel`.
+/// If no internal routes target this DAC, returns `default_dac`.
+#[allow(dead_code)]
+pub async fn get_dac_value(channel: usize, default_dac: u16) -> u16 {
+    get_dac_value_sync(channel, default_dac)
+}
+
+/// Returns the CV fader modulation offset for `channel` (-2048..2047)
+#[allow(dead_code)]
+pub async fn get_fader_offset(channel: usize) -> i16 {
+    get_fader_offset_sync(channel)
+}
+
+/// Combines multiple active routes for a single target destination
+fn evaluate_matching_routes(routes: &[&libfp::Route], default_val: u16) -> u16 {
+    if routes.is_empty() {
+        return default_val;
+    }
+
+    let mode = routes[0].mode;
+
+    match mode {
+        CombineMode::Replace => {
+            let last_route = routes.last().unwrap();
+            let src = evaluate_source_value(last_route.source);
+            apply_attenuation_and_offset(src, last_route.attenuation_percent, last_route.offset)
+        }
+        CombineMode::Sum => {
+            let mut sum: i32 = 0;
+            for r in routes {
+                let src = evaluate_source_value(r.source);
+                let val = apply_attenuation_and_offset(src, r.attenuation_percent, r.offset);
+                sum += val as i32;
+            }
+            sum.clamp(0, 4095) as u16
+        }
+        CombineMode::Average => {
+            let mut sum: i32 = 0;
+            for r in routes {
+                let src = evaluate_source_value(r.source);
+                let val = apply_attenuation_and_offset(src, r.attenuation_percent, r.offset);
+                sum += val as i32;
+            }
+            (sum / routes.len() as i32).clamp(0, 4095) as u16
+        }
+        CombineMode::Max => {
+            let mut max_val: u16 = 0;
+            for r in routes {
+                let src = evaluate_source_value(r.source);
+                let val = apply_attenuation_and_offset(src, r.attenuation_percent, r.offset);
+                if val > max_val {
+                    max_val = val;
+                }
+            }
+            max_val
+        }
+        CombineMode::Min => {
+            let mut min_val: u16 = 4095;
+            for r in routes {
+                let src = evaluate_source_value(r.source);
+                let val = apply_attenuation_and_offset(src, r.attenuation_percent, r.offset);
+                if val < min_val {
+                    min_val = val;
+                }
+            }
+            min_val
+        }
+        CombineMode::Or => {
+            let mut any_high = false;
+            for r in routes {
+                let src = evaluate_source_value(r.source);
+                if src > 2000 {
+                    any_high = true;
+                    break;
+                }
+            }
+            if any_high {
+                4095
+            } else {
+                0
+            }
+        }
+        CombineMode::And => {
+            let mut all_high = true;
+            for r in routes {
+                let src = evaluate_source_value(r.source);
+                if src <= 2000 {
+                    all_high = false;
+                    break;
+                }
+            }
+            if all_high {
+                4095
+            } else {
+                0
+            }
+        }
+        CombineMode::Xor => {
+            let mut high_count: usize = 0;
+            for r in routes {
+                let src = evaluate_source_value(r.source);
+                if src > 2000 {
+                    high_count += 1;
+                }
+            }
+            if high_count % 2 == 1 {
+                4095
+            } else {
+                0
+            }
+        }
+    }
+}
+
+/// Updates the active routing configuration in memory
+pub async fn set_routing_config(new_config: RoutingConfig) {
+    ROUTING_CONFIG.lock(|cell| {
+        let has_routes = new_config.routes.iter().flatten().any(|r| r.enabled);
+        IS_ROUTING_ACTIVE.store(has_routes, Ordering::Relaxed);
+        *cell.borrow_mut() = new_config;
+
+        for r in new_config.routes.iter().flatten() {
+            if r.enabled {
+                match r.destination {
+                    RouteDestination::AppFader { channel }
+                    | RouteDestination::AppInput { channel } => {
+                        crate::events::EVENT_PUBSUB
+                            .immediate_publisher()
+                            .publish_immediate(crate::events::InputEvent::FaderChange(
+                                channel as usize,
+                            ));
+                    }
+                    _ => {}
+                }
+            }
+        }
+    });
+}
+
+/// Gets a copy of the active routing configuration
+pub async fn get_routing_config() -> RoutingConfig {
+    ROUTING_CONFIG.lock(|cell| *cell.borrow())
+}

--- a/faderpunk/src/storage.rs
+++ b/faderpunk/src/storage.rs
@@ -11,7 +11,7 @@ use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializ
 use libfp::{
     types::{CalibFile, MaxCalibration, MaxCalibrationV1},
     AuxJackMode, ClockConfig, ClockSrc, GlobalConfig, I2cMode, Layout, MidiConfig, QuantizerConfig,
-    ResetSrc, TakeoverMode, Value, APP_MAX_PARAMS, CALIB_FILE_MAGIC,
+    ResetSrc, RoutingConfig, TakeoverMode, Value, APP_MAX_PARAMS, CALIB_FILE_MAGIC,
 };
 
 use crate::{
@@ -27,7 +27,9 @@ const GLOBAL_CONFIG_RANGE: Range<u32> = 0..320;
 const RUNTIME_STATE_RANGE: Range<u32> = GLOBAL_CONFIG_RANGE.end..384;
 const LAYOUT_RANGE: Range<u32> = RUNTIME_STATE_RANGE.end..512;
 const CALIBRATION_RANGE: Range<u32> = LAYOUT_RANGE.end..1024;
-const APP_STORAGE_RANGE: Range<u32> = CALIBRATION_RANGE.end..122_880;
+const ROUTING_RANGE: Range<u32> = CALIBRATION_RANGE.end..1536;
+const APP_STORAGE_RANGE: Range<u32> = ROUTING_RANGE.end..122_880;
+
 const APP_PARAM_RANGE: Range<u32> = APP_STORAGE_RANGE.end..SCHEMA_HEADER_RANGE.start;
 /// Reserved region at the very end of FRAM holding `SchemaHeader`. Everything
 /// before it is data laid out by the firmware version that wrote it; this
@@ -242,6 +244,29 @@ pub async fn load_layout() -> Layout {
     let layout = Layout::default();
     store_layout(&layout).await;
     layout
+}
+
+pub async fn store_routing(config: &RoutingConfig) {
+    let res = write_with(ROUTING_RANGE.start, |buf| {
+        Ok(to_slice(config, &mut *buf)?.len())
+    })
+    .await;
+
+    if res.is_err() {
+        defmt::error!("Could not save RoutingConfig");
+    }
+}
+
+pub async fn load_routing() -> RoutingConfig {
+    if let Ok(guard) = read_data(ROUTING_RANGE.start).await {
+        let data = guard.data();
+        if !data.is_empty() {
+            if let Ok(config) = from_bytes::<RoutingConfig>(data) {
+                return config;
+            }
+        }
+    }
+    RoutingConfig::default()
 }
 
 pub async fn store_calibration_data(data: &MaxCalibration) {

--- a/faderpunk/src/tasks/configure.rs
+++ b/faderpunk/src/tasks/configure.rs
@@ -232,6 +232,17 @@ pub async fn start_config_loop<'a>(usb_tx: &'a SharedUsbSender<'a>) {
                 handle_release_voct_output(&mut proto, &mut pending_voct_eviction, output_jack)
                     .await
             }
+            ConfigMsgIn::GetRouting => {
+                let routing = crate::routing_engine::get_routing_config().await;
+                proto.send_msg(ConfigMsgOut::RoutingState(routing)).await
+            }
+            ConfigMsgIn::SetRouting(new_routing) => {
+                crate::routing_engine::set_routing_config(new_routing).await;
+                crate::storage::store_routing(&new_routing).await;
+                proto
+                    .send_msg(ConfigMsgOut::RoutingState(new_routing))
+                    .await
+            }
         };
         if let Err(err) = res {
             defmt::warn!("Failed to send config response: {}", err);

--- a/faderpunk/src/tasks/max.rs
+++ b/faderpunk/src/tasks/max.rs
@@ -286,7 +286,9 @@ async fn process_channel_values(
             let mut max = max_driver.lock().await;
             match max.get_mode(port) {
                 Mode::Mode5(config) => {
-                    let target_dac_value = MAX_VALUES_DAC[i].load(Ordering::Relaxed);
+                    let raw_dac_value = MAX_VALUES_DAC[i].load(Ordering::Relaxed);
+                    let target_dac_value =
+                        crate::routing_engine::get_dac_value_sync(i, raw_dac_value);
                     let calibrated_value = if target_dac_value == 0 {
                         // If the target is 0, the output MUST be 0
                         0

--- a/faderpunk/src/tasks/transport.rs
+++ b/faderpunk/src/tasks/transport.rs
@@ -147,5 +147,6 @@ async fn run_transports(
     let midi_in_fut = midi_in_task(usb_rx, uart1_rx);
     let config_fut = start_config_loop(&usb_tx);
 
+    #[allow(clippy::large_futures)]
     join4(usb.run(), midi_in_fut, midi_out_fut, config_fut).await;
 }

--- a/gen-bindings/Cargo.lock
+++ b/gen-bindings/Cargo.lock
@@ -324,7 +324,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libfp"
-version = "0.10.5"
+version = "0.10.6-beta.1"
 dependencies = [
  "embassy-time",
  "enum-ordinalize",

--- a/gen-bindings/src/main.rs
+++ b/gen-bindings/src/main.rs
@@ -50,7 +50,12 @@ fn main() {
             libfp::TakeoverMode,
             libfp::Value,
             libfp::VoltPerOct,
-            libfp::Waveform
+            libfp::Waveform,
+            libfp::RoutingConfig,
+            libfp::Route,
+            libfp::RouteSource,
+            libfp::RouteDestination,
+            libfp::CombineMode
         ),
     )
     .unwrap();

--- a/libfp/src/latch.rs
+++ b/libfp/src/latch.rs
@@ -165,15 +165,19 @@ impl AnalogLatch {
         active_layer_target_value: u16,
         is_modulated: bool,
     ) -> Option<u16> {
-        if is_modulated && new_active_layer == LatchLayer::Main {
-            self.active_layer = new_active_layer;
-            self.is_latched = true;
-            self.prev_target = value;
-            if value != self.last_emitted_value {
-                self.last_emitted_value = value;
-                return Some(value);
+        if is_modulated {
+            if new_active_layer == LatchLayer::Main {
+                self.active_layer = new_active_layer;
+                self.is_latched = true;
+                self.prev_target = value;
+                if value != self.last_emitted_value {
+                    self.last_emitted_value = value;
+                    return Some(value);
+                }
+                return None;
+            } else if self.active_layer == LatchLayer::Main {
+                self.last_emitted_value = active_layer_target_value;
             }
-            return None;
         }
         self.update(value, new_active_layer, active_layer_target_value)
     }
@@ -185,7 +189,8 @@ impl AnalogLatch {
         active_layer_target_value: u16,
     ) -> Option<u16> {
         // Did the user switch layers?
-        if new_active_layer != self.active_layer {
+        let layer_switched = new_active_layer != self.active_layer;
+        if layer_switched {
             self.active_layer = new_active_layer;
             // For Jump mode, always latch immediately on layer switch
             // For other modes, unlatch unless fader is already at target (tight zone)
@@ -194,6 +199,9 @@ impl AnalogLatch {
                 _ => self.in_jitter_zone(value, active_layer_target_value),
             };
             self.prev_target = active_layer_target_value;
+            if !self.is_latched {
+                self.last_emitted_value = active_layer_target_value;
+            }
         } else if self.is_latched {
             // If we are latched but the target has changed externally, check if we should unlatch.
             // This happens if the target value is changed by something other than this fader.
@@ -220,7 +228,7 @@ impl AnalogLatch {
 
         let mut new_value = None;
 
-        let is_absolute_edge = value == 0 || value == 4095;
+        let is_absolute_edge = !layer_switched && (value == 0 || value == 4095);
         if is_absolute_edge && value != self.last_emitted_value {
             self.is_latched = true;
             new_value = Some(value);

--- a/libfp/src/latch.rs
+++ b/libfp/src/latch.rs
@@ -158,6 +158,26 @@ impl AnalogLatch {
     ///   the active layer.
     /// * `None` if no change should occur (e.g., the fader is moving but has not yet
     ///   reached the target value, or movement is within jitter tolerance).
+    pub fn update_modulated(
+        &mut self,
+        value: u16,
+        new_active_layer: LatchLayer,
+        active_layer_target_value: u16,
+        is_modulated: bool,
+    ) -> Option<u16> {
+        if is_modulated && new_active_layer == LatchLayer::Main {
+            self.active_layer = new_active_layer;
+            self.is_latched = true;
+            self.prev_target = value;
+            if value != self.last_emitted_value {
+                self.last_emitted_value = value;
+                return Some(value);
+            }
+            return None;
+        }
+        self.update(value, new_active_layer, active_layer_target_value)
+    }
+
     pub fn update(
         &mut self,
         value: u16,

--- a/libfp/src/lib.rs
+++ b/libfp/src/lib.rs
@@ -18,12 +18,14 @@ pub mod fp_grids_lib;
 pub mod i2c_proto;
 pub mod latch;
 pub mod quantizer;
+pub mod routing;
 pub mod sysex;
 pub mod types;
 pub mod utils;
 
-// Re-export commonly used latch types
+// Re-export commonly used latch & routing types
 pub use latch::{AnalogLatch, LatchLayer, TakeoverMode};
+pub use routing::*;
 
 use constants::{
     CURVE_EXP, CURVE_LOG, WAVEFORM_SAW, WAVEFORM_SAW_INV, WAVEFORM_SINE, WAVEFORM_SQUARE,
@@ -1086,6 +1088,10 @@ pub enum Param {
     MidiOut,
     MidiNrpn,
     VoltPerOct,
+    CombineMode {
+        name: &'static str,
+        variants: &'static [CombineMode],
+    },
 }
 
 impl Param {
@@ -1100,11 +1106,6 @@ impl Param {
             Self::i32 { name, .. }
             | Self::f32 { name, .. }
             | Self::bool { name }
-            | Self::Curve { name, .. }
-            | Self::Waveform { name, .. }
-            | Self::Color { name, .. }
-            | Self::Range { name, .. }
-            | Self::Note { name, .. }
             | Self::MidiCc { name }
             | Self::MidiChannel { name }
             | Self::MidiNote { name } => name.is_ascii(),
@@ -1121,6 +1122,12 @@ impl Param {
                 }
                 true
             }
+            Self::Curve { name, .. }
+            | Self::Waveform { name, .. }
+            | Self::Color { name, .. }
+            | Self::Range { name, .. }
+            | Self::Note { name, .. }
+            | Self::CombineMode { name, .. } => name.is_ascii(),
         }
     }
 }
@@ -1276,6 +1283,8 @@ pub enum ConfigMsgIn {
     ReleaseVoOctOutput {
         output_jack: u8,
     },
+    GetRouting,
+    SetRouting(RoutingConfig),
 }
 
 #[derive(Clone, Serialize, PostcardBindings)]
@@ -1286,6 +1295,7 @@ pub enum ConfigMsgOut<'a> {
     BatchMsgEnd,
     GlobalConfig(GlobalConfig),
     Layout(Layout),
+    RoutingState(RoutingConfig),
     AppConfig(u8, usize, ConfigMeta<'a>),
     AppState(u8, &'a [Value]),
     Version {

--- a/libfp/src/routing.rs
+++ b/libfp/src/routing.rs
@@ -1,0 +1,144 @@
+use postcard_bindgen::PostcardBindings;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize, Deserialize, PostcardBindings)]
+pub enum SignalType {
+    #[default]
+    Cv,
+    Gate,
+    Midi,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize, Deserialize, PostcardBindings)]
+pub enum CombineMode {
+    /// Saturation sum: clamp(A + B, 0, 4095)
+    #[default]
+    Sum,
+    /// Average: (A + B) / 2
+    Average,
+    /// Highest voltage/value wins
+    Max,
+    /// Lowest voltage/value wins
+    Min,
+    /// Gate logic OR (High if any active)
+    Or,
+    /// Gate logic AND (High if all active)
+    And,
+    /// Gate logic XOR (High if odd count active)
+    Xor,
+    /// Direct override / replace
+    Replace,
+}
+
+impl crate::ext::FromValue for CombineMode {
+    fn from_value(val: crate::Value) -> Self {
+        match val {
+            crate::Value::Enum(idx) => match idx {
+                0 => CombineMode::Sum,
+                1 => CombineMode::Average,
+                2 => CombineMode::Max,
+                3 => CombineMode::Min,
+                4 => CombineMode::Or,
+                5 => CombineMode::And,
+                6 => CombineMode::Xor,
+                7 => CombineMode::Replace,
+                _ => CombineMode::Sum,
+            },
+            _ => CombineMode::Sum,
+        }
+    }
+}
+
+impl From<CombineMode> for crate::Value {
+    fn from(val: CombineMode) -> Self {
+        crate::Value::Enum(val as usize)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, PostcardBindings)]
+pub enum RouteSource {
+    AppOutput { channel: u8 },
+    AppMidi { channel: u8 },
+    PhysicalAdc { channel: u8 },
+    Constant { value: u16 },
+}
+
+impl Default for RouteSource {
+    fn default() -> Self {
+        Self::AppOutput { channel: 0 }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, PostcardBindings)]
+pub enum RouteDestination {
+    PhysicalDac { channel: u8 },
+    AppInput { channel: u8 },
+    AppFader { channel: u8 },
+    AppLayer { channel: u8 },
+}
+
+impl Default for RouteDestination {
+    fn default() -> Self {
+        Self::PhysicalDac { channel: 0 }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize, Deserialize, PostcardBindings)]
+pub struct Route {
+    pub source: RouteSource,
+    pub destination: RouteDestination,
+    pub mode: CombineMode,
+    /// Gain multiplier percentage (-200% to +200%)
+    pub attenuation_percent: i16,
+    /// Constant value offset (-2048 to +2047)
+    pub offset: i16,
+    pub enabled: bool,
+}
+
+pub const MAX_ROUTES: usize = 32;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize, Deserialize, PostcardBindings)]
+pub struct RoutingConfig {
+    pub routes: [Option<Route>; MAX_ROUTES],
+}
+
+impl RoutingConfig {
+    pub const fn new() -> Self {
+        Self {
+            routes: [None; MAX_ROUTES],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use postcard::{from_bytes, to_slice};
+
+    #[test]
+    fn test_routing_config_postcard_roundtrip() {
+        let mut config = RoutingConfig::new();
+        config.routes[0] = Some(Route {
+            source: RouteSource::AppOutput { channel: 1 },
+            destination: RouteDestination::PhysicalDac { channel: 3 },
+            mode: CombineMode::Sum,
+            attenuation_percent: 100,
+            offset: 0,
+            enabled: true,
+        });
+
+        config.routes[1] = Some(Route {
+            source: RouteSource::PhysicalAdc { channel: 0 },
+            destination: RouteDestination::AppInput { channel: 2 },
+            mode: CombineMode::Or,
+            attenuation_percent: 50,
+            offset: -100,
+            enabled: false,
+        });
+
+        let mut buf = [0_u8; 512];
+        let bytes = to_slice(&config, &mut buf).unwrap();
+        let deserialized: RoutingConfig = from_bytes(bytes).unwrap();
+        assert_eq!(config, deserialized);
+    }
+}


### PR DESCRIPTION
Draft PR for internal digital patchbay and dynamic matrix routing engine.

Summary of changes:
- Internal routing engine in firmware (`faderpunk/src/routing_engine.rs`) supporting physical DAC output summing, software app input routing, and fader modulation.
- Zero-app-modification layer protection and continuous background fader modulation during Shift layer editing.
- Web Configurator Patchbay tab with dynamic matrix grid filtering, combine mode selectors (Sum, Replace, Average, Max, Min, Logic), and node alignment fixes.
- Updated configurator manual documentation and TOC.
- Marked Combiner / Mixer app as (TODO).